### PR TITLE
Fix redis default password

### DIFF
--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -254,7 +254,7 @@ func databaseConnectionConfiguration(_ app: Application) throws {
 		let redisPort = (app.environment == .testing) ? Int(Environment.get("REDIS_PORT") ?? "6380")! : 6379
 		var redisPassword = Environment.get("REDIS_PASSWORD") ?? "password"
 		if redisPassword == "" {
-			redisPassword = "password"
+			redisPassword = nil
 		}
 		app.redis.configuration = try RedisConfiguration(hostname: redisHostname, port: redisPort, password: redisPassword, pool: redisPoolOptions)
 	}

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -252,9 +252,9 @@ func databaseConnectionConfiguration(_ app: Application) throws {
 		// otherwise
 		let redisHostname = Environment.get("REDIS_HOSTNAME") ?? "localhost"
 		let redisPort = (app.environment == .testing) ? Int(Environment.get("REDIS_PORT") ?? "6380")! : 6379
-		var redisPassword = Environment.get("REDIS_PASSWORD") ?? nil
+		var redisPassword = Environment.get("REDIS_PASSWORD") ?? "password"
 		if redisPassword == "" {
-			redisPassword = nil
+			redisPassword = "password"
 		}
 		app.redis.configuration = try RedisConfiguration(hostname: redisHostname, port: redisPort, password: redisPassword, pool: redisPoolOptions)
 	}


### PR DESCRIPTION
In the docker configuration, the default redis password is `password`. Update the swift configuration's password fallback to match.