### PR TITLE
Enhancements to the container run script

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -12,7 +12,7 @@ if [ "${AUTO_MIGRATE}" = true ]; then
   # To avoid doubling up on environment variables, we're gonna consume
   # the ones passed to the app and reset the psql env vars to match.
   export PGHOST=${DATABASE_HOSTNAME} PGUSER=${DATABASE_USER} PGPASSWORD=${DATABASE_PASSWORD} PGDATABASE=${DATABASE_DB}
-  psql -P pager=off -c "SELECT * FROM users LIMIT 1;" > /dev/null
+  psql -P pager=off -c "SELECT * FROM public.user LIMIT 1;" > /dev/null
 
   if [ $? != 0 ]; then
     echo "Database not initialized. Running migration..."
@@ -25,4 +25,4 @@ else
   echo "Automatic database migration was disabled."
 fi
 
-/app/Run serve --env "${ENVIRONMENT}" --hostname ${SWIFTARR_IP} --port ${SWIFTARR_PORT}
+exec /app/Run serve --env "${ENVIRONMENT}" --hostname ${SWIFTARR_IP} --port ${SWIFTARR_PORT}


### PR DESCRIPTION
1) Fixes an issue where I was inappropriately triggering a migration call due to a bad table name. The schema is required (`public.user`) otherwise you get a postgres connection specific temporary table.

2) Signals were not getting passed from container runtime (Docker) to the app process because it was being spawned as a child process. Using `exec` effectively replaces the running PID 1 (`/run.sh`) with the app (`/app/Run`) which allows for signals to be passed correctly. See https://github.com/vapor/vapor/issues/2336#issuecomment-620736247 and https://github.com/vapor/api-template/pull/93#discussion_r413179048 for more information.

The most significant overall improvement is that calling `docker[-compose] restart` on the Swiftarr container now exits cleanly and timely rather than waiting 10 seconds for an implicit SIGKILL from the container runtime.