### PR TITLE
API Docs, Time View Improvements, Settings

### DIFF
--- a/Sources/App/Helpers/DisabledSectionMiddleware.swift
+++ b/Sources/App/Helpers/DisabledSectionMiddleware.swift
@@ -26,8 +26,10 @@ struct DisabledSiteSectionMiddleware: AsyncMiddleware {
 
 	func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
 		let features = Settings.shared.disabledFeatures.value
-		if features[.all]?.contains(featureToCheck) ?? false || features[.swiftarr]?.contains(featureToCheck) ?? false || features[.all]?.contains(.all) ?? false || features[.swiftarr]?.contains(.all) ?? false {
-			struct DisabledSectionContext : Encodable {
+		if features[.all]?.contains(featureToCheck) ?? false || features[.swiftarr]?.contains(featureToCheck) ?? false
+			|| features[.all]?.contains(.all) ?? false || features[.swiftarr]?.contains(.all) ?? false
+		{
+			struct DisabledSectionContext: Encodable {
 				var trunk: TrunkContext
 				init(_ req: Request) {
 					trunk = .init(req, title: "Disabled Section", tab: .none)

--- a/Sources/App/Helpers/DisabledSectionMiddleware.swift
+++ b/Sources/App/Helpers/DisabledSectionMiddleware.swift
@@ -10,7 +10,7 @@ struct DisabledAPISectionMiddleware: AsyncMiddleware {
 
 	func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
 		let features = Settings.shared.disabledFeatures.value
-		if features[.all]?.contains(featureToCheck) ?? false {
+		if features[.all]?.contains(featureToCheck) ?? false || features[.all]?.contains(.all) ?? false {
 			throw Abort(.serviceUnavailable)
 		}
 		return try await next.respond(to: request)
@@ -26,7 +26,7 @@ struct DisabledSiteSectionMiddleware: AsyncMiddleware {
 
 	func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
 		let features = Settings.shared.disabledFeatures.value
-		if features[.all]?.contains(featureToCheck) ?? false || features[.swiftarr]?.contains(featureToCheck) ?? false {
+		if features[.all]?.contains(featureToCheck) ?? false || features[.swiftarr]?.contains(featureToCheck) ?? false || features[.all]?.contains(.all) ?? false {
 			struct DisabledSectionContext : Encodable {
 				var trunk: TrunkContext
 				init(_ req: Request) {
@@ -34,7 +34,7 @@ struct DisabledSiteSectionMiddleware: AsyncMiddleware {
 				}
 			}
 			let ctx = DisabledSectionContext(request)
-			return try await request.view.render("featureDisabled.leaf", ctx).encodeResponse(for: request)
+			return try await request.view.render("featureDisabled", ctx).encodeResponse(for: request)
 		}
 		return try await next.respond(to: request)
 	}

--- a/Sources/App/Helpers/DisabledSectionMiddleware.swift
+++ b/Sources/App/Helpers/DisabledSectionMiddleware.swift
@@ -26,7 +26,7 @@ struct DisabledSiteSectionMiddleware: AsyncMiddleware {
 
 	func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
 		let features = Settings.shared.disabledFeatures.value
-		if features[.all]?.contains(featureToCheck) ?? false || features[.swiftarr]?.contains(featureToCheck) ?? false || features[.all]?.contains(.all) ?? false {
+		if features[.all]?.contains(featureToCheck) ?? false || features[.swiftarr]?.contains(featureToCheck) ?? false || features[.all]?.contains(.all) ?? false || features[.swiftarr]?.contains(.all) ?? false {
 			struct DisabledSectionContext : Encodable {
 				var trunk: TrunkContext
 				init(_ req: Request) {

--- a/Sources/App/Helpers/Settings.swift
+++ b/Sources/App/Helpers/Settings.swift
@@ -99,9 +99,10 @@ final class Settings : Encodable {
 	@StoredSettingsValue("userAutoQuarantineThreshold", defaultValue: 5) var userAutoQuarantineThreshold: Int
 	
 // MARK: Dates
-  /// A Date set to midnight on the day the cruise ship leaves port, in the timezone the ship leaves from. Used by the Events Controller for date arithimetic.
-  /// The default here should usually get overwritten in configure.swift.
-  @SettingsValue var cruiseStartDateComponents: DateComponents = DateComponents(year: 1970, month: 1, day: 1)
+	/// A Date set to midnight on the day the cruise ship leaves port, in the timezone the ship leaves from. Used by the Events Controller for date arithimetic.
+	/// The default here should get overwritten in configure.swift. This is purely for convenience to set the start date via
+	/// configure.swift. This setting should not be referenced anywhere. That's what cruiseStartDate()` below is for.
+	@SettingsValue var cruiseStartDateComponents: DateComponents = DateComponents(year: 1970, month: 1, day: 1)
 
 	/// The day of week when the cruise embarks, expressed as number as Calendar's .weekday uses them: Range 1...7, Sunday == 1.
 	@SettingsValue var cruiseStartDayOfWeek: Int = 7
@@ -112,6 +113,7 @@ final class Settings : Encodable {
 	/// TimeZone representative of where we departed port from. This should equal the TZ that Sched.com uses to list Events.
 	@SettingsValue var portTimeZone: TimeZone = TimeZone(identifier: "America/New_York")!
 	
+	/// Struct representing a set of TimeZoneChange's for this cruise. This setting can then be referenced elsewhere in the application.
 	@SettingsValue var timeZoneChanges: TimeZoneChangeSet = TimeZoneChangeSet()
 	
 // MARK: Images

--- a/Sources/App/Helpers/Settings.swift
+++ b/Sources/App/Helpers/Settings.swift
@@ -102,7 +102,7 @@ final class Settings : Encodable {
 	/// A Date set to midnight on the day the cruise ship leaves port, in the timezone the ship leaves from. Used by the Events Controller for date arithimetic.
 	/// The default here should get overwritten in configure.swift. This is purely for convenience to set the start date via
 	/// configure.swift. This setting should not be referenced anywhere. That's what cruiseStartDate()` below is for.
-	@SettingsValue var cruiseStartDateComponents: DateComponents = DateComponents(year: 1970, month: 1, day: 1)
+	@SettingsValue var cruiseStartDateComponents: DateComponents = DateComponents(year: 2023, month: 3, day: 5)
 
 	/// The day of week when the cruise embarks, expressed as number as Calendar's .weekday uses them: Range 1...7, Sunday == 1.
 	@SettingsValue var cruiseStartDayOfWeek: Int = 7

--- a/Sources/App/Helpers/Settings.swift
+++ b/Sources/App/Helpers/Settings.swift
@@ -99,10 +99,10 @@ final class Settings : Encodable {
 	@StoredSettingsValue("userAutoQuarantineThreshold", defaultValue: 5) var userAutoQuarantineThreshold: Int
 	
 // MARK: Dates
-	/// A Date set to midnight on the day the cruise ship leaves port, in the timezone the ship leaves from. Used by the Events Controller for date arithimetic.
-	/// The default here should usually get overwritten in configure.swift.
-	@SettingsValue var cruiseStartDateComponents: DateComponents = DateComponents(year: 2022, month: 3, day: 5)
-	
+  /// A Date set to midnight on the day the cruise ship leaves port, in the timezone the ship leaves from. Used by the Events Controller for date arithimetic.
+  /// The default here should usually get overwritten in configure.swift.
+  @SettingsValue var cruiseStartDateComponents: DateComponents = DateComponents(year: 1970, month: 1, day: 1)
+
 	/// The day of week when the cruise embarks, expressed as number as Calendar's .weekday uses them: Range 1...7, Sunday == 1.
 	@SettingsValue var cruiseStartDayOfWeek: Int = 7
 
@@ -166,7 +166,7 @@ extension Settings {
 	func cruiseStartDate() -> Date {
 		var cal = Calendar(identifier: .gregorian)
 		cal.timeZone = portTimeZone
-		var startDateComponents = DateComponents(year: 2022, month: 3, day: 5)
+		var startDateComponents = cruiseStartDateComponents
 		startDateComponents.calendar = Calendar(identifier: .gregorian)
 		startDateComponents.timeZone = portTimeZone
 		guard let result = cal.date(from: startDateComponents) else {

--- a/Sources/App/Resources/Assets/js/swiftarr.js
+++ b/Sources/App/Resources/Assets/js/swiftarr.js
@@ -683,6 +683,8 @@ window.addEventListener('DOMContentLoaded', function() {
 			hour12: true,
 			timeZoneName: 'long'
 		  });
-		document.getElementById('browserTimeDisplay').innerHTML = formatter.format(browserTime)
+		// I don't know how to get the DateTimeFormat to not spit out "Date at Time". This will at least match
+		// the formatting coming out of Swiftarr.
+		document.getElementById('browserTimeDisplay').innerHTML = formatter.format(browserTime).replace(" at ", ", ")
 	}
 })

--- a/Sources/App/Resources/Views/featureDisabled.html
+++ b/Sources/App/Resources/Views/featureDisabled.html
@@ -3,9 +3,8 @@
     	<div class="container-md ms-0 my-1">
     		<div class="row">
     			<div class="col col-auto">
-			    	<h6><b>Feature Disabled</b></h6>
-			    	<p>The server admins have temporarily disabled this section of Twitarr.</p>
-			    	<p>Most likely, this feature was causing stability or performance issues. The feature should be back up soon.</p>
+			    	<h4>Feature Disabled</h4>
+			    	<p>The server admins have temporarily disabled this section of Twitarr. It should be back up Soon™!</p>
 				</div>
 			</div>
     	</div>

--- a/Sources/App/Resources/Views/time.html
+++ b/Sources/App/Resources/Views/time.html
@@ -1,43 +1,64 @@
 #extend("trunk"):
-    #export("body"):
-    	<div class="container-fluid">
-            <div class="row my-3">
-                <h4>Time Zone Check</h4>
+#export("body"):
+<div class="container-md ms-0 mt-2">
+    <div class="row my-3">
+        <h4>Time Zone Check</h4>
+    </div>
+    <div class="row">
+        <p>
+            JoCo Cruise will be making at least one time zone change this year. San Juan and Tortola are in Atlantic
+            Standard Time while the rest of our voyage will be in Eastern Standard Time. Be careful when scheduling
+            events
+            that you take note of the expected time zone.
+        </p>
+    </div>
+    <div class="row">
+        <div class="col">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h5 class="card-title">Boat Time</h5>
+                    <p class="card-text">#(displayTime)</p>
+                    <p class="fw-light fst-italic">
+                        This should match clocks on the boat. But the Captain sets boat time, so if they don't match,
+                        boat clocks are right and Twitarr is wrong.
+                    </p>
+                </div>
             </div>
-            <div class="row">
-                <p>
-                    JoCo Cruise will be making at least one time zone change this year. San Juan and Tortola are in Atlantic Standard 
-                    Time while the rest of our voyage will be in Eastern Standard Time. Be careful when scheduling events 
-                    that you take note of the expected time zone. The server that Twitarr runs on will be in UTC (Coordinated 
-                    Universal Time, Greenwich Mean Time, Zero/Zulu time) for the duration of the cruise.
-                </p>
+        </div>
+        <div class="col">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h5 class="card-title">Device Time</h5>
+                    <p class="card-text">
+                        <span id="browserTimeDisplay">Unknown</span>
+                    </p>
+                    <p class="fw-light fst-italic">
+                        Device time is the current time on the device you're holding in your hand.
+                    </p>
+                </div>
             </div>
-            <div class="row">
-				<div class="col">
-					<div class="alert alert-primary">This should match clocks on the boat. But the Captain sets boat time, so if they don't match, boat clocks are right and Twitarr is wrong.</div>
-				</div>
-                <p><b>Boat time: </b><span>#(displayTime)</span></p>
-				<div class="col">
-					<div class="alert alert-primary">Device time is the current time on the device you're holding in your hand.</div>
-				</div>
-                <p><b>Device time: </b><span id="browserTimeDisplay">Unknown</span></p>
-            </div>
-            <div class="row">
-                <p>If the <b>Display time</b> and <b>Device time</b> above are different, you should change the time zone on your device until they match. This should be in your settings somewhere. If you can't find it, ask a tech nerd. There's probably one nearby.</p>
-            </div>
-            <div class="row my-3">
-                <h5>Additional Time Information</h5>
-            </div>
-            <div class="row">
-                <p>
-                    This section is geared torward moderators and developers. If you are not one of these groups, don't 
-                    worry about it too much.
-                </p>
-            </div>
-            <div class="row">
-                <p><b>Server time: </b><span>#(serverTime)</span></p>
-                <p><b>Port time: </b><span>#(portTime)</span></p>
-            </div>
-		</div>
-    #endexport
+        </div>
+    </div>
+    <div class="row my-3">
+        <p>
+            If the <b>Boat Time</b> and <b>Device Time</b> above are different, you should change the time zone on your
+            device until they match. This should be in your settings somewhere. If you can't find it, ask a tech nerd.
+            There's probably one nearby.
+        </p>
+    </div>
+    <div class="row my-3">
+        <h5>Additional Time Information</h5>
+    </div>
+    <div class="row">
+        <p>
+            This section is geared torward moderators and developers. If you are not one of these groups, don't
+            worry about it too much. 
+        </p>
+    </div>
+    <div class="row">
+        <p><b>Server time: </b><span>#(serverTime)</span></p>
+        <p><b>Port time: </b><span>#(portTime)</span></p>
+    </div>
+</div>
+#endexport
 #endextend

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -150,11 +150,7 @@ func configureBasicSettings(_ app: Application) throws {
 	// We do some shenanigans to date-shift the current date into a day of the cruise week (the time the schedule covers)
 	// for Events methods, because 'No Events Today' makes testing schedule features difficult.
 	Settings.shared.portTimeZone = TimeZone(identifier: "America/New_York")!
-	// 2022: StartDate=2022-03-05, DayOfWeek 7 (Sat)
-	// 2023: StartDate=2023-03-05, DayOfWeek 1 (Sun)
-	//Settings.shared.cruiseStartDateComponents = DateComponents(year: 2022, month: 3, day: 5)
-	//Settings.shared.cruiseStartDayOfWeek = 7
-	Settings.shared.cruiseStartDateComponents = DateComponents(year: 2023, month: 1, day: 29)
+	Settings.shared.cruiseStartDateComponents = DateComponents(year: 2023, month: 3, day: 5)
 	Settings.shared.cruiseStartDayOfWeek = 1
 	
 	// Ask the GD Image library what filetypes are available on the local machine.

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -147,15 +147,15 @@ func configureBundle(_ app: Application) throws {
 // Note that other configuration methods rely on values set by this method.
 func configureBasicSettings(_ app: Application) throws {
 
-	// Set the cruise start date to a date that works with the Schedule.ics file that we have. Until we have
-	// a 2022 schedule, we're using the 2020 schedule. Development builds by default will date-shift the current date
-	// into a day of the cruise week (the time the schedule covers) for Events methods, because 'No Events Today' 
-	// makes testing schedule features difficult.
+	// We do some shenanigans to date-shift the current date into a day of the cruise week (the time the schedule covers)
+	// for Events methods, because 'No Events Today' makes testing schedule features difficult.
 	Settings.shared.portTimeZone = TimeZone(identifier: "America/New_York")!
-  //Settings.shared.cruiseStartDateComponents = DateComponents(year: 2022, month: 3, day: 5)
-  //Settings.shared.cruiseStartDayOfWeek = 7 // 2022/Saturday=7
-  Settings.shared.cruiseStartDateComponents = DateComponents(year: 2023, month: 1, day: 29)
-  Settings.shared.cruiseStartDayOfWeek = 1 // 2023/Sunday=1
+	// 2022: StartDate=2022-03-05, DayOfWeek 7 (Sat)
+	// 2023: StartDate=2023-03-05, DayOfWeek 1 (Sun)
+	//Settings.shared.cruiseStartDateComponents = DateComponents(year: 2022, month: 3, day: 5)
+	//Settings.shared.cruiseStartDayOfWeek = 7
+	Settings.shared.cruiseStartDateComponents = DateComponents(year: 2023, month: 1, day: 29)
+	Settings.shared.cruiseStartDayOfWeek = 1
 	
 	// Ask the GD Image library what filetypes are available on the local machine.
 	// gd, gd2, xbm, xpm, wbmp, some other useless formats culled.
@@ -271,17 +271,17 @@ func configureHTTPServer(_ app: Application) throws {
 	// Enable HTTP response compression.
 	// app.http.server.configuration.responseCompression = .enabled
 	
-	// Each environment type has its own default hostname. The hostname controls which address we will accept new connections on.
-	// The default hostname for an environment may be overridden with the "SWIFTARR_HOSTNAME" environment variable,
-	// and the "--hostname <addr>" command line parameter overrides the environment var.
-	if let host = Environment.get("SWIFTARR_HOSTNAME") {
+	// Specify which interface Swiftarr should bind to. The default IP for an environment may be overridden 
+	// with the "SWIFTARR_IP" environment variable, and the "--hostname <addr>" command line parameter 
+	// overrides the environment var.
+	if let host = Environment.get("SWIFTARR_IP") {
 		app.http.server.configuration.hostname = host
+	}
+	else if app.environment == .production {
+		app.http.server.configuration.hostname = "0.0.0.0"
 	}
 	else if app.environment == .development {
 		app.http.server.configuration.hostname = "127.0.0.1"
-	}
-	else if app.environment == .production {
-		app.http.server.configuration.hostname = "joco.hollandamerica.com"
 	}
 	
 	// Make our chosen hostname a canonical hostname that Settings knows about

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -140,6 +140,7 @@ func configureBundle(_ app: Application) throws {
 		Logger(label: "app.swiftarr.configuration")
 				.warning("No config file detected for environment '\(app.environment.name)'. Defaulting to shell environment and code defaults.")
 	}
+  Logger(label: "app.swiftarr.configuration") .notice("Starting up in \"\(app.environment.name)\" mode.")
 }
 
 // Sets up the cruise start date, image file types supported on the local machine, and determines a few local file paths.
@@ -150,32 +151,11 @@ func configureBasicSettings(_ app: Application) throws {
 	// a 2022 schedule, we're using the 2020 schedule. Development builds by default will date-shift the current date
 	// into a day of the cruise week (the time the schedule covers) for Events methods, because 'No Events Today' 
 	// makes testing schedule features difficult.
-
-	// We do not have the displayCalendar yet so we have to build our own. Since the departure port/timezone is
-	// well-known we can safely rely on it here. Perhaps someday make it an environment variable or some other
-	// method of configuration for app startup?
-	var portCalendar = Calendar(identifier: .gregorian)
-	let portTimeZone = TimeZone(identifier: "America/New_York")!
-	portCalendar.timeZone = portTimeZone
-	Settings.shared.portTimeZone = portTimeZone
-
-	if app.environment == .testing {
-		Logger(label: "app.swiftarr.configuration") .notice("Starting up in Testing mode.")
-		Settings.shared.cruiseStartDateComponents = DateComponents(year: 2022, month: 3, day: 5)
-	}
-	else if app.environment == .development {
-		Logger(label: "app.swiftarr.configuration") .notice("Starting up in Development mode.")
-		Settings.shared.cruiseStartDateComponents = DateComponents(year: 2022, month: 3, day: 5)
-	}
-	else if app.environment == .production {
-		Logger(label: "app.swiftarr.configuration") .notice("Starting up in Production mode.")
-		// Until we get a proper future schedule, we're using the current schedule for testing. 
-		Settings.shared.cruiseStartDateComponents = DateComponents(year: 2023, month: 3, day: 5)
-	}
-	else {
-		Logger(label: "app.swiftarr.configuration") .notice("Starting up in Custom \"\(app.environment.name)\" mode.")
-		Settings.shared.cruiseStartDateComponents = DateComponents(year: 2023, month: 3, day: 5)
-	}
+	Settings.shared.portTimeZone = TimeZone(identifier: "America/New_York")!
+  //Settings.shared.cruiseStartDateComponents = DateComponents(year: 2022, month: 3, day: 5)
+  //Settings.shared.cruiseStartDayOfWeek = 7 // 2022/Saturday=7
+  Settings.shared.cruiseStartDateComponents = DateComponents(year: 2023, month: 1, day: 29)
+  Settings.shared.cruiseStartDayOfWeek = 1 // 2023/Sunday=1
 	
 	// Ask the GD Image library what filetypes are available on the local machine.
 	// gd, gd2, xbm, xpm, wbmp, some other useless formats culled.

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -83,3 +83,12 @@ aren't currently available through the API.
 and 3 similar endpoints for use by those with the Shutternaut Manager role for managing the Shutternaut role.
 * The ForumListData type has 2 new optional fields, only non-null if the Forum Thread is for an Event. One field is the Date
 the event starts, the other is the TimeZone the boat will be in when the event starts.
+
+## Jan 29, 2023
+
+* The server settings endpoint at `GET /api/v3/admin/serversettings` is now available to twitarrteam. It was previously unavailable.
+* New endpoint for live reloading of the board games seed at `POST /api/v3/boardgames/reload`. Requires admin.
+* New endpoint for live reloading of the karaoke seed at `POST /api/v3/karaoke/reload`. Requires admin.
+* Forums now support muting (`GET /api/v3/forum/mutes`, `POST/DELETE /api/v3/forum/:ID/mute`, `POST /api/v3/forum/:ID/mute/remove`). A parameter `isMuted` has been added to the various `ForumData` structs reflecting this state.
+* Forum sort order is now influenced by the mute state. Muted forums sort to the end of the paginated results.
+* Forums associated with a schedule event now contain the event ID.


### PR DESCRIPTION
* Fixes https://github.com/jocosocial/swiftarr/issues/77 by ensuring the "all clients, all features" disable combination actually works. Also render the correct template file.
* Cleanup and unification of cruise date settings. IMO it's desirable to set these in `configure.swift` which still requires a `Setting`. We can still use the convenience function for ensuring we get the correct date as coded. But it took me a few different places to find which one actually set the date and that bothered me.
* Set cruise start date and dayofweek for 2023.
* Remove a bunch of useless code in `configure.swift`.
* Unify the swift runtime hostname parameter to `SWIFTARR_IP` which is what the container expects and what is in the example env files. Apparently I missed that we used two different vars for the same function.
* Improve the UX for the time zone check page with the new timezone features.
* Catch up on API change documentation since November.