### PR TITLE
Add workflow to lock Package.resolved

### DIFF
--- a/.github/workflows/prevent_file_changes.yml
+++ b/.github/workflows/prevent_file_changes.yml
@@ -9,8 +9,8 @@ jobs:
   prevent_file_changes:
     runs-on: ubuntu-latest
     steps:
-      - name: Lock Package.swift
+      - name: Lock Package.resolved
         uses: xalvarez/prevent-file-change-action@v1
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-          pattern: Package.swift
+          pattern: Package.resolved

--- a/.github/workflows/prevent_file_changes.yml
+++ b/.github/workflows/prevent_file_changes.yml
@@ -1,0 +1,16 @@
+name: Prevent File Changes
+on:
+  pull_request: null
+  push:
+    branches:
+      - master
+
+jobs:
+  prevent_file_changes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lock Package.swift
+        uses: xalvarez/prevent-file-change-action@v1
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          pattern: Package.swift


### PR DESCRIPTION
This PR adds a workflow which will prevent PRs from modifying `Package.resolved`. When we want to start enforcing this (that is, when the release is locked down for boat), re-enable this workflow and set the Branch protection rules for `master` to "Require status checks to pass before merging" - `prevent_file_changes`