### PR TITLE
Karaoke: Allow searching by first letter of artist

### DIFF
--- a/Sources/App/Controllers/KaraokeController.swift
+++ b/Sources/App/Controllers/KaraokeController.swift
@@ -48,6 +48,7 @@ struct KaraokeController: APIRouteCollection {
 			var favorite: String?
 			var start: Int?
 			var limit: Int?
+			var letter: String?
 		}
  		let filters = try req.query.decode(SongQueryOptions.self)
 		let start = filters.start ?? 0
@@ -58,6 +59,9 @@ struct KaraokeController: APIRouteCollection {
 				or.fullTextFilter(\.$artist, search)
 				or.fullTextFilter(\.$title, search)
 			}
+		}
+		else if let letter = filters.letter {
+			songQuery.filter(\.$artist =~ letter)
 		}
 		var filteringFavorites = false
 		if let user = req.auth.get(UserCacheData.self) {

--- a/Sources/App/Controllers/KaraokeController.swift
+++ b/Sources/App/Controllers/KaraokeController.swift
@@ -37,7 +37,7 @@ struct KaraokeController: APIRouteCollection {
 	/// 
 	/// **URL Query Parameters**
 	/// * `?search=STRING` - Only show songs whose artist or title contains the given string.
-	/// * `?letter=STRING` - Only show songs whose artist begins with a number (send %23) or a specific letter (send a single letter).
+	///   If a single letter or %23 is sent, it will return songs where the artist matches the letter, or starts with a number.
 	/// * `?favorite=TRUE` - Only return songs that have been favorited by current user. 
 	///	* `?start=INT` - Offset from start of results set
 	/// * `?limit=INT` - the maximum number of songs to retrieve: 1-200, default is 50.
@@ -49,7 +49,6 @@ struct KaraokeController: APIRouteCollection {
 			var favorite: String?
 			var start: Int?
 			var limit: Int?
-			var letter: String?
 		}
  		let filters = try req.query.decode(SongQueryOptions.self)
 		let start = filters.start ?? 0
@@ -57,23 +56,22 @@ struct KaraokeController: APIRouteCollection {
 		let songQuery = KaraokeSong.query(on: req.db).sort(\.$artist, .ascending).sort(\.$title, .ascending)
 		var filteringLetters = false
 		if let search = filters.search {
-			songQuery.group(.or) { (or) in 
-				or.fullTextFilter(\.$artist, search)
-				or.fullTextFilter(\.$title, search)
-			}
-		}
-		else if let letter = filters.letter {
-			if letter.count == 1 {
+			if search.count == 1 {
 				filteringLetters = true
-
-				if letter == "#" {
+				if search == "#" {
 					songQuery.filter(\.$artist, .custom("~"), "^[0-9]")
 				}
-				else if let _ = letter.rangeOfCharacter(from: NSCharacterSet.letters) { 
-					songQuery.filter(\.$artist, .custom("ILIKE"), "\(letter)%")
+				else if let _ = search.rangeOfCharacter(from: NSCharacterSet.letters) { 
+					songQuery.filter(\.$artist, .custom("ILIKE"), "\(search)%")
 				}
 				else {
 					filteringLetters = false
+				}
+			}
+			else {
+				songQuery.group(.or) { (or) in 
+					or.fullTextFilter(\.$artist, search)
+					or.fullTextFilter(\.$title, search)
 				}
 			}
 		}
@@ -100,7 +98,7 @@ struct KaraokeController: APIRouteCollection {
 		}
 		let hasSearchString = filters.search?.count ?? 0 >= 3
 		guard filteringFavorites || filteringLetters || hasSearchString else {
-			throw Abort(.badRequest, reason: "Search string must have at least 3 characters.")
+			throw Abort(.badRequest, reason: "Search string must have at least 3 characters, or be a single letter, or be the character #.")
 		}
 		
 		let totalFoundSongs = try await songQuery.count()

--- a/Sources/App/Site/SiteKaraokeController.swift
+++ b/Sources/App/Site/SiteKaraokeController.swift
@@ -24,7 +24,8 @@ struct SiteKaraokeController: SiteControllerUtils {
 	/// GET /karaoke
 	///
 	/// **URL Query Parameters**
-	/// * `?search=STRING` - returns song library results where the artist OR song title matches the given string.
+	/// * `?search=STRING` - returns song library results where the artist OR song title matches the given string. 
+	///   If a single letter or %23 is sent, it will return songs where the artist matches the letter, or starts with a number.
 	/// * `?favorite=TRUE` - Only return songs that have been favorited by current user. 
 	///	* `?start=INT` - Offset from start of results set
 	/// * `?limit=INT` - the maximum number of songs to retrieve: 1-200, default is 50. 


### PR DESCRIPTION
This change allows karaoke users to additionally search by a single letter, or by the character `#`. Doing so will return songs whose artists start with the searched letter or any number, respectively. This should work seamlessly with current search clients, unless they are doing their own input validation to restrict searches to be at least 3 letters long (the previous API rule).