### PR TITLE
Fix Mentioning Edge Cases

### DIFF
--- a/Sources/App/Controllers/ForumController.swift
+++ b/Sources/App/Controllers/ForumController.swift
@@ -617,7 +617,6 @@ struct ForumController: APIRouteCollection {
 		}
 		
 		let constQuery = query
-		async let totalPosts = try constQuery.count()
 		async let posts = constQuery.range(start..<(start + limit)).all()
 		// The filter() for mentions will include usernames that are prefixes for other usernames and other false positives.
 		// This filters those out after the query. 
@@ -628,9 +627,9 @@ struct ForumController: APIRouteCollection {
 				try await markNotificationViewed(user: cacheUser, type: .forumMention(0), on: req)
 			}
 		}
+		let totalPosts = postFilteredPosts.count
 		let postData = try await buildPostData(postFilteredPosts, userID: cacheUser.userID, on: req, mutewords: cacheUser.mutewords)
-		return try await PostSearchData(queryString: req.url.query ?? "", totalPosts: totalPosts, 
-					start: start, limit: limit, posts: postData)
+		return PostSearchData(queryString: req.url.query ?? "", totalPosts: totalPosts, start: start, limit: limit, posts: postData)
 	}
 	
 	// MARK: POST and DELETE actions


### PR DESCRIPTION
Fixes https://github.com/jocosocial/swiftarr/issues/106
* Correct post count based on complex mention match rather than simple string.
* Fix edge case where mentioning a user at the end of a post without a sentence-ending period would trigger a mention but not be visible in the filtered view.
* Expand commentary for the next person to crawl through the mention filter function.