### PR TITLE
Make default startdayofweek match the startdate

### DIFF
--- a/Sources/App/Helpers/Settings.swift
+++ b/Sources/App/Helpers/Settings.swift
@@ -105,7 +105,7 @@ final class Settings : Encodable {
 	@SettingsValue var cruiseStartDateComponents: DateComponents = DateComponents(year: 2023, month: 3, day: 5)
 
 	/// The day of week when the cruise embarks, expressed as number as Calendar's .weekday uses them: Range 1...7, Sunday == 1.
-	@SettingsValue var cruiseStartDayOfWeek: Int = 7
+	@SettingsValue var cruiseStartDayOfWeek: Int = 1
 
 	/// The length in days of the cruise, includes partial days. A cruise that embarks on Saturday and returns the next Saturday should have a value of 8.
 	@SettingsValue var cruiseLengthInDays: Int = 8


### PR DESCRIPTION
Improves the OOBE for anyone running the app who does not set `SWIFTARR_START_DATE` in the environment file. Setting the env var will automatically set the `cruiseStartDayOfWeek` to the appropriate value based on the `cruiseStartDateComponents`. This behavior is not reflected in the raw settings defaults.