### PR TITLE
Fez Min/Max Fix, Improve Fez Filtering

### DIFF
--- a/Sources/App/Models/FriendlyFez.swift
+++ b/Sources/App/Models/FriendlyFez.swift
@@ -115,7 +115,7 @@ final class FriendlyFez: Model, Searchable  {
 		startTime: Date?,
 		endTime: Date?,
 		minCapacity: Int = 0,
-		maxCapacity: Int
+		maxCapacity: Int = 0
 	) {
 		self.$owner.id = owner
 		self.fezType = fezType

--- a/Sources/App/Resources/Assets/js/swiftarr.js
+++ b/Sources/App/Resources/Assets/js/swiftarr.js
@@ -24,13 +24,11 @@ for (let btn of document.querySelectorAll('[data-action]')) {
 		case "eventFiltersChanged": btn.addEventListener("click", filterEvents); break;
 		case "filterEventType": btn.addEventListener("click", eventFilterDropdownTappedAction); break;
 		case "eventScrollToNow": btn.addEventListener("click", soonButtonTappedAction); break;
-		case "filterFezDay": 
-			dropdownButtonSetup(btn); 
-			btn.addEventListener("click", fezDayFilterDropdownTappedAction);
-			break;
+		case "filterFezDay":
 		case "filterFezType":
+		case "filterFezHidePast": 
 			dropdownButtonSetup(btn); 
-			btn.addEventListener("click", fezTypeFilterDropdownTappedAction);
+			btn.addEventListener("click", fezFilterDropdownTappedAction);
 			break;
 	}
 }
@@ -509,7 +507,7 @@ function scrollToCurrentEvent() {
 	return false;
 }
 
-function eventFilterDropdownTappedAction() {
+function eventFilterDropdownTappedAction(event) {
 	updateDropdownButton(event.target);
 	filterEvents();
 }
@@ -538,22 +536,19 @@ function filterEvents() {
 
 // MARK: - Fez Handlers
 
-function fezDayFilterDropdownTappedAction() {
-	updateDropdownButton(event.target);
-	applyFezSearchFilters();
-}
-
-function fezTypeFilterDropdownTappedAction() {
+function fezFilterDropdownTappedAction(event) {
 	updateDropdownButton(event.target);
 	applyFezSearchFilters();
 }
 
 function applyFezSearchFilters() {
-	let typeSelection = document.getElementById("fezTypeFilterMenu").dataset.selected;
 	let queryString = ""
+
+	let typeSelection = document.getElementById("fezTypeFilterMenu").dataset.selected;
 	if (typeSelection != "all") {
 		queryString = "?type=" + typeSelection;
 	}
+
 	let daySelection = document.getElementById("fezDayFilterMenu").dataset.selected;
 	if (daySelection != "all") {
 		if (queryString.length > 0) {
@@ -563,7 +558,17 @@ function applyFezSearchFilters() {
 			queryString = "?cruiseday=" + daySelection;
 		}
 	}
-	window.location.href = "/fez" + queryString;
+
+	let hidePastSelection = document.getElementById("fezHidePastFilterMenu").dataset.selected;
+	if (hidePastSelection != "default") {
+		if (queryString.length > 0) {
+			queryString = queryString + "&hidePast=" + hidePastSelection;
+		}
+		else {
+			queryString = "?hidePast=" + hidePastSelection;
+		}
+	}
+	window.location.href = window.location.href.split("?")[0] + queryString;
 }
 
 // Populates username completions for a partial username. 

--- a/Sources/App/Resources/Views/Fez/fezCreate.html
+++ b/Sources/App/Resources/Views/Fez/fezCreate.html
@@ -87,8 +87,8 @@
 								</div>
 								<div class="row mb-2">
 									<div class="col">
-										Needs at least <input type="number" name="minimum" min="2" max="50" step="1" value="#(minPeople)"> 
-										and at most <input type="number" name="maximum" min="2" max="50" step="1" value="#(maxPeople)"> attendees
+										Needs at least <input type="number" name="minimum" min="0" step="1" value="#(minPeople)"> 
+										and at most <input type="number" name="maximum" min="0" step="1" value="#(maxPeople)"> attendees
 									</div>
 								</div>
 								<div class="row">

--- a/Sources/App/Resources/Views/Fez/fezCreate.html
+++ b/Sources/App/Resources/Views/Fez/fezCreate.html
@@ -88,7 +88,7 @@
 								<div class="row mb-2">
 									<div class="col">
 										Needs at least <input type="number" name="minimum" min="0" step="1" value="#(minPeople)"> 
-										and at most <input type="number" name="maximum" min="0" step="1" value="#(maxPeople)"> attendees
+										and at most <input type="number" name="maximum" min="0" step="1" value="#(maxPeople)"> attendees (use 0 for unlimited)
 									</div>
 								</div>
 								<div class="row">

--- a/Sources/App/Resources/Views/Fez/fezFilter.html
+++ b/Sources/App/Resources/Views/Fez/fezFilter.html
@@ -1,0 +1,57 @@
+<div class="row align-items-center justify-content-end mb-2">
+    <div class="col col-auto">
+        Filter by:
+    </div>
+    <div class="col col-auto">
+        <div class="dropdown">
+            <button class="btn btn-outline-primary dropdown-toggle btn-sm" type="button" id="fezDayFilterMenu" data-bs-toggle="dropdown" data-selected="all" aria-expanded="false">
+                All Days
+            </button>
+            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="fezDayFilterMenu">
+                <li><button class="dropdown-item" type="button" data-action="filterFezDay" data-selection="all">All Days</button></li>
+                <li><hr class="dropdown-divider"></li>
+                <li><h6 class="dropdown-header">Only show:</h6></li>
+                <li><button class="dropdown-item #if(daySelection == "0"):active#endif" type="button" data-action="filterFezDay" data-selection="0">Sun</button></li>
+                <li><button class="dropdown-item #if(daySelection == "1"):active#endif" type="button" data-action="filterFezDay" data-selection="1">Mon</button></li>
+                <li><button class="dropdown-item #if(daySelection == "2"):active#endif" type="button" data-action="filterFezDay" data-selection="2">Tue</button></li>
+                <li><button class="dropdown-item #if(daySelection == "3"):active#endif" type="button" data-action="filterFezDay" data-selection="3">Wed</button></li>
+                <li><button class="dropdown-item #if(daySelection == "4"):active#endif" type="button" data-action="filterFezDay" data-selection="4">Thu</button></li>
+                <li><button class="dropdown-item #if(daySelection == "5"):active#endif" type="button" data-action="filterFezDay" data-selection="5">Fri</button></li>
+                <li><button class="dropdown-item #if(daySelection == "6"):active#endif" type="button" data-action="filterFezDay" data-selection="6">Sat</button></li>
+                <li><button class="dropdown-item #if(daySelection == "7"):active#endif" type="button" data-action="filterFezDay" data-selection="7">Second Sun</button></li>
+            </ul>
+        </div>
+    </div>
+    <div class="col col-auto">
+        <div class="dropdown">
+            <button class="btn btn-outline-primary dropdown-toggle btn-sm" type="button" id="fezTypeFilterMenu" data-bs-toggle="dropdown" data-selected="all" aria-expanded="false">
+                All Types
+            </button>
+            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="fezDayFilterMenu">
+                <li><button class="dropdown-item" type="button" data-action="filterFezType" data-selection="all">All Types</button></li>
+                <li><hr class="dropdown-divider"></li>
+                <li><h6 class="dropdown-header">Only show:</h6></li>
+                <li><button class="dropdown-item #if(typeSelection == "activity"):active#endif" type="button" data-action="filterFezType" data-selection="activity">Activity</button></li>
+                <li><button class="dropdown-item #if(typeSelection == "dining"):active#endif" type="button" data-action="filterFezType" data-selection="dining">Dining</button></li>
+                <li><button class="dropdown-item #if(typeSelection == "gaming"):active#endif" type="button" data-action="filterFezType" data-selection="gaming">Gaming</button></li>
+                <li><button class="dropdown-item #if(typeSelection == "meetup"):active#endif" type="button" data-action="filterFezType" data-selection="meetup">Meetup</button></li>
+                <li><button class="dropdown-item #if(typeSelection == "music"):active#endif" type="button" data-action="filterFezType" data-selection="music">Music</button></li>
+                <li><button class="dropdown-item #if(typeSelection == "other"):active#endif" type="button" data-action="filterFezType" data-selection="other">Other</button></li>
+                <li><button class="dropdown-item #if(typeSelection == "shore"):active#endif" type="button" data-action="filterFezType" data-selection="shore">Shore</button></li>
+            </ul>
+        </div>
+    </div>
+    <div class="col col-auto">
+        <div class="dropdown">
+            <button class="btn btn-outline-primary dropdown-toggle btn-sm" type="button" id="fezHidePastFilterMenu" data-bs-toggle="dropdown" data-selected="default" aria-expanded="false">
+                Hide Past LFGs?
+            </button>
+            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="fezHidePastFilterMenu">
+                <li><button class="dropdown-item" type="button" data-action="filterFezHidePast" data-selection="default">Default</button></li>
+                <li><hr class="dropdown-divider"></li>
+                <li><button class="dropdown-item #if(hidePastSelection == true):active#endif" type="button" data-action="filterFezHidePast" data-selection="true">Hide Past LFGs</button></li>
+                <li><button class="dropdown-item #if(hidePastSelection == false):active#endif" type="button" data-action="filterFezHidePast" data-selection="false">Show Past LFGs</button></li>
+            </ul>
+        </div>
+    </div>
+</div>

--- a/Sources/App/Resources/Views/Fez/fezJoined.html
+++ b/Sources/App/Resources/Views/Fez/fezJoined.html
@@ -2,6 +2,7 @@
     #export("body"):
     	<div class="container-md ms-0 mt-2">
 			#extend("Fez/fezNavbar")
+			#extend("Fez/fezFilter")
 			#extend("paginator")
 			<div class="list-group">
 				#if(count(fezList.fezzes) == 0):

--- a/Sources/App/Resources/Views/Fez/fezOwned.html
+++ b/Sources/App/Resources/Views/Fez/fezOwned.html
@@ -3,6 +3,7 @@
     	<div class="container-md ms-0 mt-2">
 			#extend("Fez/fezNavbar")
 			<a class="btn btn-primary btn-sm mb-2" role="button" href="/fez/create">New LFG</a>
+			#extend("Fez/fezFilter")
 			#extend("paginator")
 			<div class="list-group">
 				#if(count(fezList.fezzes) == 0):

--- a/Sources/App/Resources/Views/Fez/fezRoot.html
+++ b/Sources/App/Resources/Views/Fez/fezRoot.html
@@ -2,50 +2,7 @@
     #export("body"):
     	<div class="container-md ms-0 mt-2">
 			#extend("Fez/fezNavbar")
-			<div class="row align-items-center justify-content-end mb-2">
-				<div class="col col-auto">
-					Filter by:
-				</div>
-				<div class="col col-auto">
-					<div class="dropdown">
-						<button class="btn btn-outline-primary dropdown-toggle btn-sm" type="button" id="fezDayFilterMenu" data-bs-toggle="dropdown" data-selected="all" aria-expanded="false">
-							All Days
-						</button>
-						<ul class="dropdown-menu dropdown-menu-end" aria-labelledby="fezDayFilterMenu">
-							<li><button class="dropdown-item #if(daySelection == "all"):active#endif" type="button" data-action="filterFezDay" data-selection="all">All Days</button></li>
- 							<li><hr class="dropdown-divider"></li>
-							<li><h6 class="dropdown-header">Only show:</h6></li>
- 							<li><button class="dropdown-item #if(daySelection == "0"):active#endif" type="button" data-action="filterFezDay" data-selection="0">Sat</button></li>
-							<li><button class="dropdown-item #if(daySelection == "1"):active#endif" type="button" data-action="filterFezDay" data-selection="1">Sun</button></li>
-							<li><button class="dropdown-item #if(daySelection == "2"):active#endif" type="button" data-action="filterFezDay" data-selection="2">Mon</button></li>
-							<li><button class="dropdown-item #if(daySelection == "3"):active#endif" type="button" data-action="filterFezDay" data-selection="3">Tue</button></li>
-							<li><button class="dropdown-item #if(daySelection == "4"):active#endif" type="button" data-action="filterFezDay" data-selection="4">Wed</button></li>
-							<li><button class="dropdown-item #if(daySelection == "5"):active#endif" type="button" data-action="filterFezDay" data-selection="5">Thu</button></li>
-							<li><button class="dropdown-item #if(daySelection == "6"):active#endif" type="button" data-action="filterFezDay" data-selection="6">Fri</button></li>
-							<li><button class="dropdown-item #if(daySelection == "7"):active#endif" type="button" data-action="filterFezDay" data-selection="7">Second Sat</button></li>
-						</ul>
-					</div>
-				</div>
-				<div class="col col-auto">
-					<div class="dropdown">
-						<button class="btn btn-outline-primary dropdown-toggle btn-sm" type="button" id="fezTypeFilterMenu" data-bs-toggle="dropdown" data-selected="#(typeSelection)" aria-expanded="false">
-							All Types
-						</button>
-						<ul class="dropdown-menu dropdown-menu-end" aria-labelledby="fezDayFilterMenu">
-							<li><button class="dropdown-item #if(typeSelection == "all"):active#endif" type="button" data-action="filterFezType" data-selection="all">All Types</button></li>
- 							<li><hr class="dropdown-divider"></li>
-							<li><h6 class="dropdown-header">Only show:</h6></li>
- 							<li><button class="dropdown-item #if(typeSelection == "activity"):active#endif" type="button" data-action="filterFezType" data-selection="activity">Activity</button></li>
-							<li><button class="dropdown-item #if(typeSelection == "dining"):active#endif" type="button" data-action="filterFezType" data-selection="dining">Dining</button></li>
-							<li><button class="dropdown-item #if(typeSelection == "gaming"):active#endif" type="button" data-action="filterFezType" data-selection="gaming">Gaming</button></li>
-							<li><button class="dropdown-item #if(typeSelection == "meetup"):active#endif" type="button" data-action="filterFezType" data-selection="meetup">Meetup</button></li>
-							<li><button class="dropdown-item #if(typeSelection == "music"):active#endif" type="button" data-action="filterFezType" data-selection="music">Music</button></li>
-							<li><button class="dropdown-item #if(typeSelection == "other"):active#endif" type="button" data-action="filterFezType" data-selection="other">Other</button></li>
-							<li><button class="dropdown-item #if(typeSelection == "shore"):active#endif" type="button" data-action="filterFezType" data-selection="shore">Shore</button></li>
-						</ul>
-					</div>
-				</div>
-			</div>
+			#extend("Fez/fezFilter")
 			#extend("paginator")
 			<div class="list-group">
 				#if(count(fezList.fezzes) == 0):

--- a/Sources/App/Site/SiteFriendlyFezController.swift
+++ b/Sources/App/Site/SiteFriendlyFezController.swift
@@ -137,8 +137,9 @@ struct SiteFriendlyFezController: SiteControllerUtils {
 			var fezList: FezListData
 			var paginator: PaginatorContext
 			var tab: FezTab
-			var typeSelection: String
+			var typeSelection: String?
 			var daySelection: Int?
+			var hidePastSelection: Bool?
 			
 			init(_ req: Request, fezList: FezListData) throws {
 				trunk = .init(req, title: "Looking For Group", tab: .lfg)
@@ -146,6 +147,8 @@ struct SiteFriendlyFezController: SiteControllerUtils {
 				tab = .find
 				typeSelection = req.query[String.self, at: "type"] ?? "all"
 				daySelection = req.query[Int.self, at: "cruiseday"]
+				let hidePastQuery = req.query[String.self, at: "hidePast"]
+				hidePastSelection = hidePastQuery == nil ? nil : hidePastQuery?.lowercased() == "true"
 				let limit = fezList.paginator.limit
 				paginator = .init(fezList.paginator) { pageIndex in
 					"/fez?start=\(pageIndex * limit)&limit=\(limit)"
@@ -184,11 +187,18 @@ struct SiteFriendlyFezController: SiteControllerUtils {
 			var fezList: FezListData
 			var paginator: PaginatorContext
 			var tab: FezTab
+			var typeSelection: String?
+			var daySelection: Int?
+			var hidePastSelection: Bool?
 			
 			init(_ req: Request, fezList: FezListData) throws {
 				trunk = .init(req, title: "LFG Joined Groups", tab: .lfg)
 				self.fezList = fezList
 				tab = .joined
+				typeSelection = req.query[String.self, at: "type"] ?? "all"
+				daySelection = req.query[Int.self, at: "cruiseday"]
+				let hidePastQuery = req.query[String.self, at: "hidePast"]
+				hidePastSelection = hidePastQuery == nil ? nil : hidePastQuery?.lowercased() == "true"
 				let limit = fezList.paginator.limit
 				paginator = .init(fezList.paginator) { pageIndex in
 					"/fez/joined?start=\(pageIndex * limit)&limit=\(limit)"
@@ -210,11 +220,18 @@ struct SiteFriendlyFezController: SiteControllerUtils {
 			var fezList: FezListData
 			var paginator: PaginatorContext
 			var tab: FezTab
+			var typeSelection: String?
+			var daySelection: Int?
+			var hidePastSelection: Bool?
 			
 			init(_ req: Request, fezList: FezListData) throws {
 				trunk = .init(req, title: "LFGs Created By You", tab: .lfg)
 				self.fezList = fezList
 				tab = .owned
+				typeSelection = req.query[String.self, at: "type"] ?? "all"
+				daySelection = req.query[Int.self, at: "cruiseday"]
+				let hidePastQuery = req.query[String.self, at: "hidePast"]
+				hidePastSelection = hidePastQuery == nil ? nil : hidePastQuery?.lowercased() == "true"
 				let limit = fezList.paginator.limit
 				paginator = .init(fezList.paginator) { pageIndex in
 					"/fez/joined?start=\(pageIndex * limit)&limit=\(limit)"

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -109,3 +109,8 @@ doesn't have the expansions.
 ## Feb 19, 2023
 
 * Fezzes now support a `search` parameter. This works just like all of the other searchable endpoints. Seamails and LFGs are now searchable in the API!
+
+## Feb 27, 2023
+
+* Fez `open`, `joined`, and `owned` queries now support a `hidePast` parameter. When `true`, fezzes with a start date more than 1 hour in the past will be hidden. These queries use default values that match query behavior prior to the addition of this parameter, so clients which do not support it will see no change in list behavior.
+* Fez `joined` and `owned` queries now allow the `cruiseday` parameter. It functions identically to the `cruiseday` parameter on `open` fezzes.


### PR DESCRIPTION
The UI was enforcing a range of 2 to 50 for fez min and max participants. This limitation does not exist in the API, and in the case of meetups or large interest groups, is probably undesired. Creating a fez with 0 max capacity means unlimited membership. The UI already has code to handle this - the 2-50 limitation was just on the input fields.

Additionally, the API's `FriendlyFez` initializer was missing a default value of 0 for `maxCapacity`.

In the API, all three Fez list queries (`joined`, `owned`, `open`) now support the `cruiseday` filter param. This allows us to make the filtering consistent across all tabs in the front-end. Also, there's a new filter type, which enables/disables showing fezzes whose start date is more than an hour in the past. If the new filter is omitted, API clients will see the same behavior that was present prior to the filter's addition.

Finally, the day labels in the Fez Day Of Week dropdown were corrected. Prior to this change, it was showing Sat to Second Sat. It's now Sun to Second Sun.