### PR TITLE
Allow TwitarrTeam to modify announcements

### DIFF
--- a/Sources/App/Controllers/AlertController.swift
+++ b/Sources/App/Controllers/AlertController.swift
@@ -239,11 +239,9 @@ struct AlertController: APIRouteCollection {
 	/// - Returns: Array of <doc:AnnouncementData>
 	func getAnnouncements(_ req: Request) async throws -> [AnnouncementData] {
 		let user = req.auth.get(UserCacheData.self)
-		var includeInactives: Bool = req.query[String.self, at: "inactives"] == "true"
 		// Prevent users with access levels below THO from loading inactive annoucnements
-		if !(user?.accessLevel.hasAccess(.tho) ?? false) {
-			includeInactives = false
-		}
+		let includeInactives: Bool = (user?.accessLevel.hasAccess(.tho) ?? false) && req.query[String.self, at: "inactives"] == "true";
+
 		let query = Announcement.query(on: req.db).sort(\.$id, .descending)
 		if includeInactives {
 			query.withDeleted()

--- a/Sources/App/Controllers/AlertController.swift
+++ b/Sources/App/Controllers/AlertController.swift
@@ -230,7 +230,7 @@ struct AlertController: APIRouteCollection {
 	/// 
 	/// **URL Query Parameters**
 	/// 
-	/// - `?inactives=true` Also return expired and deleted announcements. THO and admins only. 
+	/// - `?inactives=true` Also return expired and deleted announcements. TwitarrTeam, THO, and admins only. 
 	/// 		
 	/// The purpose if the inactives flag is to allow for finding an expired announcement and re-activating it by changing its expire time. Remember that doing so
 	/// doesn't re-alert users who have already read it.
@@ -240,7 +240,7 @@ struct AlertController: APIRouteCollection {
 	func getAnnouncements(_ req: Request) async throws -> [AnnouncementData] {
 		let user = req.auth.get(UserCacheData.self)
 		let includeInactives: Bool = req.query[String.self, at: "inactives"] == "true"
-		guard !includeInactives || (user?.accessLevel.hasAccess(.tho) ?? false) else {
+		guard !includeInactives || (user?.accessLevel.hasAccess(.twitarrteam) ?? false) else {
 			throw Abort(.forbidden, reason: "Inactive announcements are THO only")
 		}
 		let query = Announcement.query(on: req.db).sort(\.$id, .descending)


### PR DESCRIPTION
Allow TwitarrTeam members to perform operations on announcements.

Additionally, instead of throwing an error when a user without permissions requests inactive announcements, just silently pretend they only asked for active announcements.

Fixes #149 