### PR TITLE
Audit pages on the admin screen: only allow permitted roles to see links

### DIFF
--- a/Sources/App/Resources/Views/admin/root.html
+++ b/Sources/App/Resources/Views/admin/root.html
@@ -9,24 +9,30 @@
 			<div class="list-group">
 				<a class="list-group-item list-group-item-action" href="/admin/announcements">
 					<b>Announcements</b>: Create, Edit and Delete system-wide announcements
-				</a>		
+				</a>
 				<a class="list-group-item list-group-item-action" href="/admin/dailythemes">
 					<b>Daily Themes</b>: Set info for Theme Days, including explanatory text and pictures.
-				</a>		
+				</a>
 				<a class="list-group-item list-group-item-action" href="/admin/serversettings">
 					<b>Server Settings</b>: Lots of inscrutable toggles and buttons here.
-				</a>		
-				<a class="list-group-item list-group-item-action" href="/admin/timezonechanges">
-					<b>Time Zones</b>: Every time zone change we undergo during the cruise.
-				</a>		
+				</a>
 				<a class="list-group-item list-group-item-action" href="/admin/scheduleupload">
 					<b>Schedule Upload</b>: Uploads and processes a new schedule.ics file.
-				</a>		
+				</a>
 				<a class="list-group-item list-group-item-action" href="/admin/regcodes">
 					<b>Registration Codes</b>: View/Manage registration code table.
 				</a>
 				#if(trunk.userIsTHO):
 					#if(trunk.username == "admin"):
+						<a class="list-group-item list-group-item-action" href="/admin/timezonechanges">
+							<b>Time Zones</b>: Every time zone change we undergo during the cruise.
+						</a>
+						<a class="list-group-item list-group-item-action" href="/admin/karaoke">
+							<b>Karaoke</b>: Administer karaoke settings.
+						</a>
+						<a class="list-group-item list-group-item-action" href="/admin/boardgames">
+							<b>Board Games</b>: Administer board game settings.
+						</a>
 						<a class="list-group-item list-group-item-action" href="/admin/tho">
 							<b>Manage THO</b>: View/Manage THO members.
 						</a>
@@ -41,22 +47,17 @@
 					<a class="list-group-item list-group-item-action" href="/admin/mods">
 						<b>Manage Moderators</b>: View/Manage moderators.
 					</a>
+					<a class="list-group-item list-group-item-action" href="/admin/userroles">
+						<b>Manage User Roles</b>: View/Manage User Roles.
+					</a>
 				#endif
-				<a class="list-group-item list-group-item-action" href="/admin/userroles">
-					<b>Manage User Roles</b>: View/Manage User Roles.
-				</a>		
 				<a class="list-group-item list-group-item-action" href="/seamail?foruser=twitarrteam">
 					<b>TwitarrTeam Seamail</b>: Seamail to @twitarrteam
 					#if(trunk.alertCounts.moderatorData.newTTSeamailMessageCount > 0):
 						<div><span class="text-muted border-bottom border-danger"><i>#(trunk.alertCounts.moderatorData.newTTSeamailMessageCount) New Message#if(trunk.alertCounts.moderatorData.newTTSeamailMessageCount > 1):s#endif</i></span></div>
 					#endif
 				</a>
-				<a class="list-group-item list-group-item-action" href="/admin/karaoke">
-					<b>Karaoke</b>: Administer karaoke settings.
-				</a>
-				<a class="list-group-item list-group-item-action" href="/admin/boardgames">
-					<b>Board Games</b>: Administer board game settings.
-				</a>
+				
 			</div>
 		</div>
     #endexport


### PR DESCRIPTION
Announcements view/edit permission (including daily themes, I hope) will be fixed by #157.

Most dangerous operations are restricted to the admin role. TwitarrTeam doesn't need to care about managing user roles - THO can handle that, like they do for moderator promotions.

Fixes #151 