### PR TITLE
Allow login redirect for private URLs

### DIFF
--- a/Sources/App/Site/SiteAdminController.swift
+++ b/Sources/App/Site/SiteAdminController.swift
@@ -8,7 +8,7 @@ struct SiteAdminController: SiteControllerUtils {
 	var userRoleParam = PathComponent(":user_role")
 
 	func registerRoutes(_ app: Application) throws {
-		// Routes for non-shareable content. If you're not logged in we failscreen.
+		// Routes for non-shareable content.
 		let privateTTRoutes = getPrivateRoutes(app).grouped(SiteRequireTwitarrTeamMiddleware()).grouped("admin")
 		
 		privateTTRoutes.get("", use: adminRootPageHandler)

--- a/Sources/App/Site/SiteController.swift
+++ b/Sources/App/Site/SiteController.swift
@@ -630,16 +630,23 @@ extension SiteControllerUtils {
 		])
 	}
 		
-	// Routes for non-shareable content. If you're not logged in we failscreen. Most POST actions go here.
+	// Routes for non-shareable content. Most POST actions go here.
 	//
 	// Private site routes should not allow token auth. Token auth is for apps that want to open a webpage with their
 	// token. They can initiate a web flow with a token, get a session back, and use that to complete the flow. However,
 	// we don't want apps to be able to jump to private web pages.
 	func getPrivateRoutes(_ app: Application) -> RoutesBuilder {
+		// This middleware redirects to "/login" when accessing a page that requires auth while not logged in.
+		// It saves the page the user was attempting to view in the session, so we can return there post-login.
+		let redirectMiddleware = UserCacheData.redirectMiddleware { (req) -> String in
+			req.session.data["returnAfterLogin"] = req.url.string
+			return "/login"
+		}
+
 		return app.grouped( [ 
 				app.sessions.middleware, 
 				UserCacheData.SessionAuth(),
-				UserCacheData.guardMiddleware()
+				redirectMiddleware
 		])
 	}
 	

--- a/Sources/App/Site/SiteEventsController.swift
+++ b/Sources/App/Site/SiteEventsController.swift
@@ -60,7 +60,7 @@ struct SiteEventsController: SiteControllerUtils {
 		openRoutes.get("events", eventIDParam, use: eventGetPageHandler)
 		openRoutes.get("events", eventIDParam, "calendarevent.ics", use: eventsDownloadICSHandler)
 
-		// Routes for non-shareable content. If you're not logged in we failscreen.
+		// Routes for non-shareable content.
 		let privateRoutes = getPrivateRoutes(app).grouped(DisabledSiteSectionMiddleware(feature: .schedule))
 		privateRoutes.post("events", eventIDParam, "favorite", use: eventsAddRemoveFavoriteHandler)
 		privateRoutes.delete("events", eventIDParam, "favorite", use: eventsAddRemoveFavoriteHandler)

--- a/Sources/App/Site/SiteForumController.swift
+++ b/Sources/App/Site/SiteForumController.swift
@@ -225,7 +225,7 @@ struct SiteForumController: SiteControllerUtils {
 		globalRoutes.get("forum", forumIDParam, use: forumThreadPageHandler)
 		globalRoutes.get("forum", "containingpost", postIDParam, use: forumThreadFromPostPageHandler)
 
-		// Routes for non-shareable content. If you're not logged in we failscreen.
+		// Routes for non-shareable content.
 		let privateRoutes = getPrivateRoutes(app).grouped(DisabledSiteSectionMiddleware(feature: .forums))
 		privateRoutes.post("forumpost", postIDParam, "like", use: forumPostLikeActionHandler)
 		privateRoutes.post("forumpost", postIDParam, "laugh", use: forumPostLaughActionHandler)

--- a/Sources/App/Site/SiteFriendlyFezController.swift
+++ b/Sources/App/Site/SiteFriendlyFezController.swift
@@ -91,7 +91,7 @@ struct SiteFriendlyFezController: SiteControllerUtils {
 		globalRoutes.get(fezIDParam, use: singleFezPageHandler)
 		globalRoutes.get("faq", use: fezFAQHandler)
 
-		// Routes for non-shareable content. If you're not logged in we failscreen.
+		// Routes for non-shareable content.
 		let privateRoutes = getPrivateRoutes(app).grouped("fez").grouped(DisabledSiteSectionMiddleware(feature: .friendlyfez))
 		privateRoutes.get("create", use: fezCreatePageHandler)
 		privateRoutes.get(fezIDParam, "update", use: fezUpdatePageHandler)

--- a/Sources/App/Site/SiteLoginController.swift
+++ b/Sources/App/Site/SiteLoginController.swift
@@ -17,7 +17,7 @@ struct SiteLoginController: SiteControllerUtils {
 		openRoutes.post("recoverPassword", use: recoverPasswordPostHandler)		// Change pw while not logged in
 		openRoutes.get("codeOfConduct", use: codeOfConductViewHandler)
 				
-		// Routes for non-shareable content. If you're not logged in we failscreen.
+		// Routes for non-shareable content.
 		let privateRoutes = getPrivateRoutes(app)
 		privateRoutes.get("logout", use: loginPageViewHandler)
 		privateRoutes.post("logout", use: loginPageLogoutHandler)

--- a/Sources/App/Site/SiteModController.swift
+++ b/Sources/App/Site/SiteModController.swift
@@ -54,7 +54,7 @@ struct SiteModController: SiteControllerUtils {
 		modRoutes.get("moderate", "userprofile", userIDParam, use: moderateUserProfileContentPageHandler)
 		modRoutes.get("moderate", "user", userIDParam, use: moderateUserContentPageHandler)
 
-		// Routes for non-shareable content. If you're not logged in we failscreen.
+		// Routes for non-shareable content.
 		let modPrivateRoutes = getPrivateRoutes(app).grouped(SiteRequireModeratorMiddleware())
 		modPrivateRoutes.get("archivedimage", imageIDParam, use: archivedImageHandler)
 

--- a/Sources/App/Site/SiteSeamailController.swift
+++ b/Sources/App/Site/SiteSeamailController.swift
@@ -20,7 +20,7 @@ struct SiteSeamailController: SiteControllerUtils {
 		let globalRoutes = getGlobalRoutes(app).grouped(DisabledSiteSectionMiddleware(feature: .seamail))
 		globalRoutes.get("seamail", use: seamailRootPageHandler)
 
-		// Routes for non-shareable content. If you're not logged in we failscreen.
+		// Routes for non-shareable content.
 		let privateRoutes = getPrivateRoutes(app).grouped(DisabledSiteSectionMiddleware(feature: .seamail))
 		privateRoutes.get("seamail", "search", use: seamailSearchHandler)
 		privateRoutes.get("seamail", "create", use: seamailCreatePageHandler)

--- a/Sources/App/Site/SiteTwittarController.swift
+++ b/Sources/App/Site/SiteTwittarController.swift
@@ -170,7 +170,7 @@ struct SiteTwitarrController: SiteControllerUtils {
 		globalRoutes.get("tweets", use: tweetsPageHandler)
 		globalRoutes.get("tweets", twarrtIDParam, use: tweetReplyPageHandler)
 
-		// Routes for non-shareable content. If you're not logged in we failscreen.
+		// Routes for non-shareable content.
 		let privateRoutes = getPrivateRoutes(app).grouped(DisabledSiteSectionMiddleware(feature: .tweets))
 		privateRoutes.get("tweets", twarrtIDParam, "details", use: tweetGetDetailHandler)
 		privateRoutes.post("tweets", twarrtIDParam, "like", use: tweetLikeActionHandler)

--- a/Sources/App/Site/SiteUserController.swift
+++ b/Sources/App/Site/SiteUserController.swift
@@ -79,7 +79,7 @@ struct SiteUserController: SiteControllerUtils {
 		globalRoutes.get("username", ":username", use: usernameProfilePageHandler)
 		globalRoutes.get("profile", ":username", use: usernameProfilePageHandler)
 
-		// Routes for non-shareable content. If you're not logged in we failscreen.
+		// Routes for non-shareable content.
 		let privateRoutes = getPrivateRoutes(app).grouped(DisabledSiteSectionMiddleware(feature: .users))
 		privateRoutes.get("profile", use: selfProfilePageHandler)
 		privateRoutes.get("profile", "edit", use: selfProfileEditPageHandler)


### PR DESCRIPTION
When deep linking to "private" pages while not logged in, the site will give a hard error. We have the capability to redirect through the login page, which is a much better experience. This PR replaces the hard error with the login page redirect.

This is especially a problem with the android app's deep links to seamails originating from notifications. If for some reason the app gets logged out of the twitarr web UI, notifications will currently send the user to a hard error instead of a login prompt.

We still don't allow token auth to the "private" pages.