### PR TITLE
Fix issue with theme day of week calculations

### DIFF
--- a/Sources/swiftarr/Site/SiteAdminController.swift
+++ b/Sources/swiftarr/Site/SiteAdminController.swift
@@ -254,7 +254,7 @@ struct SiteAdminController: SiteControllerUtils {
 				let components = cal.dateComponents(
 					[.day],
 					from: cal.startOfDay(for: Settings.shared.cruiseStartDate()),
-					to: Date()
+					to: cal.startOfDay(for: Date())
 				)
 				currentCruiseDay = Int(components.day ?? 0)
 			}

--- a/Sources/swiftarr/Site/SiteController.swift
+++ b/Sources/swiftarr/Site/SiteController.swift
@@ -423,7 +423,7 @@ struct SiteController: SiteControllerUtils {
 		let components = cal.dateComponents(
 			[.day],
 			from: cal.startOfDay(for: Settings.shared.cruiseStartDate()),
-			to: Date()
+			to: cal.startOfDay(for: Date())
 		)
 		let cruiseDay = Int32(components.day ?? 0)
 		var backupTheme: DailyThemeData


### PR DESCRIPTION
I was trying to figure out why Tricordarr wasn't calculating the `cruiseDayIndex` the same way as Swiftarr, and after much swearing I realized that perhaps maybe Swiftarr is wrong. If a cruise starts "tomorrow" (which we define as midnight in the `portTimeZone` it is expected that "today's" `cruiseDayIndex` is `-1` (tomorrow is 0, etc). This was not the case since we were not anchoring the current date in the comparison calculation. A sample program using snippets from the various Swiftarr calculations revealed:

```
---
Start: 2024-03-09 05:00:00 +0000
Prior: Day -64 Hour -10 Minute -14
  New: Day -65 Hour 0 Minute 0
---
---
Start: 2024-01-03 05:00:00 +0000
Prior: Day 1 Hour 13 Minute 45
  New: Day 1 Hour 0 Minute 0
---
---
Start: 2024-01-04 05:00:00 +0000
Prior: Day 0 Hour 13 Minute 45
  New: Day 0 Hour 0 Minute 0
---
---
Start: 2024-01-05 05:00:00 +0000
Prior: Day 0 Hour -10 Minute -14
  New: Day -1 Hour 0 Minute 0
---
```

Since we only look at the `.day` component of `dateComponents` the number of full days on the day before the cruise can be 0, which is inaccurate. By also using `cal.startOfDay` for the comparison we lock the comparison to midnight to ensure that the correct index comes back.