### PR TITLE
Upcoming Event/LFG Notifications

### DIFF
--- a/Sources/swiftarr/Controllers/AdminController.swift
+++ b/Sources/swiftarr/Controllers/AdminController.swift
@@ -180,6 +180,9 @@ struct AdminController: APIRouteCollection {
 		if let value = data.scheduleUpdateURL {
 			Settings.shared.scheduleUpdateURL = value
 		}
+		if let value = data.upcomingEventNotificationSeconds {
+			Settings.shared.upcomingEventNotificationSeconds = Double(value)
+		}
 		var localDisables = Settings.shared.disabledFeatures.value
 		for pair in data.enableFeatures {
 			if let app = SwiftarrClientApp(rawValue: pair.app), let feature = SwiftarrFeature(rawValue: pair.feature) {

--- a/Sources/swiftarr/Controllers/AdminController.swift
+++ b/Sources/swiftarr/Controllers/AdminController.swift
@@ -183,6 +183,12 @@ struct AdminController: APIRouteCollection {
 		if let value = data.upcomingEventNotificationSeconds {
 			Settings.shared.upcomingEventNotificationSeconds = Double(value)
 		}
+		if let value = data.upcomingEventNotificationSetting {
+			Settings.shared.upcomingEventNotificationSetting = value
+		}
+		if let value = data.upcomingLFGNotificationSetting {
+			Settings.shared.upcomingLFGNotificationSetting = value
+		}
 		var localDisables = Settings.shared.disabledFeatures.value
 		for pair in data.enableFeatures {
 			if let app = SwiftarrClientApp(rawValue: pair.app), let feature = SwiftarrFeature(rawValue: pair.feature) {

--- a/Sources/swiftarr/Controllers/AlertController.swift
+++ b/Sources/swiftarr/Controllers/AlertController.swift
@@ -103,7 +103,7 @@ struct AlertController: APIRouteCollection {
 		var nextLFG = try await req.redis.getNextLFGFromUserHash(userHash)
 		if let validDate = nextLFG?.0, Date() > validDate {
 			// The previously cached LFG already happend; figure out what's next
-			nextLFG = try await storeNextFollowedEvent(userID: user.userID, on: req)
+			nextLFG = try await storeNextJoinedLFG(userID: user.userID, on: req)
 		}
 		var result = try await UserNotificationData(
 			newFezCount: unreadLFGCount,

--- a/Sources/swiftarr/Controllers/Structs/AdminControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/AdminControllerStructs.swift
@@ -148,6 +148,7 @@ public struct SettingsAdminData: Content {
 	var disabledFeatures: [SettingsAppFeaturePair]
 	var shipWifiSSID: String?
 	var scheduleUpdateURL: String
+	var upcomingEventNotificationSeconds: Int
 }
 
 extension SettingsAdminData {
@@ -169,6 +170,7 @@ extension SettingsAdminData {
 		}
 		self.shipWifiSSID = settings.shipWifiSSID
 		self.scheduleUpdateURL = settings.scheduleUpdateURL
+		self.upcomingEventNotificationSeconds = Int(settings.upcomingEventNotificationSeconds)
 	}
 }
 
@@ -197,6 +199,8 @@ public struct SettingsUpdateData: Content {
 	var shipWifiSSID: String?
 	/// The URL to use for automated schedule updates. The server polls this every hour to update the Events table.
 	var scheduleUpdateURL: String?
+	/// Number of seconds before an event to trigger the Soon notifications.
+	var upcomingEventNotificationSeconds: Int?
 }
 
 /// Used to return information about the time zone changes scheduled to occur during the cruise.

--- a/Sources/swiftarr/Controllers/Structs/AdminControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/AdminControllerStructs.swift
@@ -149,6 +149,8 @@ public struct SettingsAdminData: Content {
 	var shipWifiSSID: String?
 	var scheduleUpdateURL: String
 	var upcomingEventNotificationSeconds: Int
+	var upcomingEventNotificationSetting: EventNotificationSetting
+	var upcomingLFGNotificationSetting: EventNotificationSetting
 }
 
 extension SettingsAdminData {
@@ -171,6 +173,8 @@ extension SettingsAdminData {
 		self.shipWifiSSID = settings.shipWifiSSID
 		self.scheduleUpdateURL = settings.scheduleUpdateURL
 		self.upcomingEventNotificationSeconds = Int(settings.upcomingEventNotificationSeconds)
+		self.upcomingEventNotificationSetting = settings.upcomingEventNotificationSetting
+		self.upcomingLFGNotificationSetting = settings.upcomingLFGNotificationSetting
 	}
 }
 
@@ -201,6 +205,10 @@ public struct SettingsUpdateData: Content {
 	var scheduleUpdateURL: String?
 	/// Number of seconds before an event to trigger the Soon notifications.
 	var upcomingEventNotificationSeconds: Int?
+	/// Upcoming event notification setting
+	var upcomingEventNotificationSetting: EventNotificationSetting?
+	/// Upcoming joined LFG notification setting
+	var upcomingLFGNotificationSetting: EventNotificationSetting?
 }
 
 /// Used to return information about the time zone changes scheduled to occur during the cruise.

--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -1552,6 +1552,13 @@ public struct UserNotificationData: Content {
 	/// If the user has favorited multiple events that start at the same time, this will be random among them.
 	var nextFollowedEventID: UUID?
 
+	/// The start time of the earliest LFG that the user has joined with a start time > now. nil if not logged in or no matching LFG.
+	var nextJoinedLFGTime: Date?
+
+	/// The LFG ID of the the next future LFG the user has joined. This LFGs's start time should always be == nextJoinedLFGTime.
+	/// If the user has joined multiple LFGs that start at the same time, this will be random among them.
+	var nextJoinedLFG: UUID?
+
 	/// For each alertword the user has, this returns data on hit counts for that word.
 	var alertWords: [UserNotificationAlertwordData]
 
@@ -1588,7 +1595,9 @@ extension UserNotificationData {
 		activeAnnouncementIDs: [Int],
 		newAnnouncementCount: Int,
 		nextEventTime: Date?,
-		nextEvent: UUID?
+		nextEvent: UUID?,
+		nextLFGTime: Date?,
+		nextLFG: UUID?
 	) {
 		serverTime = ISO8601DateFormatter().string(from: Date())
 		serverTimeOffset = Settings.shared.timeZoneChanges.tzAtTime().secondsFromGMT(for: Date())
@@ -1606,6 +1615,8 @@ extension UserNotificationData {
 		self.nextFollowedEventTime = nextEventTime
 		self.nextFollowedEventID = nextEvent
 		self.alertWords = []
+		self.nextJoinedLFG = nextLFG
+		self.nextJoinedLFGTime = nextLFGTime
 	}
 
 	// Initializes an dummy struct, for when there's no user logged in.
@@ -1625,6 +1636,7 @@ extension UserNotificationData {
 		self.newFezMessageCount = 0
 		self.nextFollowedEventTime = nil
 		self.alertWords = []
+		self.nextJoinedLFGTime = nil
 	}
 }
 

--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -1557,7 +1557,7 @@ public struct UserNotificationData: Content {
 
 	/// The LFG ID of the the next future LFG the user has joined. This LFGs's start time should always be == nextJoinedLFGTime.
 	/// If the user has joined multiple LFGs that start at the same time, this will be random among them.
-	var nextJoinedLFG: UUID?
+	var nextJoinedLFGID: UUID?
 
 	/// For each alertword the user has, this returns data on hit counts for that word.
 	var alertWords: [UserNotificationAlertwordData]
@@ -1615,7 +1615,7 @@ extension UserNotificationData {
 		self.nextFollowedEventTime = nextEventTime
 		self.nextFollowedEventID = nextEvent
 		self.alertWords = []
-		self.nextJoinedLFG = nextLFG
+		self.nextJoinedLFGID = nextLFG
 		self.nextJoinedLFGTime = nextLFGTime
 	}
 

--- a/Sources/swiftarr/Controllers/Structs/SocketStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/SocketStructs.swift
@@ -89,8 +89,7 @@ struct SocketNotificationData: Content {
 		case twarrtMention
 		/// A user has posted a Forum Post that @mentions this user.
 		case forumMention
-		/// An event the user is following is about to start. NOT CURRENTLY IMPLEMENTED. Plan is to add support for this as a bulk process that runs every 30 mins
-		/// at :25 and :55, giving all users following an event about to start a notification 5 mins before the event start time.
+		/// An event the user is following is about to start.
 		case followedEventStarting
 		/// Someone is trying to call this user via KrakenTalk.
 		case incomingPhoneCall
@@ -128,6 +127,7 @@ extension SocketNotificationData {
 		case .nextFollowedEventTime: self.type = .followedEventStarting
 		case .moderatorForumMention: self.type = .moderatorForumMention
 		case .twitarrTeamForumMention: self.type = .twitarrTeamForumMention
+		case .followedEventStarting: self.type = .followedEventStarting
 		}
 		self.info = info
 		self.contentID = id

--- a/Sources/swiftarr/Controllers/Structs/SocketStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/SocketStructs.swift
@@ -101,6 +101,8 @@ struct SocketNotificationData: Content {
 		case moderatorForumMention
 		/// A new or edited forum post that now @mentions @twitarrteam.
 		case twitarrTeamForumMention
+		/// An LFG the user has joined is about to start.
+		case joinedLFGStarting
 	}
 	/// The type of event that happened. See `SocketNotificationData.NotificationTypeData` for values.
 	var type: NotificationTypeData
@@ -124,10 +126,13 @@ extension SocketNotificationData {
 		case .alertwordPost: self.type = .alertwordPost
 		case .twarrtMention: self.type = .twarrtMention
 		case .forumMention: self.type = .forumMention
-		case .nextFollowedEventTime: self.type = .followedEventStarting
 		case .moderatorForumMention: self.type = .moderatorForumMention
 		case .twitarrTeamForumMention: self.type = .twitarrTeamForumMention
+		// nextFollowedEventTime and nextJoinedLFGTime are not a socket event, so is this OK?
+		case .nextFollowedEventTime: self.type = .followedEventStarting
 		case .followedEventStarting: self.type = .followedEventStarting
+		case .nextJoinedLFGTime: self.type = .joinedLFGStarting
+		case .joinedLFGStarting: self.type = .joinedLFGStarting
 		}
 		self.info = info
 		self.contentID = id

--- a/Sources/swiftarr/Enumerations/EventNotificationSetting.swift
+++ b/Sources/swiftarr/Enumerations/EventNotificationSetting.swift
@@ -1,0 +1,23 @@
+import RediStack
+
+// Different settings for event and LFG notifications. Since this is used as a StoredSettingValue
+// this enum has to be Redis-able.
+public enum EventNotificationSetting: String, Codable, RESPValueConvertible {
+    public init?(fromRESP value: RediStack.RESPValue) {
+        guard let stringValue = value.string else {
+            return nil
+        }
+        self.init(rawValue: stringValue)
+    }
+
+    public func convertedToRESPValue() -> RediStack.RESPValue {
+        return .init(from: rawValue)
+    }
+
+	/// Notifications should be disabled.
+	case disabled = "disabled"
+	/// Pretend that we are at this time but during the cruise week.
+	case cruiseWeek = "cruiseWeek"
+	/// The current actual real time and date.
+	case current = "current"
+}

--- a/Sources/swiftarr/Enumerations/NotificationType.swift
+++ b/Sources/swiftarr/Enumerations/NotificationType.swift
@@ -56,6 +56,8 @@ enum NotificationType {
 	case twitarrTeamForumMention(Int)
 	/// An upcoming event that the user has followed.
 	case nextFollowedEventTime(Date?, UUID?)
+	/// An event the user is following is about to start.
+	case followedEventStarting(UUID)
 
 	/// Returns the hash field name used to store info about this notification type in Redis.
 	func redisFieldName() -> String {
@@ -70,6 +72,7 @@ enum NotificationType {
 		case .moderatorForumMention: return "moderatorForumMention"
 		case .twitarrTeamForumMention: return "twitarrTeamForumMention"
 		case .nextFollowedEventTime: return "nextFollowedEventTime"
+		case .followedEventStarting: return "followedEventStarting"
 		}
 	}
 
@@ -91,6 +94,7 @@ enum NotificationType {
 		case .moderatorForumMention: return "NotificationHash-\(userID)"
 		case .twitarrTeamForumMention: return "NotificationHash-\(userID)"
 		case .nextFollowedEventTime: return "NotificationHash-\(userID)"
+		case .followedEventStarting:  return "NotificationHash-\(userID)"
 		}
 	}
 
@@ -118,6 +122,7 @@ enum NotificationType {
 		case .moderatorForumMention(let id): return String(id)
 		case .twitarrTeamForumMention(let id): return String(id)
 		case .nextFollowedEventTime(_, let uuid): return uuid != nil ? String(uuid!) : ""
+		case .followedEventStarting(let id): return String(id)
 		}
 	}
 }

--- a/Sources/swiftarr/Enumerations/NotificationType.swift
+++ b/Sources/swiftarr/Enumerations/NotificationType.swift
@@ -58,6 +58,10 @@ enum NotificationType {
 	case nextFollowedEventTime(Date?, UUID?)
 	/// An event the user is following is about to start.
 	case followedEventStarting(UUID)
+	/// An upcoming LFG that the user has joined.
+	case nextJoinedLFGTime(Date?, UUID?)
+	/// An LFG the user is joined is about to start.
+	case joinedLFGStarting(UUID)
 
 	/// Returns the hash field name used to store info about this notification type in Redis.
 	func redisFieldName() -> String {
@@ -73,6 +77,8 @@ enum NotificationType {
 		case .twitarrTeamForumMention: return "twitarrTeamForumMention"
 		case .nextFollowedEventTime: return "nextFollowedEventTime"
 		case .followedEventStarting: return "followedEventStarting"
+		case .nextJoinedLFGTime: return "nextJoinedLFGTime"
+		case .joinedLFGStarting: return "joinedLFGStarting"
 		}
 	}
 
@@ -94,7 +100,9 @@ enum NotificationType {
 		case .moderatorForumMention: return "NotificationHash-\(userID)"
 		case .twitarrTeamForumMention: return "NotificationHash-\(userID)"
 		case .nextFollowedEventTime: return "NotificationHash-\(userID)"
-		case .followedEventStarting:  return "NotificationHash-\(userID)"
+		case .followedEventStarting: return "NotificationHash-\(userID)"
+		case .nextJoinedLFGTime: return "NotificationHash-\(userID)"
+		case .joinedLFGStarting: return "NotificationHash-\(userID)"
 		}
 	}
 
@@ -123,6 +131,8 @@ enum NotificationType {
 		case .twitarrTeamForumMention(let id): return String(id)
 		case .nextFollowedEventTime(_, let uuid): return uuid != nil ? String(uuid!) : ""
 		case .followedEventStarting(let id): return String(id)
+		case .nextJoinedLFGTime(_, let uuid): return uuid != nil ? String(uuid!) : ""
+		case .joinedLFGStarting(let id): return String(id)
 		}
 	}
 }

--- a/Sources/swiftarr/Helpers/Settings.swift
+++ b/Sources/swiftarr/Helpers/Settings.swift
@@ -124,6 +124,7 @@ final class Settings: Encodable {
 
 	/// Number of seconds before an event starts to consider it happening "soon".
 	/// The default value means 15 minutes before an event starts notifications/banners will start.
+	/// @TODO Make this a StoredSetting so it can be dynamically adjusted
 	@SettingsValue var upcomingEventFutureSeconds: Double = 15 * 60.0
 
 	/// Number of seconds after an upcoming event starts to no longer consider it happening.

--- a/Sources/swiftarr/Helpers/Settings.swift
+++ b/Sources/swiftarr/Helpers/Settings.swift
@@ -122,10 +122,13 @@ final class Settings: Encodable {
 	/// Struct representing a set of TimeZoneChange's for this cruise. This setting can then be referenced elsewhere in the application.
 	@SettingsValue var timeZoneChanges: TimeZoneChangeSet = TimeZoneChangeSet()
 
-	/// Number of seconds before an event starts to consider it happening "soon".
-	/// The default value means 15 minutes before an event starts notifications/banners will start.
-	/// @TODO Make this a StoredSetting so it can be dynamically adjusted
-	@SettingsValue var upcomingEventFutureSeconds: Double = 15 * 60.0
+	/// Number of minutes before an event to trigger notifications. Some day this should be set per-user
+	/// based on their preferences. But since we don't have the concept of "User Settings" yet we set
+	/// a sane default instead. This is a StoredSettingsValue so that it can be modified in real time.
+	/// This is a Double because that's what most range comparison operations desire. Though it does make this
+	/// a bit more complex on the Server Settings views and [Site]AdminController because we expose them as Ints
+	/// to the UI. This is to prevent anyone from using truly whacky values.
+	@StoredSettingsValue("upcomingEventNotificationSeconds", defaultValue: 10 * 60.0) var upcomingEventNotificationSeconds: Double
 
 	/// Number of seconds after an upcoming event starts to no longer consider it happening.
 	/// The desired default value means 5 minutes after an event starts notifications/banners will stop.

--- a/Sources/swiftarr/Helpers/Settings.swift
+++ b/Sources/swiftarr/Helpers/Settings.swift
@@ -221,6 +221,7 @@ extension Settings {
 	// This takes it a step further and pretends based on the time rather than just a weekday.
 	func getDateInCruiseWeek() -> Date {
 		// @TODO Ensure this honors or passes sanity check for portTimeZone or something like that.
+		// It's probably OK, but we should be sure.
 		let secondsPerWeek = 60 * 60 * 24 * 7
 		let partialWeek = Int(Date().timeIntervalSince(Settings.shared.cruiseStartDate())) % secondsPerWeek
 		return Settings.shared.cruiseStartDate() + TimeInterval(partialWeek)

--- a/Sources/swiftarr/Helpers/WebSocketStorage.swift
+++ b/Sources/swiftarr/Helpers/WebSocketStorage.swift
@@ -53,9 +53,10 @@ extension Application {
 			return cacheResult
 		}
 
-		// @TODO dedup this with APIRouteCollection.swift
+		// Send a message to all involved users with open websockets.
+		// This logic used to be in APIRouteCollection.swift. But with the introduction of the
+		// UserEventNotificationJob we needed this function in a non-Request context.
 		func forwardToSockets(users: [UUID], type: NotificationType, info: String) -> Void {
-			// Send a message to all involved users with open websockets.
 			let socketeers = app.websocketStorage.getSockets(users)
 			if socketeers.count > 0 {
 				app.logger.log(level: .info, "Socket: Sending \(type) msg to \(socketeers.count) client.")

--- a/Sources/swiftarr/Jobs/EventJobs.swift
+++ b/Sources/swiftarr/Jobs/EventJobs.swift
@@ -106,7 +106,7 @@ public struct UserEventNotificationJob: AsyncScheduledJob {
         for event in upcomingEvents {
             let eventID = try event.requireID()
             let favoriteUserIDs = try event.favorites.map { try $0.requireID() }
-            context.application.websocketStorage.forwardToSockets(users: favoriteUserIDs, type: .followedEventStarting(eventID), info: "Event Starting")
+            context.application.websocketStorage.forwardToSockets(users: favoriteUserIDs, type: .followedEventStarting(eventID), info: "Event starting soon: \(event.title)")
         }
 	}
 }

--- a/Sources/swiftarr/Jobs/EventJobs.swift
+++ b/Sources/swiftarr/Jobs/EventJobs.swift
@@ -106,7 +106,8 @@ public struct UserEventNotificationJob: AsyncScheduledJob {
         for event in upcomingEvents {
             let eventID = try event.requireID()
             let favoriteUserIDs = try event.favorites.map { try $0.requireID() }
-            context.application.websocketStorage.forwardToSockets(users: favoriteUserIDs, type: .followedEventStarting(eventID), info: "Event starting soon: \(event.title)")
+			let infoStr = "\(event.title) is starting Soon™ in \(event.location)."
+            context.application.websocketStorage.forwardToSockets(users: favoriteUserIDs, type: .followedEventStarting(eventID), info: infoStr)
         }
 	}
 }

--- a/Sources/swiftarr/Jobs/EventJobs.swift
+++ b/Sources/swiftarr/Jobs/EventJobs.swift
@@ -1,5 +1,6 @@
 import Queues
 import Vapor
+import Fluent
 
 /// AsyncJobs require a payload, and apparently we can't just shove Codable at it.
 /// So this struct exists in case the job ever decides to need runtime parameters.
@@ -8,62 +9,106 @@ public struct EmptyJobPayload: Codable {}
 /// Base class for the Sched schedule update job. This is common between the AsyncScheduledJob
 /// and AsyncJob.
 class UpdateScheduleJobBase {
-    static func execute(context: QueueContext) async throws {
-        do {
-            context.logger.notice("Starting UpdateScheduleJob")
-            let scheduleURLString = Settings.shared.scheduleUpdateURL
-            guard !scheduleURLString.isEmpty else {
-                throw Abort(.internalServerError, reason: "Schedule Updater ran, but the URL is empty, so we're bailing.")
-            }
-            let scheduleURL = URI(string: Settings.shared.scheduleUpdateURL)
-            let userAgent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-            let response = try await context.application.client.get(scheduleURL, headers: [ "User-Agent" : userAgent])
-            guard response.status == .ok else {
-                throw Abort(.internalServerError, reason: "Failed to GET schedule data from \(String(reflecting: scheduleURL)) got response \(response.status.code)")
-            }
-            guard let fileLen = response.body?.readableBytes, let scheduleFileStr = response.body?.getString(at: 0, length: fileLen) else {
-                throw Abort(.badRequest, reason: "Could not read schedule data.")
-            }
-            // Parse and validate, throw if >50 events deleted (require manual in this case)
-            let differences = try await EventParser().validateEventsInICS(scheduleFileStr, on: context.application.db)
-            if differences.deletedEvents.count > 50 {
-                throw Abort(.badRequest, reason: "This update deletes more than 50 events and should be done manually, not via automatic updating.")
-            }
-            if differences.deletedEvents.isEmpty && differences.createdEvents.isEmpty && differences.timeChangeEvents.isEmpty &&
-                    differences.locationChangeEvents.isEmpty && differences.minorChangeEvents.isEmpty {
-                // Log that no change was needed
-                try await ScheduleLog(diff: nil, isAutomatic: true).save(on: context.application.db)
-                context.logger.notice("UpdateScheduleJob completed successfully. Source schedule hasn't changed, no updates to apply.")
-            }
-            else {
-                // Apply changes to db, log what happened
-                guard let forumAuthor = context.application.getUserHeader("admin") else {
-                    throw Abort(.internalServerError, reason: "Could not find admin user when running schedule updater.")
-                }
-                try await EventParser().updateDatabaseFromICS(scheduleFileStr, on: context.application.db, forumAuthor: forumAuthor)
-                try await ScheduleLog(diff: differences, isAutomatic: true).save(on: context.application.db)
-                context.logger.notice("UpdateScheduleJob completed successfully--there were updates to apply.")
-            }
-        }
-        catch {
-            context.logger.notice("UpdateScheduleJob failed. \(String(reflecting: error))")
-            try await ScheduleLog(error: error).save(on: context.application.db)
-        }
-    }
+	static func execute(context: QueueContext) async throws {
+		do {
+			context.logger.notice("Starting UpdateScheduleJob")
+			let scheduleURLString = Settings.shared.scheduleUpdateURL
+			guard !scheduleURLString.isEmpty else {
+				throw Abort(
+					.internalServerError,
+					reason: "Schedule Updater ran, but the URL is empty, so we're bailing."
+				)
+			}
+			let scheduleURL = URI(string: Settings.shared.scheduleUpdateURL)
+			let userAgent =
+				"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+			let response = try await context.application.client.get(scheduleURL, headers: ["User-Agent": userAgent])
+			guard response.status == .ok else {
+				throw Abort(
+					.internalServerError,
+					reason:
+						"Failed to GET schedule data from \(String(reflecting: scheduleURL)) got response \(response.status.code)"
+				)
+			}
+			guard let fileLen = response.body?.readableBytes,
+				let scheduleFileStr = response.body?.getString(at: 0, length: fileLen)
+			else {
+				throw Abort(.badRequest, reason: "Could not read schedule data.")
+			}
+			// Parse and validate, throw if >50 events deleted (require manual in this case)
+			let differences = try await EventParser().validateEventsInICS(scheduleFileStr, on: context.application.db)
+			if differences.deletedEvents.count > 50 {
+				throw Abort(
+					.badRequest,
+					reason:
+						"This update deletes more than 50 events and should be done manually, not via automatic updating."
+				)
+			}
+			if differences.deletedEvents.isEmpty && differences.createdEvents.isEmpty
+				&& differences.timeChangeEvents.isEmpty && differences.locationChangeEvents.isEmpty
+				&& differences.minorChangeEvents.isEmpty
+			{
+				// Log that no change was needed
+				try await ScheduleLog(diff: nil, isAutomatic: true).save(on: context.application.db)
+				context.logger.notice(
+					"UpdateScheduleJob completed successfully. Source schedule hasn't changed, no updates to apply."
+				)
+			}
+			else {
+				// Apply changes to db, log what happened
+				guard let forumAuthor = context.application.getUserHeader("admin") else {
+					throw Abort(
+						.internalServerError,
+						reason: "Could not find admin user when running schedule updater."
+					)
+				}
+				try await EventParser()
+					.updateDatabaseFromICS(scheduleFileStr, on: context.application.db, forumAuthor: forumAuthor)
+				try await ScheduleLog(diff: differences, isAutomatic: true).save(on: context.application.db)
+				context.logger.notice("UpdateScheduleJob completed successfully--there were updates to apply.")
+			}
+		}
+		catch {
+			context.logger.notice("UpdateScheduleJob failed. \(String(reflecting: error))")
+			try await ScheduleLog(error: error).save(on: context.application.db)
+		}
+	}
 }
 
 /// Job to update the Sched schedule on a "cron" (and by "cron" I mean Vapor Queue).
 public struct UpdateScheduleJob: AsyncScheduledJob {
-    public func run(context: QueueContext) async throws {
-        try await UpdateScheduleJobBase.execute(context: context)
-    }
+	public func run(context: QueueContext) async throws {
+		try await UpdateScheduleJobBase.execute(context: context)
+	}
 }
 
 /// Job to update the Sched schedule on demand.
 public struct UpdateJob: AsyncJob {
-    public typealias Payload = EmptyJobPayload
+	public typealias Payload = EmptyJobPayload
 
-    public func dequeue(_ context: QueueContext,  _ payload: EmptyJobPayload) async throws {
-        try await UpdateScheduleJobBase.execute(context: context)
-    }
+	public func dequeue(_ context: QueueContext, _ payload: EmptyJobPayload) async throws {
+		try await UpdateScheduleJobBase.execute(context: context)
+	}
+}
+
+/// Job to push socket notifications of an upcoming event on a "cron" (and by "cron" I mean Vapor Queue).
+public struct UserEventNotificationJob: AsyncScheduledJob {
+	public func run(context: QueueContext) async throws {
+		context.logger.info("Running Notification Job")
+        // Events are managed in the Port Time Zone
+        let portCalendar = Settings.shared.getPortCalendar()
+        let filterStartTime = portCalendar.date(byAdding: .second, value: Int(Settings.shared.upcomingEventFutureSeconds), to: Settings.shared.getDateInCruiseWeek())!
+
+		let upcomingEvents = try await Event.query(on: context.application.db)
+            .with(\.$favorites)
+            .filter(\.$startTime == filterStartTime)
+            .all()
+        for event in upcomingEvents {
+            print("Event:", event.title)
+            for favorite in event.favorites {
+                print("User:", favorite.username)
+            }
+            // try await addNotifications()
+        }
+	}
 }

--- a/Sources/swiftarr/Jobs/EventJobs.swift
+++ b/Sources/swiftarr/Jobs/EventJobs.swift
@@ -104,11 +104,9 @@ public struct UserEventNotificationJob: AsyncScheduledJob {
             .filter(\.$startTime == filterStartTime)
             .all()
         for event in upcomingEvents {
-            print("Event:", event.title)
-            for favorite in event.favorites {
-                print("User:", favorite.username)
-            }
-            // try await addNotifications()
+            let eventID = try event.requireID()
+            let favoriteUserIDs = try event.favorites.map { try $0.requireID() }
+            context.application.websocketStorage.forwardToSockets(users: favoriteUserIDs, type: .followedEventStarting(eventID), info: "Event Starting")
         }
 	}
 }

--- a/Sources/swiftarr/Jobs/EventJobs.swift
+++ b/Sources/swiftarr/Jobs/EventJobs.swift
@@ -94,15 +94,16 @@ public struct UpdateJob: AsyncJob {
 /// Job to push socket notifications of an upcoming event on a "cron" (and by "cron" I mean Vapor Queue).
 public struct UserEventNotificationJob: AsyncScheduledJob {
 	public func run(context: QueueContext) async throws {
-		context.logger.info("Running Notification Job")
+		context.logger.info("Running UserEventNotificationJob")
         // Events are managed in the Port Time Zone
         let portCalendar = Settings.shared.getPortCalendar()
-        let filterStartTime = portCalendar.date(byAdding: .second, value: Int(Settings.shared.upcomingEventFutureSeconds), to: Settings.shared.getDateInCruiseWeek())!
+        let filterStartTime = portCalendar.date(byAdding: .second, value: Int(Settings.shared.upcomingEventNotificationSeconds), to: Settings.shared.getDateInCruiseWeek())!
 
 		let upcomingEvents = try await Event.query(on: context.application.db)
             .with(\.$favorites)
             .filter(\.$startTime == filterStartTime)
             .all()
+
         for event in upcomingEvents {
             let eventID = try event.requireID()
             let favoriteUserIDs = try event.favorites.map { try $0.requireID() }

--- a/Sources/swiftarr/Models/Event.swift
+++ b/Sources/swiftarr/Models/Event.swift
@@ -51,7 +51,7 @@ final class Event: Model, Searchable {
 	/// so the forum can keep existing even if the event is deleted.
 	@OptionalParent(key: "forum_id") var forum: Forum?
 
-	/// The users that have favorited this game.
+	/// The users that have favorited this event.
 	@Siblings(through: EventFavorite.self, from: \.$event, to: \.$user) var favorites: [User]
 
 	// MARK: Initialization

--- a/Sources/swiftarr/Protocols/APIRouteCollection.swift
+++ b/Sources/swiftarr/Protocols/APIRouteCollection.swift
@@ -181,6 +181,8 @@ extension APIRouteCollection {
 				for userID in users {
 					group.addTask { try await req.redis.incrementIntInUserHash(field: type, userID: userID) }
 				}
+			case .followedEventStarting(_):
+				break
 			}
 
 			if forwardToSockets {
@@ -328,7 +330,7 @@ extension APIRouteCollection {
 						try await req.redis.deletedUnreadMessage(msgID: msgID, userID: userID, inbox: .lfgMessages)
 					}
 				}
-			case .nextFollowedEventTime(_, _):
+			case .nextFollowedEventTime(_, _), .followedEventStarting(_):
 				break
 			}
 			group.addTask { try await req.redis.addUsersWithStateChange(users) }
@@ -374,7 +376,7 @@ extension APIRouteCollection {
 			}
 		case .fezUnreadMsg:
 			try await req.redis.markSeamailRead(type: type, in: .lfgMessages, userID: user.userID)
-		case .nextFollowedEventTime:
+		case .nextFollowedEventTime, .followedEventStarting:
 			return  // Can't be cleared
 		}
 		try await req.redis.addUsersWithStateChange([user.userID])

--- a/Sources/swiftarr/Protocols/APIRouteCollection.swift
+++ b/Sources/swiftarr/Protocols/APIRouteCollection.swift
@@ -411,13 +411,16 @@ extension APIRouteCollection {
 			.join(EventFavorite.self, on: \Event.$id == \EventFavorite.$event.$id)
 			.filter(EventFavorite.self, \.$user.$id == userID)
 			.first()
+		// This will "clear" the next Event values of the UserNotificationData if no Events match the
+		// query (which is to say there is no next Event). Thought about using subtractNotifications()
+		// but this just seems easier for now.
+		try await addNotifications(
+			users: [userID],
+			type: .nextFollowedEventTime(nextFavoriteEvent?.startTime, nextFavoriteEvent?.id),
+			info: "",
+			on: req
+		)
 		if let event = nextFavoriteEvent, let id = event.id {
-			try await addNotifications(
-				users: [userID],
-				type: .nextFollowedEventTime(event.startTime, id),
-				info: "",
-				on: req
-			)
 			return (event.startTime, id)
 		}
 		return nil

--- a/Sources/swiftarr/Protocols/APIRouteCollection.swift
+++ b/Sources/swiftarr/Protocols/APIRouteCollection.swift
@@ -187,18 +187,7 @@ extension APIRouteCollection {
 
 			if forwardToSockets {
 				// Send a message to all involved users with open websockets.
-				let socketeers = req.webSocketStore.getSockets(users)
-				if socketeers.count > 0 {
-					req.logger.log(level: .info, "Socket: Sending \(type) msg to \(socketeers.count) client.")
-					let msgStruct = SocketNotificationData(type, info: info, id: type.objectID())
-					if let jsonData = try? JSONEncoder().encode(msgStruct),
-						let jsonDataStr = String(data: jsonData, encoding: .utf8)
-					{
-						socketeers.forEach { userSocket in
-							userSocket.socket.send(jsonDataStr)
-						}
-					}
-				}
+				app.websocketStorage.forwardToSockets(users: users, type: type, info: info)
 			}
 
 			let notifyUsersCopy = notifyUsers

--- a/Sources/swiftarr/Resources/Views/admin/serversettings.html
+++ b/Sources/swiftarr/Resources/Views/admin/serversettings.html
@@ -67,6 +67,12 @@
 				</div>
 				<div class="row my-1">
 					<div class="col">
+						<label for="upcomingEventNotificationSeconds">Seconds before upcoming event to trigger notification</label>
+						<input type="number" id="upcomingEventNotificationSeconds" name="upcomingEventNotificationSeconds" min="0" max="1800" value="#(settings.upcomingEventNotificationSeconds)" #if(!enableFields):disabled#endif>
+					</div>
+				</div>
+				<div class="row my-1">
+					<div class="col">
 						<label for="shipWifiSSID">Onboard Wifi Network SSID</label>
 						<input type="text" class="form-control" id="shipWifiSSID" name="shipWifiSSID" value="#(settings.shipWifiSSID)" #if(!enableFields):disabled#endif>
 					</div>

--- a/Sources/swiftarr/Resources/Views/admin/serversettings.html
+++ b/Sources/swiftarr/Resources/Views/admin/serversettings.html
@@ -67,8 +67,35 @@
 				</div>
 				<div class="row my-1">
 					<div class="col">
-						<label for="upcomingEventNotificationSeconds">Seconds before upcoming event to trigger notification</label>
+						<label for="upcomingEventNotificationSeconds">Upcoming event/LFG notification offset (seconds)</label>
 						<input type="number" id="upcomingEventNotificationSeconds" name="upcomingEventNotificationSeconds" min="0" max="1800" value="#(settings.upcomingEventNotificationSeconds)" #if(!enableFields):disabled#endif>
+					</div>
+				</div>
+				<div class="row my-1">
+					
+				</div>
+				<div class="row my-2">
+					<div class="col col-auto">
+						<label for="upcomingEventNotificationSetting">Upcoming event notifications</label>
+					</div>
+					<div class="col col-auto">
+						<select class="form-select" name="upcomingEventNotificationSetting" #if(!enableFields):disabled#endif>
+							<option #if(settings.upcomingEventNotificationSetting == "disabled"):selected#endif value="disabled">Disabled (no notifications)</option>
+							<option #if(settings.upcomingEventNotificationSetting == "cruiseWeek"):selected#endif value="cruiseWeek">Cruise Week (time travel)</option>
+							<option #if(settings.upcomingEventNotificationSetting == "current"):selected#endif value="current">Current (real-time date)</option>
+						</select
+					</div>
+				</div>
+				<div class="row my-2">
+					<div class="col col-auto">
+						<label for="upcomingLFGNotificationSetting">Upcoming joined LFG notifications</label>
+					</div>
+					<div class="col col-auto">
+						<select class="form-select" name="upcomingLFGNotificationSetting" #if(!enableFields):disabled#endif>
+							<option #if(settings.upcomingLFGNotificationSetting == "disabled"):selected#endif value="disabled">Disabled (no notifications)</option>
+							<option #if(settings.upcomingLFGNotificationSetting == "cruiseWeek"):selected#endif value="cruiseWeek">Cruise Week (time travel)</option>
+							<option #if(settings.upcomingLFGNotificationSetting == "current"):selected#endif value="current">Current (real-time date)</option>
+						</select
 					</div>
 				</div>
 				<div class="row my-1">

--- a/Sources/swiftarr/Site/SiteAdminController.swift
+++ b/Sources/swiftarr/Site/SiteAdminController.swift
@@ -396,6 +396,7 @@ struct SiteAdminController: SiteControllerUtils {
 			var allowAnimatedImages: String?
 			var disableAppName: String
 			var disableFeatureName: String
+			var upcomingEventNotificationSeconds: Int
 			// In the .leaf file, the name property for the select that sets this is "reenable[]".
 			// The "[]" in the name is magic, somewhere in multipart-kit. It collects all form-data value with the same name into an array.
 			var reenable: [String]?
@@ -432,7 +433,8 @@ struct SiteAdminController: SiteControllerUtils {
 			enableFeatures: enablePairs,
 			disableFeatures: disablePairs,
 			shipWifiSSID: postStruct.shipWifiSSID,
-			scheduleUpdateURL: postStruct.scheduleUpdateURL
+			scheduleUpdateURL: postStruct.scheduleUpdateURL,
+			upcomingEventNotificationSeconds: postStruct.upcomingEventNotificationSeconds
 		)
 		try await apiQuery(req, endpoint: "/admin/serversettings/update", method: .POST, encodeContent: apiPostContent)
 		return .ok

--- a/Sources/swiftarr/Site/SiteAdminController.swift
+++ b/Sources/swiftarr/Site/SiteAdminController.swift
@@ -397,6 +397,8 @@ struct SiteAdminController: SiteControllerUtils {
 			var disableAppName: String
 			var disableFeatureName: String
 			var upcomingEventNotificationSeconds: Int
+			var upcomingEventNotificationSetting: EventNotificationSetting
+			var upcomingLFGNotificationSetting: EventNotificationSetting
 			// In the .leaf file, the name property for the select that sets this is "reenable[]".
 			// The "[]" in the name is magic, somewhere in multipart-kit. It collects all form-data value with the same name into an array.
 			var reenable: [String]?
@@ -434,7 +436,9 @@ struct SiteAdminController: SiteControllerUtils {
 			disableFeatures: disablePairs,
 			shipWifiSSID: postStruct.shipWifiSSID,
 			scheduleUpdateURL: postStruct.scheduleUpdateURL,
-			upcomingEventNotificationSeconds: postStruct.upcomingEventNotificationSeconds
+			upcomingEventNotificationSeconds: postStruct.upcomingEventNotificationSeconds,
+			upcomingEventNotificationSetting: postStruct.upcomingEventNotificationSetting,
+			upcomingLFGNotificationSetting: postStruct.upcomingLFGNotificationSetting
 		)
 		try await apiQuery(req, endpoint: "/admin/serversettings/update", method: .POST, encodeContent: apiPostContent)
 		return .ok

--- a/Sources/swiftarr/Site/SiteController.swift
+++ b/Sources/swiftarr/Site/SiteController.swift
@@ -76,7 +76,7 @@ struct TrunkContext: Encodable {
 			// If we have a nextEventTime, and that event starts within the configured notification time bounds,
 			// mark that we have an event starting soon.
 			if let nextEventInterval = alerts?.nextFollowedEventTime?.timeIntervalSince(Settings.shared.getDateInCruiseWeek()),
-				(Settings.shared.upcomingEventPastSeconds...Settings.shared.upcomingEventFutureSeconds).contains(nextEventInterval)
+				(Settings.shared.upcomingEventPastSeconds...Settings.shared.upcomingEventNotificationSeconds).contains(nextEventInterval)
 			{
 				eventStartingSoon = true
 			}

--- a/Sources/swiftarr/Site/SiteController.swift
+++ b/Sources/swiftarr/Site/SiteController.swift
@@ -73,10 +73,10 @@ struct TrunkContext: Encodable {
 			let alerts = try? JSONDecoder().decode(UserNotificationData.self, from: alertData)
 			alertCounts = alerts ?? UserNotificationData()
 
-			// If we have a nextEventTime, and that event starts between 15 mins in the past -> 30 mins in the future,
-			// mark that we have an event starting soon
-			if let nextEventInterval = alerts?.nextFollowedEventTime?.timeIntervalSinceNow,
-				((-15 * 60.0)...(30 * 60.0)).contains(nextEventInterval)
+			// If we have a nextEventTime, and that event starts within the configured notification time bounds,
+			// mark that we have an event starting soon.
+			if let nextEventInterval = alerts?.nextFollowedEventTime?.timeIntervalSince(Settings.shared.getDateInCruiseWeek()),
+				(Settings.shared.upcomingEventPastSeconds...Settings.shared.upcomingEventFutureSeconds).contains(nextEventInterval)
 			{
 				eventStartingSoon = true
 			}

--- a/Sources/swiftarr/Site/SiteController.swift
+++ b/Sources/swiftarr/Site/SiteController.swift
@@ -80,6 +80,7 @@ struct TrunkContext: Encodable {
 			{
 				eventStartingSoon = true
 			}
+			// We don't do the same thing with LFG since that'd be confusing with the chat notifications.
 		}
 		else {
 			alertCounts = UserNotificationData()

--- a/Sources/swiftarr/Site/SiteEventsController.swift
+++ b/Sources/swiftarr/Site/SiteEventsController.swift
@@ -42,7 +42,7 @@ struct EventPageContext: Encodable {
 
 		if let _ = trunk.alertCounts.nextFollowedEventTime {
 			upcomingEvent = events.first {
-				return $0.isFavorite && (Settings.shared.upcomingEventPastSeconds...Settings.shared.upcomingEventFutureSeconds).contains($0.startTime.timeIntervalSince(Settings.shared.getDateInCruiseWeek()))
+				return $0.isFavorite && (Settings.shared.upcomingEventPastSeconds...Settings.shared.upcomingEventNotificationSeconds).contains($0.startTime.timeIntervalSince(Settings.shared.getDateInCruiseWeek()))
 			}
 		}
 		self.filterString = filterString

--- a/Sources/swiftarr/Site/SiteEventsController.swift
+++ b/Sources/swiftarr/Site/SiteEventsController.swift
@@ -41,12 +41,8 @@ struct EventPageContext: Encodable {
 		}
 
 		if let _ = trunk.alertCounts.nextFollowedEventTime {
-			let secondsPerWeek = 60 * 60 * 24 * 7
-			let partialWeek = Int(Date().timeIntervalSince(Settings.shared.cruiseStartDate())) % secondsPerWeek
-			let dateInCruiseWeek = Settings.shared.cruiseStartDate() + TimeInterval(partialWeek)
 			upcomingEvent = events.first {
-				return $0.isFavorite
-					&& ((-5 * 60)...(15 * 60)).contains(dateInCruiseWeek.timeIntervalSince($0.startTime))
+				return $0.isFavorite && (Settings.shared.upcomingEventPastSeconds...Settings.shared.upcomingEventFutureSeconds).contains($0.startTime.timeIntervalSince(Settings.shared.getDateInCruiseWeek()))
 			}
 		}
 		self.filterString = filterString

--- a/Sources/swiftarr/configure.swift
+++ b/Sources/swiftarr/configure.swift
@@ -506,6 +506,7 @@ struct SwiftarrConfigurator {
 
 		// Setup the schedule update job to run at an interval and on-demand.
 		app.queues.schedule(UpdateScheduleJob()).hourly().at(5)
+		app.queues.schedule(UserEventNotificationJob()).minutely().at(0)
 		app.queues.add(UpdateJob())
 		try app.queues.startInProcessJobs(on: .default)
 		try app.queues.startScheduledJobs()

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -138,3 +138,8 @@ doesn't have the expansions.
 ## Feb 12, 2024
 * New ForumController endpoints for retrieving pinned posts (`GET /api/v3/forum/:forumID/pinnedposts`) and pinning/unpinning them (`POST/DELETE /api/v3/forum/post/:postID/pin`).
 * New ForumController endpoints for moderators to pin a forum thread at `POST/DELETE /api/v3/forum/ID/pin`.
+
+## Feb 27, 2024
+* `UserNotificationData` now includes `nextJoinedLFGID` and `nextJoinedLFGTime`.
+* `SettingsAdminData` now includes `upcomingEventNotificationSeconds`, `upcomingEventNotificationSetting`, and `upcomingLFGNotificationSetting`.
+* New `SocketNotificationType` of `joinedLFGStarting`.


### PR DESCRIPTION
Like most calendaring applications, Swiftarr now generates NotificationSocket messages for upcoming schedule events. These now occur for Events (official+shadow, anything in the schedule that we import from Sched) that the user has favorited/followed (we use the term inconsistently) and for LFGs the user has joined. I made these separate socket notification types in case down the line we want to have different configurations for each.

The generation of these notifications is a globally defined offset before the event/LFG occurs (such as 10 mins before, 5 minutes before, at start time, etc). This can get a little hard to test for Events since the start time for those is defined before/after a sailing. A configuration option exists to transpose the current time into "day of cruise week". This mimics the behavior of the Schedule page when it displays "these are the events from that day". This can be set for either LFGs or Events independently based on what the operator desires. All three of these are new server settings available in the admin page and can be adjusted or disabled on the fly without an app restart.

This also adds the users next joined LFG to the `UserNotificationData` endpoint `/api/v3/notification/global` the same way that it does for the next followed Event.

My biggest concerns with this are:
* The changes necessary in `WebSocketStorage.swift`. The added code there was moved/copied from other areas of the app, so I'm confident in that. But anything that touches websocket concurrency gives me PTSD to the "Bad Gateway" of 2022.
* Running the notification job every minute. If I had my way, I'd do it every 5 minutes instead. But that seems obnoxiously difficult with the Vapor queuing API. I wish I could just give it a Cron string.