### PR TITLE
Added SWIFTARR_EXTERNAL_URL env var.

### DIFF
--- a/Sources/swiftarr/Controllers/MicroKaraokeController.swift
+++ b/Sources/swiftarr/Controllers/MicroKaraokeController.swift
@@ -124,7 +124,7 @@ struct MicroKaraokeController: APIRouteCollection {
 		let snippetURL = try getUserUploadedClipsDir().appendingPathComponent(offer.requireID().uuidString).appendingPathExtension("mp4")
 // TODO: For files this big, we might need nonblocking writes
 		try data.videoData.write(to: snippetURL)
-		var serverSnippetDirURL = Settings.shared.apiUrlComponents
+		var serverSnippetDirURL = Settings.shared.canonicalServerURLComponents
 		serverSnippetDirURL.path = try "/api/v3/microkaraoke/video/\(offer.requireID().uuidString).mp4"
 		guard let mediaURL = serverSnippetDirURL.url?.absoluteString else {
 			throw Abort(.internalServerError, reason: "Couldn't construct URL for uploaded media.")
@@ -191,7 +191,7 @@ struct MicroKaraokeController: APIRouteCollection {
 		}
 		let songSnippets = try await MKSnippet.query(on: req.db).filter(\.$song.$id == songID ).sort(\.$songSnippetIndex).all()
 		let songInfo = try await getSongInfo(forSongNamed: song.songName, on: req)
-		var karaokeTrack = Settings.shared.apiUrlComponents
+		var karaokeTrack = Settings.shared.canonicalServerURLComponents
 		karaokeTrack.path = "/microkaraoke/\(song.songName)/karaokeAudio.mp3"
 		guard let karaokeTrackURL = karaokeTrack.url else {
 			throw Abort(.internalServerError, reason: "Could not build audio file URL for karaoke audio track.")
@@ -267,7 +267,7 @@ struct MicroKaraokeController: APIRouteCollection {
 		let localSnippetDir = urlForSongDirectory(songName: song.songName, snippetIndex: snippet.songSnippetIndex)
 		let lyricsFileURL = localSnippetDir.appendingPathComponent("lyric.txt")
 		let lyrics = try String(contentsOf: lyricsFileURL, encoding: .utf8)
-		var serverSnippetDirURL = Settings.shared.apiUrlComponents
+		var serverSnippetDirURL = Settings.shared.canonicalServerURLComponents
 		serverSnippetDirURL.path = "/microkaraoke/\(song.songName)/\(snippet.songSnippetIndex)"
 		guard let url = serverSnippetDirURL.url else {
 			throw Abort(.internalServerError, reason: "Could not convert URL Components to URL")

--- a/Sources/swiftarr/Helpers/Settings.swift
+++ b/Sources/swiftarr/Helpers/Settings.swift
@@ -122,6 +122,11 @@ final class Settings: Encodable {
 	/// Struct representing a set of TimeZoneChange's for this cruise. This setting can then be referenced elsewhere in the application.
 	@SettingsValue var timeZoneChanges: TimeZoneChangeSet = TimeZoneChangeSet()
 
+	/// Enable Late Day Flip where the site UI shows the next days schedule after 3:00AM rather than after Midnight.
+	/// For example, with this setting enabled opening the schedule at 2:00AM on Thursday will show you Wednesday's
+	/// schedule by default. If this setting is disabled, at 2:00AM on Thursday you would see Thursdays schedule by default.
+	@SettingsValue var enableLateDayFlip: Bool = false
+
 	// MARK: Images
 	/// The  set of image file types that we can parse with the GD library. I believe GD hard-codes these values on install based on what ./configure finds.
 	/// If our server app is moved to a new machine after it's built, the valid input types will likely differ.
@@ -146,16 +151,18 @@ final class Settings: Encodable {
 	/// User uploaded images will be inside this dir.
 	@SettingsValue var userImagesRootPath: URL = URL(fileURLWithPath: "~/swiftarrImages")
 
-	/// Endpoint to call for the API.
-	@SettingsValue var apiUrlComponents: URLComponents = URLComponents(string: "http://localhost:8081/api/v3")!
+	// MARK: URLs
+	/// This is the EXTERNALLY VISIBLE URL for the server. If a user asks "What should I type into my browser to get to Twitarr?" you could tell them this.
+	/// The server uses this to generate URLs referring to itself. Be wary of using this for web UI URLs; it could cause cross-origin problems in browsers.
+	@SettingsValue var canonicalServerURLComponents: URLComponents = URLComponents(string: "http://localhost:8081")!
 
-	/// Canonical hostnames for the Twitarr server.
+	/// Canonical hostnames for the Twitarr server. The server uses this to find links to itself inside posts.
 	@SettingsValue var canonicalHostnames: [String] = ["twitarr.com", "joco.hollandamerica.com"]
 
-	/// Enable Late Day Flip where the site UI shows the next days schedule after 3:00AM rather than after Midnight.
-	/// For example, with this setting enabled opening the schedule at 2:00AM on Thursday will show you Wednesday's
-	/// schedule by default. If this setting is disabled, at 2:00AM on Thursday you would see Thursdays schedule by default.
-	@SettingsValue var enableLateDayFlip: Bool = false
+	/// Base URL that the web UI uses to call API level endpoints.
+	@SettingsValue var apiUrlComponents: URLComponents = URLComponents(string: "http://localhost:8081/api/v3")!
+
+
 }
 
 /// Derivative directory paths. These are computed property getters that return a path based on a root path.


### PR DESCRIPTION
This environment variable is the externally-routable URL to the server--what a user would enter into a browser address bar to get to Swiftarr.

It's used by the server to build URLs pointing to itself. Defaults to "http://" plus the first hostname in the "SWIFTARR_CANONICAL_HOSTNAMES" env var if available, or "http://localhost:8081" as a backup.