### PR TITLE
Fix issues with cruise start in future

### DIFF
--- a/Sources/swiftarr/Controllers/AlertController.swift
+++ b/Sources/swiftarr/Controllers/AlertController.swift
@@ -98,12 +98,14 @@ struct AlertController: APIRouteCollection {
 		let newAnnouncements = try await actives.reduce(0) { $1 > userHighestReadAnnouncement ? $0 + 1 : $0 }
 		// Get the next event this user's following or lfg this user has joined, if any
 		var nextEvent = try await req.redis.getNextEventFromUserHash(userHash)
-		if let validDate = nextEvent?.0, Date() > validDate {
+		let eventDateNow = Settings.shared.getScheduleReferenceDate(Settings.shared.upcomingEventNotificationSetting)
+		if let validDate = nextEvent?.0, eventDateNow > validDate {
 			// The previously cached event already happend; figure out what's next
 			nextEvent = try await storeNextFollowedEvent(userID: user.userID, on: req)
 		}
+		let lfgDateNow = Settings.shared.getScheduleReferenceDate(Settings.shared.upcomingLFGNotificationSetting)
 		var nextLFG = try await req.redis.getNextLFGFromUserHash(userHash)
-		if let validDate = nextLFG?.0, Date() > validDate {
+		if let validDate = nextLFG?.0, lfgDateNow > validDate {
 			// The previously cached LFG already happend; figure out what's next
 			nextLFG = try await storeNextJoinedLFG(userID: user.userID, on: req)
 		}

--- a/Sources/swiftarr/Jobs/EventJobs.swift
+++ b/Sources/swiftarr/Jobs/EventJobs.swift
@@ -99,15 +99,7 @@ public struct UserEventNotificationJob: AsyncScheduledJob {
 			return
 		}
 
-		// The filter date is calculated by adding the notification offset interval to either:
-		// 1) The current date (as in what the server is experiencing right now).
-		// 2) The current time/day transposed within the cruise week (when we pretend it is).
-		var filterDate: Date
-		if (Settings.shared.upcomingEventNotificationSetting == .cruiseWeek) {
-			filterDate = Settings.shared.getDateInCruiseWeek()
-		} else {
-			filterDate = Settings.shared.getCurrentFilterDate()
-		}
+		let filterDate = Settings.shared.getScheduleReferenceDate(Settings.shared.upcomingEventNotificationSetting)
 		let portCalendar = Settings.shared.getPortCalendar()
 		let filterStartTime = portCalendar.date(
 			byAdding: .second,
@@ -137,12 +129,7 @@ public struct UserEventNotificationJob: AsyncScheduledJob {
 			return
 		}
 
-		var filterDate: Date
-		if (Settings.shared.upcomingLFGNotificationSetting == .cruiseWeek) {
-			filterDate = Settings.shared.getDateInCruiseWeek()
-		} else {
-			filterDate = Settings.shared.getCurrentFilterDate()
-		}
+		let filterDate = Settings.shared.getScheduleReferenceDate(Settings.shared.upcomingLFGNotificationSetting)
 		let portCalendar = Settings.shared.getPortCalendar()
 		let filterStartTime = portCalendar.date(
 			byAdding: .second,


### PR DESCRIPTION
This all started with a different problem: Since updating to the 2024 schedule, the `nextFollowedEventID` in `/notification/global` wasn't getting updated when the current event had passed. it gets updated when the alert handler gets re-run or the user performs an event favorite mutation. In digging further there was a math problem that only manifest itself if the `cruiseStartDate()` was in the future (which wasn't true until earlier today). The time interval between now and the future start date was negative, which presented a problem when adding that value to the `cruiseStartDate` to get the pretend date during the week. Yeet some `abs()` at that and problem solved.

This also establishes a common place to get the "comparison date" for events and LFGs. The logic was similar in both LFG and Event processing of the notification job, and since this was now going to be a third place needing that logic, it felt like a good time to do it.