### PR TITLE
MK  snippet mod page now shows sub-totals for various snippet states

### DIFF
--- a/Sources/swiftarr/Controllers/MicroKaraokeController.swift
+++ b/Sources/swiftarr/Controllers/MicroKaraokeController.swift
@@ -309,8 +309,8 @@ struct MicroKaraokeController: APIRouteCollection {
 //		let snippets = try FileManager.default.contentsOfDirectory(at: selectedSong, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
 		for index in 0..<totalSnippets {
 			let fillPath = selectedSong.appendingPathComponent("\(index)").appendingPathComponent("fill.mp3")
-			if FileManager.default.fileExists(atPath: fillPath.path), let krakenUser = req.userCache.getUser(username: "kraken") {
-				let newSnippetModel = try MKSnippet(song: newSongModel, songSnippetIndex: index, author: krakenUser)
+			if FileManager.default.fileExists(atPath: fillPath.path), let mkUser = req.userCache.getUser(username: "MicroKaraoke") {
+				let newSnippetModel = try MKSnippet(song: newSongModel, songSnippetIndex: index, author: mkUser)
 				var mediaURL = Settings.shared.apiUrlComponents
 				let filename = newSongModel.isPortrait ? "fillVideoPortrait" : "fillVideoLandscape"
 				mediaURL.path = "/microkaraoke/\(songInfo.songname)/\(index)/\(filename).mp4"

--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -893,6 +893,8 @@ public struct MicroKaraokeCompletedSong: Content {
 	var songName: String
 	/// The artist, as they'd appear in karaoke metadata
 	var artistName: String
+	/// How many song slots this song has. NOT how many are currently filled. This number includes pre-filled 'filler' slots for instrumental sections.
+	var totalSnippetSlots: Int
 	/// Always TRUE unless the user is a mod, in which case will be FALSE for songs that have all the necessary clips recorded but require mod approval to publish.
 	var modApproved: Bool
 	/// When the song's clips were last modified. Usually the time the final snippet gets uploaded (although 'final' means '30th out of 30'
@@ -908,6 +910,7 @@ extension MicroKaraokeCompletedSong {
 		songID = try song.requireID()
 		songName = song.songName
 		artistName = song.artistName
+		totalSnippetSlots = song.totalSnippets
 		completionTime = song.isComplete ? (song.updatedAt ?? Date()) : nil
 		modApproved = song.modApproved
 		self.userContributed = userContributed

--- a/Sources/swiftarr/Resources/Views/moderation/mkSnippetView.html
+++ b/Sources/swiftarr/Resources/Views/moderation/mkSnippetView.html
@@ -17,6 +17,11 @@
 			    	<h6><b>Song Clips for Song \##(songInfo.songID)</b></h6>
 				</div>
 			</div>
+    		<div class="row align-items-end">
+    			<div class="col col-auto">
+			    	#(count(modData))/#(songInfo.totalSnippetSlots) slots; #(numFillerSlots) filler, #(numSlotsOffered) offered, #(numSlotsUploaded) uploaded
+				</div>
+			</div>
 			<div class="list-group">
 				#if(count(modData) == 0):
 					<div class="row">
@@ -33,7 +38,7 @@
 										<b>Clip \#</b>#(clip.snippetIndex)
 									</div>
 									<div class="col col-auto me-auto">
-										#if(clip.user.username == "kraken"):
+										#if(clip.user.username == "MicroKaraoke"):
 											Filler Video
 										#elseif(clip.videoURL):
 											Uploaded by: #userByline(clip.user)
@@ -46,7 +51,7 @@
 									<div class="col col-auto">
 										#if(clip.videoURL):<a class="btn btn-outline-primary btn-sm" href="#(clip.videoURL)">Watch Clip</a>#endif
 									</div>
-									#if(clip.user.username != "kraken" && clip.videoURL):
+									#if(clip.user.username != "MicroKaraoke" && clip.videoURL):
 										<div class="col col-auto">
 											<button type="button" class="btn btn-outline-primary btn-sm" data-bs-toggle="modal" data-bs-target="\#deleteModal">Delete</button>
 										</div>

--- a/Sources/swiftarr/Site/SiteModController.swift
+++ b/Sources/swiftarr/Site/SiteModController.swift
@@ -589,11 +589,29 @@ struct SiteModController: SiteControllerUtils {
 			var trunk: TrunkContext
 			var songInfo: MicroKaraokeCompletedSong
 			var modData: [MicroKaraokeSnippetModeration]
+			var numSlotsUploaded: Int
+			var numSlotsOffered: Int			// Only includes non-expired offers, even through they might be accepted late.
+			var numFillerSlots: Int				// Most songs have a few filler sections with no vocals.
 
 			init(_ req: Request, modData: [MicroKaraokeSnippetModeration], songInfo: MicroKaraokeCompletedSong) throws {
 				trunk = .init(req, title: "Micro Karaoke Moderation", tab: .moderator)
 				self.songInfo = songInfo
 				self.modData = modData
+				
+				numFillerSlots = 0
+				numSlotsOffered = 0
+				numSlotsUploaded = 0
+				for clip in modData {
+					if clip.user.username == "MicroKaraoke" {
+						numFillerSlots += 1
+					}
+					else if clip.videoURL == nil {
+						numSlotsOffered += 1
+					}
+					else {
+						numSlotsUploaded += 1
+					}
+				}
 			}
 		}
 		let ctx = try ReportContext(req, modData: modData, songInfo: songInfo)


### PR DESCRIPTION
The MK snippet moderation page now displays how many slots are filled in the song and how many offers are outstanding.

Info is similar to: "5/38 slots; 4 filler, 0 offered, 1 uploaded".

Also fixes a couple of places where 'kraken' should be changed to 'MicroKaraoke'.