### PR TITLE
Add Client Data Pattern

### DIFF
--- a/Sources/swiftarr/Resources/Assets/public/clients/README.md
+++ b/Sources/swiftarr/Resources/Assets/public/clients/README.md
@@ -1,0 +1,8 @@
+Swiftarr Client Config
+======================
+
+Sometimes it can be useful for client applications to have seed data provided by the server. At this time, Tricordarr is the only app looking to implement this feature.
+
+The convention is to put a JSON file in this directory matching the client name in `SwiftarrClientApp` defined in `AppFeatures.swift`. The filename should be entirely lower-case. The file can contain any valid JSON. The file can then be accessed by any HTTP client at `/public/clients/${filename}.json`.
+
+These files can be dynamically edited on the Swiftarr server and do not require version controlling. Any defaults here are provided to enhance developer testing.

--- a/Sources/swiftarr/Resources/Assets/public/clients/tricordarr.json
+++ b/Sources/swiftarr/Resources/Assets/public/clients/tricordarr.json
@@ -1,0 +1,14 @@
+{
+    "apiVersion": "v1",
+    "kind": "SwiftarrClientConfig",
+    "metadata": {
+        "name": "tricordarr"
+    },
+    "spec": {
+        "latestVersion": "2024.1.2",
+        "oobeVersion": 2,
+        "cruiseStartDate": "2024-03-09",
+        "cruiseLength": "8",
+        "portTimeZoneID": "America/New_York"
+    }
+}


### PR DESCRIPTION
This establishes a pattern for serving client-specific data as JSON from the `/public` file server area. This can be consumed by client apps to read any configuration data specific to them. I want to consume this in Tricordarr to avoid needing to ship certain settings with the builds. Clients are responsible for processing their own data, assuming it even exists at all.