### PR TITLE
Add WebSocket Ping/Pong

### DIFF
--- a/Sources/swiftarr/Controllers/AlertController.swift
+++ b/Sources/swiftarr/Controllers/AlertController.swift
@@ -229,7 +229,6 @@ struct AlertController: APIRouteCollection {
 			_ = ws.close()
 			return
 		}
-
 		let userSocket = UserSocket(userID: user.userID, socket: ws)
 		req.webSocketStore.storeSocket(userSocket)
 		req.logger.log(level: .info, "Created notification socket for user \(user.username)")

--- a/Sources/swiftarr/Controllers/AlertController.swift
+++ b/Sources/swiftarr/Controllers/AlertController.swift
@@ -236,23 +236,17 @@ struct AlertController: APIRouteCollection {
 		ws.onClose.whenComplete { result in
 			req.webSocketStore.removeSocket(userSocket)
 		}
-
 		
 		ws.eventLoop.execute {
-			// ws.onText { ws, text in
-			// 	Task {
-			// 		req.logger.log(level: .info, "Got message: \(text)")
-			// 	}
-			// }
 			ws.onText { ws, text in 
 				Task {
-					req.logger.log(level: .info, "NotificationSocket has received something from the client.")
-					guard let socketEvent = try? JSONDecoder().decode(SocketNotificationData.self, from: text) else {
+					req.logger.log(level: .debug, "NotificationSocket has received something from the client.")
+					guard let data = text.data(using: .utf8), let socketEvent = try? JSONDecoder().decode(SocketNotificationData.self, from: data) else {
 						req.logger.log(level: .error, "Error decoding socket event from a client.")
 						return
 					}
 					if socketEvent.type == .ping {
-                		let response = SocketNotificationData(type: .pong, info: "pong", contentID: socketEvent.contentID)
+						let response = SocketNotificationData(type: .pong, info: "pong", contentID: socketEvent.contentID)
 						guard let responseData = try? JSONEncoder().encode(response) else {
 							req.logger.log(level: .error, "Error encoding socket pong response.")
 							return

--- a/Sources/swiftarr/Controllers/Structs/SocketStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/SocketStructs.swift
@@ -74,7 +74,7 @@ struct SocketFezMemberChangeData: Content {
 /// Each notification is delivered as a JSON string, containing a type of announcement and a string appropriate for displaying to the user.
 /// The string will be of the form, "User @authorName wrote a forum post that mentioned you."
 struct SocketNotificationData: Content {
-	enum NotificationTypeData: Content {
+	enum NotificationTypeData: String, Content {
 		/// A server-wide announcement has just been added.
 		case announcement
 		/// A participant in a Fez the user is a member of has posted a new message.
@@ -105,9 +105,9 @@ struct SocketNotificationData: Content {
 		case joinedLFGStarting
 		/// A Micro Karaoke song the user contributed to is ready for viewing. .
 		case microKaraokeSongReady
-		/// A ping from the client to the server.
+		/// A ping request, from the client to the server.
 		case ping
-		/// A pong from the server to the client.
+		/// A response to a ping, from the server to the client.
 		case pong
 	}
 	/// The type of event that happened. See `SocketNotificationData.NotificationTypeData` for values.

--- a/Sources/swiftarr/Controllers/Structs/SocketStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/SocketStructs.swift
@@ -105,6 +105,10 @@ struct SocketNotificationData: Content {
 		case joinedLFGStarting
 		/// A Micro Karaoke song the user contributed to is ready for viewing. .
 		case microKaraokeSongReady
+		/// A ping from the client to the server.
+		case ping
+		/// A pong from the server to the client.
+		case pong
 	}
 	/// The type of event that happened. See `SocketNotificationData.NotificationTypeData` for values.
 	var type: NotificationTypeData


### PR DESCRIPTION
This closes #187. Since browser clients do not implement WebSocket control frames, the native ping/pong mechanism is unavailable. it is left to the client/server protocol vendors to develop their own solution. This gives native clients the ability to make smarter healthcheck functions to determine the liveness state of the socket. For example, Tricordarr currently does a simple check based on the WS state https://github.com/jocosocial/tricordarr/blob/main/src/libraries/Network/Websockets.ts#L84-L91.

It is entirely possible this is a solution in search of a problem. On-board I feel like the auto reconnection library in Tricordarr seemed to work pretty well since roaming to an area with bad network closed the socket and it attempted to reconnect a few times before giving up. But I don't have specific anecdotes to confirm or deny this.