### PR TITLE
Make photostream report API consistent with other APIs

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -65,6 +65,7 @@ custom_categories:
     - MicroKaraokeController
     - ModerationController
     - PhonecallController
+    - PhotostreamController
     - TestController
     - TwitarrController
     - UserController

--- a/Sources/swiftarr/Controllers/PhotostreamController.swift
+++ b/Sources/swiftarr/Controllers/PhotostreamController.swift
@@ -12,7 +12,7 @@ struct PhotostreamController: APIRouteCollection {
 		tokenAuthGroup.get("", use: photostreamHandler)
 		tokenAuthGroup.get("placenames", use: getPlacenames)
 		tokenAuthGroup.post("upload", use: photostreamUploadHandler)
-		tokenAuthGroup.post("report", streamPhotoIDParam, use: photostreamReportHandler)
+		tokenAuthGroup.post(streamPhotoIDParam, "report", use: photostreamReportHandler)
 
 		let modRoutes = app.tokenRoutes(feature: .photostream, minAccess: .moderator, path: "api", "v3", "mod", "photostream")
 		modRoutes.get(streamPhotoIDParam, use: getPhotoModerationData)		
@@ -114,7 +114,7 @@ struct PhotostreamController: APIRouteCollection {
 		return response
 	}
 	
-	/// `POST /api/v3/photostream/report/:photoID`
+	/// `POST /api/v3/photostream/:photoID/report`
 	///
 	/// Create a `Report` regarding the specified `StreamPhoto`.
 	///

--- a/Sources/swiftarr/Site/SitePhotostreamController.swift
+++ b/Sources/swiftarr/Site/SitePhotostreamController.swift
@@ -60,7 +60,7 @@ struct SitePhotostreamController: SiteControllerUtils {
 			throw Abort(.badRequest, reason: "Missing photostream_ID parameter.")
 		}
 		let report = try req.content.decode(ReportData.self)
-		try await apiQuery(req, endpoint: "/photostream/report/\(photostreamID)", method: .POST, encodeContent: report)
+		try await apiQuery(req, endpoint: "/photostream/\(photostreamID)/report", method: .POST, encodeContent: report)
 		return .created
 	}
 }


### PR DESCRIPTION
We have a convention for mod report API endpoints of `/api/v3/:resource/:id/report`. In the SiteUI those routes become `/:resource/report/:id`. The generalized report handlers in Tricordarr don't work with the `:id` and `report` URL path components reversed in this API. Since this is a brand new controller I think we should be consistent with what we've done in the past.

This also expressly includes the `PhotostreamController` in the list of controllers in https://docs.twitarr.com