### PR TITLE
Command to Delete Old Event Forums

### DIFF
--- a/Sources/swiftarr/Commands/PruneEventForums.swift
+++ b/Sources/swiftarr/Commands/PruneEventForums.swift
@@ -1,0 +1,60 @@
+import Fluent
+import Foundation
+import Vapor
+
+struct PruneEventForumsCommand: AsyncCommand {
+	struct Signature: CommandSignature {}
+
+	var help: String {
+		"""
+		Delete forum threads for events from past schedules. For example, if your server was
+		started with a schedule from 2023 and you imported 2024, you would continue to see forum
+		threads for the 2023 events in the relevant forum categories.
+		"""
+	}
+
+	func run(using context: CommandContext, signature: Signature) async throws {
+		context.application.logger.info("Pruning deleted event forums")
+        try await findEvents(on: context.application)
+        // @TODO update category counts
+	}
+
+	private func findEvents(on app: Application) async throws {
+        // Count the number of deleted events.
+        let deletedEventCount = try await Event.query(on: app.db)
+            .withDeleted()
+            .filter(\.$deletedAt != nil)
+            .count()
+        app.logger.info("Found \(deletedEventCount) deleted events in the database.")
+
+        // Count the number of active event forums.
+        let activeEventForums = try await Forum.query(on: app.db)
+            .join(child: \.$scheduleEvent, method: .left)
+            .with(\.$scheduleEvent)
+            .filter(Event.self, \.$deletedAt == nil)
+            .all()
+        app.logger.info("Found \(activeEventForums.count) active event forums.")
+
+        // Count the number of deleted event forums. This should match the deleted 
+        // event count from above.
+        let deletedEventForums = try await Forum.query(on: app.db)
+            .join(child: \.$scheduleEvent, method: .left)
+            .with(\.$scheduleEvent)
+            .filter(Event.self, \.$deletedAt != nil)
+            .withDeleted()
+            .all()
+        app.logger.info("Found \(deletedEventForums.count) deleted event forums")
+
+        // Actually delete them now.
+        try await app.db.transaction { database in 
+            await withThrowingTaskGroup(of: Void.self) { group in
+                for forum in deletedEventForums {
+                    group.addTask {
+                        app.logger.info("Deleting forum: \(forum.title)")
+                        try await forum.delete(on: database)
+                    }
+                }
+            }
+        }
+	}
+}

--- a/Sources/swiftarr/Commands/PruneEventForums.swift
+++ b/Sources/swiftarr/Commands/PruneEventForums.swift
@@ -3,16 +3,16 @@ import Foundation
 import Vapor
 
 /// Prune Old Event Forums
-/// 
+///
 /// In long-lived Swiftarr instances such as the Beta, we typically do not reset
 /// the database between sailings. As we accumulate years of events, the amount
 /// of forums starts to grow unweildy. The old events are marked as deleted and
 /// removed from the schedule, but the forums remain. This backend command is
 /// intended to be executed by an operator in one of these long-lived environments
 /// to soft-delete all forums that are linked to soft-deleted events.
-/// 
+///
 /// The effects of this command can be reversed by importing the deleted schedule
-/// again which will restore the events and their associated forums (thanks, 
+/// again which will restore the events and their associated forums (thanks,
 /// soft-delete).
 ///
 struct PruneEventForumsCommand: AsyncCommand {
@@ -28,69 +28,71 @@ struct PruneEventForumsCommand: AsyncCommand {
 
 	func run(using context: CommandContext, signature: Signature) async throws {
 		context.application.logger.info("Pruning deleted event forums")
-        try await findEvents(on: context.application)
-        try await updateCategoryCounts(on: context.application)
-        context.application.logger.info("Complete!")
+		try await findEvents(on: context.application)
+		try await updateCategoryCounts(on: context.application)
+		context.application.logger.info("Complete!")
 	}
 
 	private func findEvents(on app: Application) async throws {
-        // Count the number of deleted events.
-        let deletedEventCount = try await Event.query(on: app.db)
-            .withDeleted()
-            .filter(\.$deletedAt != nil)
-            .count()
-        app.logger.info("Found \(deletedEventCount) deleted events in the database.")
+		// Count the number of deleted events.
+		let deletedEventCount = try await Event.query(on: app.db)
+			.withDeleted()
+			.filter(\.$deletedAt != nil)
+			.count()
+		app.logger.info("Found \(deletedEventCount) deleted events in the database.")
 
-        // Count the number of active event forums.
-        let activeEventForums = try await Forum.query(on: app.db)
-            .join(child: \.$scheduleEvent, method: .left)
-            .with(\.$scheduleEvent)
-            .filter(Event.self, \.$deletedAt == nil)
-            .all()
-        app.logger.info("Found \(activeEventForums.count) active event forums.")
+		// Count the number of active event forums.
+		let activeEventForums = try await Forum.query(on: app.db)
+			.join(child: \.$scheduleEvent, method: .left)
+			.with(\.$scheduleEvent)
+			.filter(Event.self, \.$deletedAt == nil)
+			.all()
+		app.logger.info("Found \(activeEventForums.count) active event forums.")
 
-        // Count the number of deleted event forums. This should match the deleted 
-        // event count from above.
-        let deletedEventForums = try await Forum.query(on: app.db)
-            .join(child: \.$scheduleEvent, method: .left)
-            .with(\.$scheduleEvent)
-            .filter(Event.self, \.$deletedAt != nil)
-            .withDeleted()
-            .all()
-        app.logger.info("Found \(deletedEventForums.count) deleted event forums")
+		// Count the number of deleted event forums. This should match the deleted
+		// event count from above.
+		let deletedEventForums = try await Forum.query(on: app.db)
+			.join(child: \.$scheduleEvent, method: .left)
+			.with(\.$scheduleEvent)
+			.filter(Event.self, \.$deletedAt != nil)
+			.withDeleted()
+			.all()
+		app.logger.info("Found \(deletedEventForums.count) deleted event forums")
 
-        // Actually delete them now.
-        try await app.db.transaction { database in 
-            await withThrowingTaskGroup(of: Void.self) { group in
-                for forum in deletedEventForums {
-                    guard forum.deletedAt == nil else {
-                        app.logger.info("Skipping previously deleted forum: \(forum.title)")
-                        continue
-                    }
-                    group.addTask {
-                        app.logger.info("Deleting forum: \(forum.title)")
-                        try await forum.delete(on: database)
-                    }
-                }
-            }
-        }
+		// Actually delete them now.
+		try await app.db.transaction { database in
+			await withThrowingTaskGroup(of: Void.self) { group in
+				for forum in deletedEventForums {
+					guard forum.deletedAt == nil else {
+						app.logger.info("Skipping previously deleted forum: \(forum.title)")
+						continue
+					}
+					group.addTask {
+						app.logger.info("Deleting forum: \(forum.title)")
+						try await forum.delete(on: database)
+					}
+				}
+			}
+		}
 	}
 
-    private func updateCategoryCounts(on app: Application) async throws {
-        let categories = try await Category.query(on: app.db)
-            .filter(\.$isEventCategory == true)
-            .with(\.$forums)
-            .all()
+	private func updateCategoryCounts(on app: Application) async throws {
+		let categories = try await Category.query(on: app.db)
+			.filter(\.$isEventCategory == true)
+			.with(\.$forums)
+			.all()
 
-        await withThrowingTaskGroup(of: Void.self) { group in
-            categories.forEach { category in
-                group.addTask {
-                    let newCount = Int32(category.forums.count)
-                    app.logger.info("Adjusting count for category \(category.title): \(category.forumCount) -> \(newCount)")
-                    category.forumCount = newCount;
-                    try await category.save(on: app.db)
-                }
-            }
-        }
-    }
+		await withThrowingTaskGroup(of: Void.self) { group in
+			categories.forEach { category in
+				group.addTask {
+					let newCount = Int32(category.forums.count)
+					app.logger.info(
+						"Adjusting count for category \(category.title): \(category.forumCount) -> \(newCount)"
+					)
+					category.forumCount = newCount
+					try await category.save(on: app.db)
+				}
+			}
+		}
+	}
 }

--- a/Sources/swiftarr/Commands/PruneEventForums.swift
+++ b/Sources/swiftarr/Commands/PruneEventForums.swift
@@ -2,6 +2,19 @@ import Fluent
 import Foundation
 import Vapor
 
+/// Prune Old Event Forums
+/// 
+/// In long-lived Swiftarr instances such as the Beta, we typically do not reset
+/// the database between sailings. As we accumulate years of events, the amount
+/// of forums starts to grow unweildy. The old events are marked as deleted and
+/// removed from the schedule, but the forums remain. This backend command is
+/// intended to be executed by an operator in one of these long-lived environments
+/// to soft-delete all forums that are linked to soft-deleted events.
+/// 
+/// The effects of this command can be reversed by importing the deleted schedule
+/// again which will restore the events and their associated forums (thanks, 
+/// soft-delete).
+///
 struct PruneEventForumsCommand: AsyncCommand {
 	struct Signature: CommandSignature {}
 
@@ -9,7 +22,7 @@ struct PruneEventForumsCommand: AsyncCommand {
 		"""
 		Delete forum threads for events from past schedules. For example, if your server was
 		started with a schedule from 2023 and you imported 2024, you would continue to see forum
-		threads for the 2023 events in the relevant forum categories.
+		threads for the 2023 events in the relevant forum categories until running this command.
 		"""
 	}
 

--- a/Sources/swiftarr/Helpers/EventParser.swift
+++ b/Sources/swiftarr/Helpers/EventParser.swift
@@ -352,26 +352,6 @@ final class EventParser {
 								)
 								try await newPost.save(on: database)
 							}
-							// PhotoStream
-							// This clears the event tag for any photo stream posts.
-							// While this is not reversable and some metadata is lost,
-							// at least the content is preserved for future viewing.
-							let streamPhotos = try await StreamPhoto.query(on: database)
-								// .join(parent: \.$atEvent, method: .left)
-								// .with(\.$atEvent)
-            					// .filter(Event.self, \.$id == existingEvent.requireID())
-								.filter(\.$atEvent.$id == existingEvent.requireID())
-								.all()
-							try await database.transaction { db in 
-								await withThrowingTaskGroup(of: Void.self) { group in
-									for photo in streamPhotos {
-										group.addTask {
-											photo.$atEvent.id = nil
-											try await photo.save(on: database)
-										}
-									}
-								}
-							}
 						}
 					}
 				}

--- a/Sources/swiftarr/Helpers/EventParser.swift
+++ b/Sources/swiftarr/Helpers/EventParser.swift
@@ -352,6 +352,26 @@ final class EventParser {
 								)
 								try await newPost.save(on: database)
 							}
+							// PhotoStream
+							// This clears the event tag for any photo stream posts.
+							// While this is not reversable and some metadata is lost,
+							// at least the content is preserved for future viewing.
+							let streamPhotos = try await StreamPhoto.query(on: database)
+								// .join(parent: \.$atEvent, method: .left)
+								// .with(\.$atEvent)
+            					// .filter(Event.self, \.$id == existingEvent.requireID())
+								.filter(\.$atEvent.$id == existingEvent.requireID())
+								.all()
+							try await database.transaction { db in 
+								await withThrowingTaskGroup(of: Void.self) { group in
+									for photo in streamPhotos {
+										group.addTask {
+											photo.$atEvent.id = nil
+											try await photo.save(on: database)
+										}
+									}
+								}
+							}
 						}
 					}
 				}

--- a/Sources/swiftarr/configure.swift
+++ b/Sources/swiftarr/configure.swift
@@ -754,5 +754,6 @@ struct SwiftarrConfigurator {
 	// These should be stored in Sources/swiftarr/Commands.
 	func configureCommands(_ app: Application) {
 		app.asyncCommands.use(GenerateScheduleCommand(), as: "generate-schedule")
+		app.asyncCommands.use(PruneEventForumsCommand(), as: "prune-event-forums")
 	}
 }


### PR DESCRIPTION
This address #146 by introducing a management command that can be used in long-lived instances to clean up old event forums for events that are no longer in the schedule. The intention is that this will clean up some of the 500+ event forums in the beta (and my personal instance). This command will likely never be run on-boat or similar context.