### PR TITLE
Forum sort direction

### DIFF
--- a/Sources/swiftarr/Controllers/ForumController.swift
+++ b/Sources/swiftarr/Controllers/ForumController.swift
@@ -199,19 +199,20 @@ struct ForumController: APIRouteCollection {
 			}
 		}
 		var dateFilterUsesUpdate = false
+		let orderDirection = req.orderDirection()
 		switch req.query[String.self, at: "sort"] {
-		case "create": _ = query.sort(\.$createdAt, query.sortDir(req, .descending))
-		case "title": _ = query.sort(.custom("lower(\"forum\".\"title\")"), query.sortDir(req, .ascending))
+		case "create": _ = query.sort(\.$createdAt, orderDirection ?? .descending)
+		case "title": _ = query.sort(.custom("lower(\"forum\".\"title\")"), orderDirection ?? .ascending)
 		case "update":
-			_ = query.sort(\.$lastPostTime, query.sortDir(req, .descending))
+			_ = query.sort(\.$lastPostTime, orderDirection ?? .descending)
 			dateFilterUsesUpdate = true
 		default:
 			if category.isEventCategory {
 				// Sort by event start time
-				_ = query.sort(Event.self, \Event.$startTime, query.sortDir(req, .ascending)).sort(Event.self, \Event.$title, query.sortDir(req, .ascending))
+				_ = query.sort(Event.self, \Event.$startTime, orderDirection ?? .ascending).sort(Event.self, \Event.$title, orderDirection ?? .ascending)
 			}
 			else {
-				_ = query.sort(\.$lastPostTime, query.sortDir(req, .descending))
+				_ = query.sort(\.$lastPostTime, orderDirection ?? .descending)
 				dateFilterUsesUpdate = true
 			}
 		}
@@ -369,11 +370,12 @@ struct ForumController: APIRouteCollection {
 		async let forumCount = try countQuery.count()
 		let start = urlQuery.start ?? 0
 		let limit = urlQuery.limit ?? 50
+		let orderDirection = req.orderDirection();
 		let forumQuery = countQuery.copy().range(start..<(start + limit)).join(child: \.$scheduleEvent, method: .left)
 		switch req.query[String.self, at: "sort"] {
-			case "create": _ = forumQuery.sort(\.$createdAt, forumQuery.sortDir(req, .descending))
-			case "title": _ = forumQuery.sort(.custom("lower(\"forum\".\"title\")"), forumQuery.sortDir(req, .ascending))
-			default: _ = forumQuery.sort(\.$lastPostTime, forumQuery.sortDir(req, .descending))
+			case "create": _ = forumQuery.sort(\.$createdAt, orderDirection ?? .descending)
+			case "title": _ = forumQuery.sort(.custom("lower(\"forum\".\"title\")"), orderDirection ?? .ascending)
+			default: _ = forumQuery.sort(\.$lastPostTime, orderDirection ?? .descending)
 		}
 		async let forums = try forumQuery.all()
 		let forumList = try await buildForumListData(forums, on: req, user: cacheUser)
@@ -405,11 +407,12 @@ struct ForumController: APIRouteCollection {
 			countQuery.filter(\.$category.$id == cat)
 		}
 		async let forumCount = try countQuery.count()
+		let orderDirection = req.orderDirection();
 		let forumQuery = countQuery.copy().range(start..<(start + limit)).join(child: \.$scheduleEvent, method: .left)
 		switch req.query[String.self, at: "sort"] {
-		case "create": _ = forumQuery.sort(\.$createdAt, forumQuery.sortDir(req, .descending))
-		case "update": _ = forumQuery.sort(\.$lastPostTime, forumQuery.sortDir(req, .descending))
-		default: _ = forumQuery.sort(.custom("lower(forum.title)"), forumQuery.sortDir(req, .ascending))
+		case "create": _ = forumQuery.sort(\.$createdAt, orderDirection ?? .descending)
+		case "update": _ = forumQuery.sort(\.$lastPostTime, orderDirection ?? .descending)
+		default: _ = forumQuery.sort(.custom("lower(forum.title)"), orderDirection ?? .ascending)
 		}
 		async let forums = try forumQuery.all()
 		let forumList = try await buildForumListData(forums, on: req, user: cacheUser)
@@ -444,11 +447,12 @@ struct ForumController: APIRouteCollection {
 			countQuery.filter(\.$category.$id == cat)
 		}
 		async let forumCount = try countQuery.count()
+		let orderDirection = req.orderDirection()
 		let forumQuery = countQuery.copy().range(start..<(start + limit)).join(child: \.$scheduleEvent, method: .left)
 		switch req.query[String.self, at: "sort"] {
-		case "create": _ = forumQuery.sort(\.$createdAt, forumQuery.sortDir(req, .descending))
-		case "title": _ = forumQuery.sort(.custom("lower(\"forum\".\"title\")"), forumQuery.sortDir(req, .ascending))
-		default: _ = forumQuery.sort(\.$lastPostTime, forumQuery.sortDir(req, .descending))
+		case "create": _ = forumQuery.sort(\.$createdAt, orderDirection ?? .descending)
+		case "title": _ = forumQuery.sort(.custom("lower(\"forum\".\"title\")"), orderDirection ?? .ascending)
+		default: _ = forumQuery.sort(\.$lastPostTime, orderDirection ?? .descending)
 		}
 		async let forums = try forumQuery.all()
 		let forumList = try await buildForumListData(forums, on: req, user: cacheUser, forceIsFavorite: true)
@@ -483,11 +487,12 @@ struct ForumController: APIRouteCollection {
 			countQuery.filter(\.$category.$id == cat)
 		}
 		async let forumCount = try countQuery.count()
+		let orderDirection = req.orderDirection()
 		let forumQuery = countQuery.copy().range(start..<(start + limit)).join(child: \.$scheduleEvent, method: .left)
 		switch req.query[String.self, at: "sort"] {
-		case "create": _ = forumQuery.sort(\.$createdAt, forumQuery.sortDir(req, .descending))
-		case "title": _ = forumQuery.sort(.custom("lower(\"forum\".\"title\")"), forumQuery.sortDir(req, .ascending))
-		default: _ = forumQuery.sort(\.$lastPostTime, forumQuery.sortDir(req, .descending))
+		case "create": _ = forumQuery.sort(\.$createdAt, orderDirection ?? .descending)
+		case "title": _ = forumQuery.sort(.custom("lower(\"forum\".\"title\")"), orderDirection ?? .ascending)
+		default: _ = forumQuery.sort(\.$lastPostTime, orderDirection ?? .descending)
 		}
 		async let forums = try forumQuery.all()
 		let forumList = try await buildForumListData(forums, on: req, user: cacheUser, forceIsMuted: true)
@@ -536,11 +541,12 @@ struct ForumController: APIRouteCollection {
 			countQuery.filter(\.$category.$id == cat)
 		}
 		async let forumCount = try countQuery.count()
+		let orderDirection = req.orderDirection()
 		let forumQuery = countQuery.copy().range(start..<(start + limit)).join(child: \.$scheduleEvent, method: .left)
 		switch req.query[String.self, at: "sort"] {
-		case "create": _ = forumQuery.sort(\.$createdAt, forumQuery.sortDir(req, .descending))
-		case "title": _ = forumQuery.sort(.custom("lower(\"forum\".\"title\")"), forumQuery.sortDir(req, .ascending))
-		default: _ = forumQuery.sort(\.$lastPostTime, forumQuery.sortDir(req, .descending))
+		case "create": _ = forumQuery.sort(\.$createdAt, orderDirection ?? .descending)
+		case "title": _ = forumQuery.sort(.custom("lower(\"forum\".\"title\")"), orderDirection ?? .ascending)
+		default: _ = forumQuery.sort(\.$lastPostTime, orderDirection ?? .descending)
 		}
 		async let forums = try forumQuery.all()
 		let forumList = try await buildForumListData(forums, on: req, user: cacheUser)

--- a/Sources/swiftarr/Extensions/Fluent+Extensions.swift
+++ b/Sources/swiftarr/Extensions/Fluent+Extensions.swift
@@ -263,20 +263,6 @@ extension QueryBuilder {
 		let bindString = binds.count == 0 ? "" : binds.reduce(("Binds:\n", 1)) { ($0.0.appending("    \($0.1): \($1)\n"), $0.1 + 1) }.0
 		print("\(sqlString)\n\(bindString)")		
 	}
-
-	/// Returns a sort direction for queries based on the Request's `order` parameter. If the `order` is not passed or invalid,
-	/// it will sort by the passed-in default order direction.
-	func sortDir(_ req: Request, _ defaultOrder: DatabaseQuery.Sort.Direction) -> DatabaseQuery.Sort.Direction {
-		let order = req.query[String.self, at: "order"]
-		switch order {
-			case "ascending":
-				return DatabaseQuery.Sort.Direction.ascending
-			case "descending":
-				return DatabaseQuery.Sort.Direction.descending
-			default:
-				return defaultOrder
-		}
-	}
 	
 	/// Copied from file `PostgresConverterDelegate.swift` in package `fluent-postgres-driver` to make it available here for debugging
 	private struct PostgresConverterDelegate: SQLConverterDelegate {

--- a/Sources/swiftarr/Extensions/Fluent+Extensions.swift
+++ b/Sources/swiftarr/Extensions/Fluent+Extensions.swift
@@ -263,6 +263,20 @@ extension QueryBuilder {
 		let bindString = binds.count == 0 ? "" : binds.reduce(("Binds:\n", 1)) { ($0.0.appending("    \($0.1): \($1)\n"), $0.1 + 1) }.0
 		print("\(sqlString)\n\(bindString)")		
 	}
+
+	/// Returns a sort direction for queries based on the Request's `order` parameter. If the `order` is not passed or invalid,
+	/// it will sort by the passed-in default order direction.
+	func sortDir(_ req: Request, _ defaultOrder: DatabaseQuery.Sort.Direction) -> DatabaseQuery.Sort.Direction {
+		let order = req.query[String.self, at: "order"]
+		switch order {
+			case "ascending":
+				return DatabaseQuery.Sort.Direction.ascending
+			case "descending":
+				return DatabaseQuery.Sort.Direction.descending
+			default:
+				return defaultOrder
+		}
+	}
 	
 	/// Copied from file `PostgresConverterDelegate.swift` in package `fluent-postgres-driver` to make it available here for debugging
 	private struct PostgresConverterDelegate: SQLConverterDelegate {

--- a/Sources/swiftarr/Extensions/Vapor+Extensions.swift
+++ b/Sources/swiftarr/Extensions/Vapor+Extensions.swift
@@ -24,17 +24,18 @@ extension Route {
     }
 }
 
+
 extension Request {
-    /// Returns a database sort direction for queries based on the Request's `order` parameter. If the `order` is not passed
+	/// Returns a database sort direction for queries based on the Request's `order` parameter. If the `order` is not passed
 	/// or invalid, we return nil so the caller can fall back to a default.
 	public func orderDirection() -> DatabaseQuery.Sort.Direction? {
 		switch query[String.self, at: "order"] {
-			case "ascending":
-				return DatabaseQuery.Sort.Direction.ascending
-			case "descending":
-				return DatabaseQuery.Sort.Direction.descending
-			default:
-				return nil
+		case "ascending":
+			return DatabaseQuery.Sort.Direction.ascending
+		case "descending":
+			return DatabaseQuery.Sort.Direction.descending
+		default:
+			return nil
 		}
 	}
 }

--- a/Sources/swiftarr/Extensions/Vapor+Extensions.swift
+++ b/Sources/swiftarr/Extensions/Vapor+Extensions.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Vapor
+import FluentSQL
 
 extension Route {
 	/// Adds metadata to a route that describes in user-visible terms where the route takes the user.
@@ -21,5 +22,19 @@ extension Route {
     public func usedForPreregistration() -> Bool {
 		return (self.userInfo["usedForPreregistration"] as? Bool?) == true
     }
+}
 
+extension Request {
+    /// Returns a database sort direction for queries based on the Request's `order` parameter. If the `order` is not passed
+	/// or invalid, we return nil so the caller can fall back to a default.
+	public func orderDirection() -> DatabaseQuery.Sort.Direction? {
+		switch query[String.self, at: "order"] {
+			case "ascending":
+				return DatabaseQuery.Sort.Direction.ascending
+			case "descending":
+				return DatabaseQuery.Sort.Direction.descending
+			default:
+				return nil
+		}
+	}
 }

--- a/Sources/swiftarr/Helpers/CryptoHelper.swift
+++ b/Sources/swiftarr/Helpers/CryptoHelper.swift
@@ -1,4 +1,4 @@
-import CryptoKit
+import Crypto
 import Foundation
 
 /// Helper for random crypto related stuff.


### PR DESCRIPTION
Add optional parameter `order` to forum queries. Supported values are `ascending, descending`.

Also fixes a crypto import to allow building on linux.

Closes #317 

Sort direction controls are not exposed in the UI, but they do work when the URL is edited:
![image](https://github.com/user-attachments/assets/74a07329-d5bc-4e84-a86b-f6216a768b81)
