### PR TITLE
Fixes #329.

### DIFF
--- a/Sources/swiftarr/Resources/Assets/js/swiftarr.js
+++ b/Sources/swiftarr/Resources/Assets/js/swiftarr.js
@@ -423,7 +423,11 @@ async function submitAJAXForm(formElement, event) {
 	event.preventDefault();
 	try {
 		spinnerElem?.classList.remove("d-none");
-		let response = await fetch(formElement.action, { method: 'POST', body: new FormData(formElement) });
+		var uploadBody = new FormData(formElement);
+		if (formElement.classList.contains('fileupload')) {
+			uploadBody = formElement.querySelector('input[type=file]').files[0];
+		}
+		let response = await fetch(formElement.action, { method: 'POST', body: uploadBody });
 		if (response.status < 300) {
 			let successURL = formElement.dataset.successurl;
 			formElement.reset();

--- a/Sources/swiftarr/Resources/Views/admin/bulkUser.html
+++ b/Sources/swiftarr/Resources/Views/admin/bulkUser.html
@@ -47,7 +47,7 @@
 					The user archive file *should* be named 'Twitarr_userfile.zip'.
 				</li>
 				<li class="list-group-item bg-transparent mb-3">				
-					<form class="ajax" action="/admin/bulkuser/upload" enctype="multipart/form-data" method="POST" data-successurl="/admin/bulkuser/upload/verify" id="userfileuploadform">
+					<form class="ajax fileupload" action="/admin/bulkuser/upload" enctype="multipart/form-data" method="POST" data-successurl="/admin/bulkuser/upload/verify" id="userfileuploadform">
 						<div class="container-fluid">
 							<div class="row mb-2"> 
 								<input type="file" accept=".zip" name="userfile" required>

--- a/Sources/swiftarr/Site/SiteAdminController.swift
+++ b/Sources/swiftarr/Site/SiteAdminController.swift
@@ -77,7 +77,7 @@ struct SiteAdminController: SiteControllerUtils {
 		
 		privateTTRoutes.get("bulkuser", use: bulkUserRootViewHandler)
 		privateTTRoutes.get("bulkuser", "download", use: bulkUserFileDownload)
-		privateTTRoutes.post("bulkuser", "upload", use: bulkUserfileUploadPostHandler)
+		privateTTRoutes.on(.POST, "bulkuser", "upload", body: .collect(maxSize: "1gb"), use: bulkUserfileUploadPostHandler)
 		privateTTRoutes.get("bulkuser", "upload", "verify", use: bulkUserVerifyViewHandler)
 		privateTTRoutes.get("bulkuser", "upload", "commit", use: bulkUserUpdateCommitHandler)
 		
@@ -750,11 +750,9 @@ struct SiteAdminController: SiteControllerUtils {
 	//
 	// Uploads a previously archived userfile. 
 	func bulkUserfileUploadPostHandler(_ req: Request) async throws -> HTTPStatus {
-		struct BulkUserUploadData: Content {
-			var userfile: Data
-		}
-		let uploadData = try req.content.decode(BulkUserUploadData.self)
-		try await apiQuery(req, endpoint: "/admin/bulkuserfile/upload", method: .POST, encodeContent: uploadData.userfile)
+		try await apiQuery(req, endpoint: "/admin/bulkuserfile/upload", method: .POST, beforeSend: { clientReq in
+			clientReq.body = req.body.data
+		})
 		return .ok
 	}
 	


### PR DESCRIPTION
This makes AdminController's `userfileUploadPostHandler` stream its POST data into a file, and makes the HTML form for the userfile upload POST the file directly, instead of wrapping the file in JSON.

Previously, swiftarr.js would create a `FormData()` for this form's values and upload that from the js. This turned the zip file into a uuencoded JSON string. So, now the `fileupload` class special-cases this and makes the form POST the file contents directly in the request body. Part of the reason to do this was to remove the 8-to-6 increase in payload size, part of it was because Vapor's built in content decoders aren't built to decode while streaming in data.

However, this doesn't fully make the operation use streaming. SiteAdminController's `bulkUserfileUploadPostHandler` bounces the call to the API layer by making a client request using Vapor's Client API, wrapped in our own `apiQuery()` call. Vapor's Client API doesn't support chunking the request body. Vapor's Client API is written on top of AsyncHTTPClient, which does support chunking the request body, but moving to that for this one call involves a bunch of work that I don't want to do for a call that we need to make one time, and if the call fails to work we can just SFTP the file to the proper directory on the server and go directly to the verification page.

So, the method in SiteAdminController is set to use the `.collect` body method with a maxSize of 1gb. If it doesn't work we can copy the file up manually.