### PR TITLE
Fixes #236

### DIFF
--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -204,6 +204,10 @@ public struct CategoryData: Content {
 	var isRestricted: Bool
 	/// if TRUE, this category is for Event Forums, and is prepopulated with forum threads for each Schedule Event.
 	var isEventCategory: Bool
+	/// The number of threads in this category.
+	/// Maintains backwards compatibility with API clients and is used when
+	/// paginator is not relevant such as in `/api/v3/forum/categories`.
+	var numThreads: Int32
 	/// The threads in the category. Only populated for /categories/ID.
 	var forumThreads: [ForumListData]?
 	/// Pagination of the results
@@ -217,6 +221,7 @@ extension CategoryData {
 		purpose = cat.purpose
 		isRestricted = restricted
 		isEventCategory = cat.isEventCategory
+		numThreads = cat.forumCount
 		self.forumThreads = forumThreads
 		self.paginator = paginator
 	}

--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -206,7 +206,9 @@ public struct CategoryData: Content {
 	var isEventCategory: Bool
 	/// The threads in the category. Only populated for /categories/ID.
 	var forumThreads: [ForumListData]?
-	/// Pagination of the results
+	/// Pagination of the results. For the `GET /api/v3/categories` endpoint only the `Paginator`s `total` is meaningful.
+	/// That values is the number of threads in the category (prior to blocks). It is never the number of categories.
+	/// Queries to `GET /api/v3/categories/:ID` return paginated results for the threads within that category.
 	var paginator: Paginator
 }
 

--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -204,21 +204,21 @@ public struct CategoryData: Content {
 	var isRestricted: Bool
 	/// if TRUE, this category is for Event Forums, and is prepopulated with forum threads for each Schedule Event.
 	var isEventCategory: Bool
-	/// The number of threads in this category
-	var numThreads: Int32
 	/// The threads in the category. Only populated for /categories/ID.
 	var forumThreads: [ForumListData]?
+	/// Pagination of the results
+	var paginator: Paginator
 }
 
 extension CategoryData {
-	init(_ cat: Category, restricted: Bool, forumThreads: [ForumListData]? = nil) throws {
+	init(_ cat: Category, restricted: Bool, paginator: Paginator, forumThreads: [ForumListData]? = nil) throws {
 		categoryID = try cat.requireID()
 		title = cat.title
 		purpose = cat.purpose
 		isRestricted = restricted
 		isEventCategory = cat.isEventCategory
-		numThreads = cat.forumCount
 		self.forumThreads = forumThreads
+		self.paginator = paginator
 	}
 }
 

--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -204,10 +204,6 @@ public struct CategoryData: Content {
 	var isRestricted: Bool
 	/// if TRUE, this category is for Event Forums, and is prepopulated with forum threads for each Schedule Event.
 	var isEventCategory: Bool
-	/// The number of threads in this category.
-	/// Maintains backwards compatibility with API clients and is used when
-	/// paginator is not relevant such as in `/api/v3/forum/categories`.
-	var numThreads: Int32
 	/// The threads in the category. Only populated for /categories/ID.
 	var forumThreads: [ForumListData]?
 	/// Pagination of the results
@@ -221,7 +217,6 @@ extension CategoryData {
 		purpose = cat.purpose
 		isRestricted = restricted
 		isEventCategory = cat.isEventCategory
-		numThreads = cat.forumCount
 		self.forumThreads = forumThreads
 		self.paginator = paginator
 	}

--- a/Sources/swiftarr/Resources/Views/Forums/forumCategories.html
+++ b/Sources/swiftarr/Resources/Views/Forums/forumCategories.html
@@ -28,7 +28,7 @@
 									#(cat.title)
 								</div>
 								<div class="col col-auto">
-									#(cat.paginator.total) threads
+									#(cat.numThreads) threads
 								</div>
 							</div>
 							<div class="row">

--- a/Sources/swiftarr/Resources/Views/Forums/forumCategories.html
+++ b/Sources/swiftarr/Resources/Views/Forums/forumCategories.html
@@ -28,7 +28,7 @@
 									#(cat.title)
 								</div>
 								<div class="col col-auto">
-									#(cat.numThreads) threads
+									#(cat.paginator.total) threads
 								</div>
 							</div>
 							<div class="row">

--- a/Sources/swiftarr/Site/SiteForumController.swift
+++ b/Sources/swiftarr/Site/SiteForumController.swift
@@ -47,7 +47,6 @@ struct ForumPageContext: Encodable {
 				purpose: "",
 				isRestricted: false,
 				isEventCategory: false,
-				numThreads: 0,
 				forumThreads: nil,
 				paginator: Paginator(total: 0, start: 0, limit: 50)
 			)
@@ -417,7 +416,6 @@ struct SiteForumController: SiteControllerUtils {
 						purpose: "",
 						isRestricted: false,
 						isEventCategory: false,
-						numThreads: 0,
 						forumThreads: nil,
 						paginator: Paginator(total: 0, start: 0, limit: 50)
 					)

--- a/Sources/swiftarr/Site/SiteForumController.swift
+++ b/Sources/swiftarr/Site/SiteForumController.swift
@@ -47,6 +47,7 @@ struct ForumPageContext: Encodable {
 				purpose: "",
 				isRestricted: false,
 				isEventCategory: false,
+				numThreads: 0,
 				forumThreads: nil,
 				paginator: Paginator(total: 0, start: 0, limit: 50)
 			)
@@ -416,6 +417,7 @@ struct SiteForumController: SiteControllerUtils {
 						purpose: "",
 						isRestricted: false,
 						isEventCategory: false,
+						numThreads: 0,
 						forumThreads: nil,
 						paginator: Paginator(total: 0, start: 0, limit: 50)
 					)

--- a/Sources/swiftarr/Site/SiteForumController.swift
+++ b/Sources/swiftarr/Site/SiteForumController.swift
@@ -47,8 +47,8 @@ struct ForumPageContext: Encodable {
 				purpose: "",
 				isRestricted: false,
 				isEventCategory: false,
-				numThreads: 0,
-				forumThreads: nil
+				forumThreads: nil,
+				paginator: Paginator(total: 0, start: 0, limit: 50)
 			)
 		}
 		paginator = PaginatorContext(forum.paginator) { pageIndex in
@@ -361,7 +361,7 @@ struct SiteForumController: SiteControllerUtils {
 			init(_ req: Request, forums: CategoryData, start: Int, limit: Int) throws {
 				trunk = .init(req, title: "\(forums.title) | Forum Threads", tab: .forums)
 				self.forums = forums
-				paginator = .init(start: start, total: Int(forums.numThreads), limit: limit) { pageIndex in
+				paginator = .init(start: start, total: Int(forums.paginator.total), limit: limit) { pageIndex in
 					"/forums/\(forums.categoryID)?start=\(pageIndex * limit)&limit=\(limit)"
 				}
 
@@ -416,8 +416,8 @@ struct SiteForumController: SiteControllerUtils {
 						purpose: "",
 						isRestricted: false,
 						isEventCategory: false,
-						numThreads: 0,
-						forumThreads: nil
+						forumThreads: nil,
+						paginator: Paginator(total: 0, start: 0, limit: 50)
 					)
 				}
 			}

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -179,4 +179,4 @@ associated AddedToChat field value increase.
 * SocketNotificationData has new `addedTo...` message types
 
 ## Dec 25, 2024
-* `CategoryData` now uses `Paginator` in `/api/v3/forum/categories/:ID`.
+* `CategoryData` now implements `Paginator`

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -178,3 +178,5 @@ associated AddedToChat field value increase.
 * UserNotificationData has a new `PrivateEventMessageCount` field
 * SocketNotificationData has new `addedTo...` message types
 
+## Dec 25, 2024
+* `CategoryData` now uses `Paginator`, removes the `numThreads` parameter in `/api/v3/forum/categories` and `/api/v3/forum/categories/:ID`.

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -179,4 +179,4 @@ associated AddedToChat field value increase.
 * SocketNotificationData has new `addedTo...` message types
 
 ## Dec 25, 2024
-* `CategoryData` now uses `Paginator`, removes the `numThreads` parameter in `/api/v3/forum/categories` and `/api/v3/forum/categories/:ID`.
+* `CategoryData` now uses `Paginator` in `/api/v3/forum/categories/:ID`.

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -179,4 +179,4 @@ associated AddedToChat field value increase.
 * SocketNotificationData has new `addedTo...` message types
 
 ## Dec 25, 2024
-* `CategoryData` now implements `Paginator`
+* `CategoryData` now implements `Paginator`, removes `numThreads`


### PR DESCRIPTION
`CategoryData` now implements `Paginator`. This is an implicit breaking change in that the `numThreads` attribute is now removed in favor of `paginator.total`.