### PR TITLE
Fixes #272

### DIFF
--- a/Sources/swiftarr/Controllers/FezController.swift
+++ b/Sources/swiftarr/Controllers/FezController.swift
@@ -628,7 +628,7 @@ struct FezController: APIRouteCollection {
 			_ = try await storeNextJoinedAppointment(userID: fezParticipant, on: req)
 		}
 		let cancelNotifyTargets = fez.participantArray.filter { $0 != cacheUser.userID }
-		_ = try await addNotifications(users: cancelNotifyTargets, type: .chatCanceled(fez.requireID(), fez.fezType), info: "\(fez.title) has been canceled", on: req)
+			try await addNotifications(users: cancelNotifyTargets, type: .chatCanceled(fez.requireID(), fez.fezType), info: "\(fez.title) has been canceled", on: req)
 		let pivot = try await fez.$participants.$pivots.query(on: req.db).filter(\.$user.$id == cacheUser.userID)
 			.first()
 		return try buildFezData(from: fez, with: pivot, for: cacheUser, on: req)

--- a/Sources/swiftarr/Controllers/FezController.swift
+++ b/Sources/swiftarr/Controllers/FezController.swift
@@ -612,8 +612,6 @@ struct FezController: APIRouteCollection {
 	/// Cancel a FriendlyFez. Owner only. Cancelling a Fez is different from deleting it. A canceled fez is still visible; members may still post to it.
 	/// But, a cenceled fez does not show up in searches for open fezzes, and should be clearly marked in UI to indicate that it's been canceled.
 	///
-	/// - Note: Eventually, cancelling a fez should notifiy all members via the notifications endpoint.
-	///
 	/// - Parameter fezID: in URL path.
 	/// - Throws: 403 error if user is not the fez owner. A 5xx response should be
 	///   reported as a likely bug, please and thank you.
@@ -624,12 +622,13 @@ struct FezController: APIRouteCollection {
 		guard fez.$owner.id == cacheUser.userID else {
 			throw Abort(.forbidden, reason: "user does not own this \(fez.fezType.lfgLabel)")
 		}
-		// FIXME: this should send out notifications
+		fez.cancelled = true
+		try await fez.save(on: req.db)
 		for fezParticipant in fez.participantArray {
 			_ = try await storeNextJoinedAppointment(userID: fezParticipant, on: req)
 		}
-		fez.cancelled = true
-		try await fez.save(on: req.db)
+		let cancelNotifyTargets = fez.participantArray.filter { $0 != cacheUser.userID }
+		_ = try await addNotifications(users: cancelNotifyTargets, type: .chatCanceled(fez.requireID(), fez.fezType), info: "\(fez.title) has been canceled", on: req)
 		let pivot = try await fez.$participants.$pivots.query(on: req.db).filter(\.$user.$id == cacheUser.userID)
 			.first()
 		return try buildFezData(from: fez, with: pivot, for: cacheUser, on: req)

--- a/Sources/swiftarr/Controllers/Structs/SocketStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/SocketStructs.swift
@@ -88,6 +88,10 @@ struct SocketNotificationData: Content {
 		case addedToLFG
 		/// The creator of the event has added this user.
 		case addedToPrivateEvent
+		/// A Private Event the user has joined has been canceled.
+		case privateEventCanceled
+		/// An LFG the user has joined has been canceled.
+		case lfgCanceled
 		
 // New Chat Messages
 		/// A participant in a Chat the user is a member of has posted a new message.
@@ -161,6 +165,10 @@ extension SocketNotificationData {
 		case .chatUnreadMsg(_, let chatType) where chatType.isPrivateEventType: self.type = .privateEventUnreadMsg
 		case .chatUnreadMsg: self.type = .seamailUnreadMsg
 		
+		case .chatCanceled(_, let chatType) where chatType.isLFGType: self.type = .lfgCanceled
+		case .chatCanceled(_, let chatType) where chatType.isPrivateEventType: self.type = .privateEventCanceled
+		case .chatCanceled: self.type = .lfgCanceled
+
 		// nextFollowedEventTime and nextJoinedLFGTime are not a socket event, so is this OK?
 		case .nextFollowedEventTime: self.type = .followedEventStarting
 		case .followedEventStarting: self.type = .followedEventStarting

--- a/Sources/swiftarr/Enumerations/NotificationType.swift
+++ b/Sources/swiftarr/Enumerations/NotificationType.swift
@@ -57,6 +57,8 @@ enum NotificationType {
 	case joinedLFGStarting(UUID)
 	/// A Personal Event the user has created or was added to is about to start.
 	case personalEventStarting(UUID)
+	/// An LFG or Private Event the user has joined has been cancelled.
+	case chatCanceled(UUID, FezType)
 
 // @mentions and Alertwords
 	/// A twarrt has been posted that contained a word that a user was alerting on. Associated value is a tuple. First is the alert word that matched.
@@ -84,6 +86,7 @@ enum NotificationType {
 		case .announcement: return "announcement"
 		
 		case .addedToChat(let msgID, _): return msgID.uuidString
+		case .chatCanceled(let msgID, _): return msgID.uuidString
 		case .chatUnreadMsg(let msgID, _): return msgID.uuidString
 		
 		case .nextFollowedEventTime: return "nextFollowedEventTime"
@@ -115,6 +118,7 @@ enum NotificationType {
 		
 		case .addedToChat: return "UnreadChats-\(userID)"
 		case .chatUnreadMsg: return "UnreadSeamails-\(userID)"
+		case .chatCanceled: return "NotificationHash-\(userID)"
 		
 		case .nextFollowedEventTime: return "NotificationHash-\(userID)"
 		case .followedEventStarting: return "NotificationHash-\(userID)"
@@ -156,6 +160,7 @@ enum NotificationType {
 		
 		case .addedToChat(let uuid, _): return String(uuid)
 		case .chatUnreadMsg(let uuid, _): return String(uuid)
+		case .chatCanceled(let uuid, _): return String(uuid)
 
 		case .nextFollowedEventTime(_, let uuid): return uuid != nil ? String(uuid!) : ""
 		case .followedEventStarting(let id): return String(id)

--- a/Sources/swiftarr/Protocols/APIRouteCollection.swift
+++ b/Sources/swiftarr/Protocols/APIRouteCollection.swift
@@ -208,7 +208,7 @@ extension APIRouteCollection {
 				for userID in users {
 					group.addTask { try await req.redis.incrementIntInUserHash(field: type, userID: userID) }
 				}
-			case .followedEventStarting(_), .joinedLFGStarting(_), .personalEventStarting(_):
+			case .followedEventStarting(_), .joinedLFGStarting(_), .personalEventStarting(_), .chatCanceled(_):
 				break
 			case .microKaraokeSongReady(_):
 				for userID in users {
@@ -373,7 +373,7 @@ extension APIRouteCollection {
 					)
 				}
 			case .nextFollowedEventTime, .followedEventStarting, .nextJoinedLFGTime, .joinedLFGStarting,
-				.personalEventStarting:
+				.personalEventStarting, .chatCanceled:
 				break
 			case .microKaraokeSongReady(_):
 				// There is currently no method by which songs become not-ready. But,
@@ -432,7 +432,7 @@ extension APIRouteCollection {
 				try await req.redis.markAllViewedInUserHash(field: type, userID: user.userID)
 			}
 		case .nextFollowedEventTime, .followedEventStarting, .nextJoinedLFGTime, .joinedLFGStarting,
-			.personalEventStarting:
+			.personalEventStarting, .chatCanceled:
 			return  // Can't be cleared
 		case .microKaraokeSongReady:
 			try await req.redis.markAllViewedInUserHash(field: type, userID: user.userID)
@@ -477,6 +477,7 @@ extension APIRouteCollection {
 			.join(FezParticipant.self, on: \FezParticipant.$fez.$id == \FriendlyFez.$id)
 			.filter(FezParticipant.self, \.$user.$id == userID)
 			.filter(\.$fezType !~ [.open, .closed])
+			.filter(\.$cancelled == false)
 			.filter(\.$startTime != nil)
 			.filter(\.$startTime > filterDate)
 			.sort(\.$startTime, .ascending)


### PR DESCRIPTION
LFGs and Private Events now generate a Socket Notification for all non-owner participants when the event has been canceled. It will not generate notifications if the owner has un-canceled them (by saving).

Also fixes a bug in `storeNextJoinedAppointment` where next LFG could be something that was canceled.