### PR TITLE
Board game recommend POST rather than GET

### DIFF
--- a/Sources/swiftarr/Controllers/BoardgameController.swift
+++ b/Sources/swiftarr/Controllers/BoardgameController.swift
@@ -175,6 +175,9 @@ struct BoardgameController: APIRouteCollection {
 		if data.minAge != 0 {
 			query.filter(\.$minAge >= data.minAge)
 		}
+		if (data.complexity != 0) {
+			query.filter(\.$complexity >= Float(data.complexity))
+		}
 		let games = try await query.all()
 		struct GameScore {
 			let game: Boardgame

--- a/Sources/swiftarr/Controllers/BoardgameController.swift
+++ b/Sources/swiftarr/Controllers/BoardgameController.swift
@@ -15,7 +15,7 @@ struct BoardgameController: APIRouteCollection {
 		flexAuthGroup.get("", use: getBoardgames)
 		flexAuthGroup.get(boardgameIDParam, use: getBoardgame)
 		flexAuthGroup.get("expansions", boardgameIDParam, use: getExpansions)
-		flexAuthGroup.get("recommend", use: recommendGames)
+		flexAuthGroup.post("recommend", use: recommendGames)
 
 		let tokenAuthGroup = boardgameRoutes.tokenRoutes(feature: .gameslist)
 		tokenAuthGroup.post(boardgameIDParam, "favorite", use: addFavorite)
@@ -146,7 +146,7 @@ struct BoardgameController: APIRouteCollection {
 		return .noContent
 	}
 
-	/// `GET /api/v3/boardgames/recommend`
+	/// `POST /api/v3/boardgames/recommend`
 	///
 	/// Returns an array of boardgames in a structure designed to support pagination. The returned array of board games will be sorted
 	/// in decreasing order of how closely each games matches the criteria in the `BoardgameRecommendationData` JSON content.

--- a/Sources/swiftarr/Site/SiteBoardgameController.swift
+++ b/Sources/swiftarr/Site/SiteBoardgameController.swift
@@ -148,7 +148,7 @@ struct SiteBoardgameController: SiteControllerUtils {
 				minAge: minAge,
 				complexity: complexity
 			)
-			let response = try await apiQuery(req, endpoint: "/boardgames/recommend", encodeContent: queryContent)
+			let response = try await apiQuery(req, endpoint: "/boardgames/recommend", method: .POST, encodeContent: queryContent)
 			games = try response.content.decode(BoardgameResponseData.self)
 		}
 		let gameListContext = try GameListContext(req, games: games)

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -180,3 +180,6 @@ associated AddedToChat field value increase.
 
 ## Dec 25, 2024
 * `CategoryData` now implements `Paginator`, removes `numThreads`
+
+## Jan 03, 2025
+* `/api/v3/boardgames/recommend` is now a `POST` rather than a `GET` with the same request body.


### PR DESCRIPTION
Switches the `/api/v3/boardgames/recommend` (which needs a request body payload) to be `POST` rather than `GET`. I stumbled on this while adding boardgames to Tricordarr. The pattern of a `GET` request with a body is non-standard even though it usually works in client libraries. This is the only usage of this pattern in Swiftarr as far as I've encountered.