### PR TITLE
Alternate text for createAccount page when pre-embark mode is active

### DIFF
--- a/Sources/swiftarr/Resources/Views/Login/createAccount.html
+++ b/Sources/swiftarr/Resources/Views/Login/createAccount.html
@@ -30,7 +30,7 @@
 							Your Twit-arr registration code was sent to you via the e-mail associated to your JoCo Cruise booking account. If you did not receive your registration code or do not have access to that e-mail, go to the JoCo Cruise Info Desk for assistance. Please enter your code below. Your registration code can only be used once, so do not share it with others. You will be held accountable for the actions of ANYONE using your code. If you need an additional code to create an additional account, please request one at the JoCo Cruise Info Desk.
 						</p>
 					#endif
-					</div>
+				</div>
 				<form action="/createAccount" method="POST">
 					<div class="row mb-2 mx-2">
 						<div class="col">

--- a/Sources/swiftarr/Resources/Views/Login/createAccount.html
+++ b/Sources/swiftarr/Resources/Views/Login/createAccount.html
@@ -21,8 +21,16 @@
 				</div>
 			#else:			
 				<div class="row mt-3">
-					<p>Your Twit-arr registration code was sent to you via e-mail. If you did not receive your registration code or do not have access to your e-mail, go to the JoCo Cruise Info Desk for assistance. Please enter your code below. Your registration code can only be used once, so do not share it with others. You will be held accountable for the actions of ANYONE using your code. If you need an additional code to create an additional account, please request one at the JoCo Cruise Info Desk.</p>
-				</div>
+					#if(trunk.preregistrationMode):
+						<p>
+							Your Twit-arr registration code was sent to you via the e-mail associated to your JoCo Cruise booking account. If you did not receive your registration code or do not have access to that e-mail, either wait for an e-mail to arrive, or go to the JoCo Cruise Info Desk for assistance after embarkation. Please enter your code below. Your registration code can only be used once, so do not share it with others. You will be held accountable for the actions of ANYONE using your code. If you need an additional code to create an additional account, please request one at the JoCo Cruise Info Desk after embarkation.
+						</p>
+					#else:
+						<p>
+							Your Twit-arr registration code was sent to you via the e-mail associated to your JoCo Cruise booking account. If you did not receive your registration code or do not have access to that e-mail, go to the JoCo Cruise Info Desk for assistance. Please enter your code below. Your registration code can only be used once, so do not share it with others. You will be held accountable for the actions of ANYONE using your code. If you need an additional code to create an additional account, please request one at the JoCo Cruise Info Desk.
+						</p>
+					#endif
+					</div>
 				<form action="/createAccount" method="POST">
 					<div class="row mb-2 mx-2">
 						<div class="col">

--- a/Sources/swiftarr/Resources/Views/Login/createAccount.html
+++ b/Sources/swiftarr/Resources/Views/Login/createAccount.html
@@ -23,11 +23,11 @@
 				<div class="row mt-3">
 					#if(trunk.preregistrationMode):
 						<p>
-							Your Twit-arr registration code was sent to you via the e-mail associated to your JoCo Cruise booking account. If you did not receive your registration code or do not have access to that e-mail, either wait for an e-mail to arrive, or go to the JoCo Cruise Info Desk for assistance after embarkation. Please enter your code below. Your registration code can only be used once, so do not share it with others. You will be held accountable for the actions of ANYONE using your code. If you need an additional code to create an additional account, please request one at the JoCo Cruise Info Desk after embarkation.
+							Your Twit-arr registration code was sent to you via the e-mail associated to your JoCo Cruise booking account. If you did not receive your registration code or do not have access to that e-mail, either wait for an e-mail to arrive, or go to the JoCo Cruise Info Desk for assistance after embarkation. Please enter your code below. Your registration code can only be used once, so do not share it with others. You will be held accountable for the actions of ANYONE using your code.
 						</p>
 					#else:
 						<p>
-							Your Twit-arr registration code was sent to you via the e-mail associated to your JoCo Cruise booking account. If you did not receive your registration code or do not have access to that e-mail, go to the JoCo Cruise Info Desk for assistance. Please enter your code below. Your registration code can only be used once, so do not share it with others. You will be held accountable for the actions of ANYONE using your code. If you need an additional code to create an additional account, please request one at the JoCo Cruise Info Desk.
+							Your Twit-arr registration code was sent to you via the e-mail associated to your JoCo Cruise booking account. If you did not receive your registration code or do not have access to that e-mail, go to the JoCo Cruise Info Desk for assistance. Please enter your code below. Your registration code can only be used once, so do not share it with others. You will be held accountable for the actions of ANYONE using your code.
 						</p>
 					#endif
 				</div>


### PR DESCRIPTION
Fixes #357 

Update the text on the createAccount screen. Also, display different text (for clarity) when the site has the pre-embark UI enabled.