### PR TITLE
Make User Registration Disable-able

### DIFF
--- a/Sources/swiftarr/Controllers/ImageController.swift
+++ b/Sources/swiftarr/Controllers/ImageController.swift
@@ -15,9 +15,9 @@ struct ImageController: APIRouteCollection {
 		let userImageRoutes = imageRoutes.flexRoutes(feature: .images)
 		userImageRoutes.get("full", imageFilenameParam, use: getImage_FullHandler).setUsedForPreregistration()
 		userImageRoutes.get("thumb", imageFilenameParam, use: getImage_ThumbnailHandler).setUsedForPreregistration()
-		userImageRoutes.get("user", "identicon", userIDParam, use: getUserIdenticonHandler)
-		userImageRoutes.get("user", "full", userIDParam, use: getUserAvatarHandler)
-		userImageRoutes.get("user", "thumb", userIDParam, use: getUserAvatarHandler)
+		userImageRoutes.get("user", "identicon", userIDParam, use: getUserIdenticonHandler).setUsedForPreregistration()
+		userImageRoutes.get("user", "full", userIDParam, use: getUserAvatarHandler).setUsedForPreregistration()
+		userImageRoutes.get("user", "thumb", userIDParam, use: getUserAvatarHandler).setUsedForPreregistration()
 
 		// Moderator-only endpoints
 		let tokenAuthGroup = imageRoutes.tokenRoutes(feature: .images, minAccess: .moderator)

--- a/Sources/swiftarr/Controllers/UserController.swift
+++ b/Sources/swiftarr/Controllers/UserController.swift
@@ -85,9 +85,10 @@ struct UserController: APIRouteCollection {
 
 		// convenience route group for all /api/v3/user endpoints
 		let userRoutes = app.grouped("api", "v3", "user")
-
-		// open access endpoints
-		userRoutes.post("create", use: createHandler).setUsedForPreregistration()
+		
+		// Route group needed for registration
+		let regRoutes = userRoutes.grouped(DisabledAPISectionMiddleware(feature: .registration))
+		regRoutes.post("create", use: createHandler).setUsedForPreregistration()
 
 		// endpoints available only when logged in
 		let tokenAuthGroup = userRoutes.tokenRoutes()

--- a/Sources/swiftarr/Enumerations/AppFeatures.swift
+++ b/Sources/swiftarr/Enumerations/AppFeatures.swift
@@ -49,6 +49,7 @@ public enum SwiftarrFeature: String, Content, CaseIterable, Sendable {
 	case photostream  // Photos taken on the ship. Web UI cannot have photo upload, for THO reasons.
 	case performers  // Official and Shadow performers; gallery, bio pages, links inside Event cells.
 	case personalevents  // Personal event schedule
+	case registration // User account creation. This is independent of .users above.
 
 	case all
 

--- a/Sources/swiftarr/Site/SiteController.swift
+++ b/Sources/swiftarr/Site/SiteController.swift
@@ -743,7 +743,7 @@ extension SiteControllerUtils {
 
 	// Routes that the user does not need to be logged in to access.
 	func getOpenRoutes(_ app: Application, feature: SwiftarrFeature? = nil, path: PathComponent...) -> RoutesBuilder {
-		return app.grouped([
+		var builder = app.grouped(path).grouped([
 			app.sessions.middleware,
 			SiteErrorMiddleware(environment: app.environment),
 			UserCacheData.SessionAuth(),
@@ -751,6 +751,10 @@ extension SiteControllerUtils {
 			NotificationsMiddleware(),
 			SiteMinUserAccessLevelMiddleware(requireAuth: false),
 		])
+		if let feature = feature {
+			builder = builder.grouped(DisabledSiteSectionMiddleware(feature: feature))
+		}
+		return builder
 	}
 
 	// Routes that require login but are generally 'global' -- Two logged-in users could share this URL and both see the content

--- a/Sources/swiftarr/Site/SiteLoginController.swift
+++ b/Sources/swiftarr/Site/SiteLoginController.swift
@@ -9,11 +9,14 @@ struct SiteLoginController: SiteControllerUtils {
 		let openRoutes = getOpenRoutes(app)
 		openRoutes.get("login", use: loginPageViewHandler)
 		openRoutes.post("login", use: loginPagePostHandler)
-		openRoutes.get("createAccount", use: createAccountPageHandler)
-		openRoutes.post("createAccount", use: createAccountPostHandler)
 		openRoutes.post("recoverPassword", use: recoverPasswordPostHandler)  // Change pw while not logged in
 		openRoutes.get("codeOfConduct", use: codeOfConductViewHandler)
 		openRoutes.get("conductAgree", use: codeOfConductViewHandler)
+
+		// Registration routes
+		let regOpenRoutes = getOpenRoutes(app, feature: .registration)
+		regOpenRoutes.get("createAccount", use: createAccountPageHandler)
+		regOpenRoutes.post("createAccount", use: createAccountPostHandler)
 
 		// Routes for non-shareable content. If you're not logged in we failscreen.
 		let privateRoutes = getPrivateRoutes(app, overrideMinUserAccessLevel: true)


### PR DESCRIPTION
#355. Gives us an off-switch for user registration. This is necessary for the pre-embarkation server since at some point we are going to want to shut down registration and do the user export.