### PR TITLE
Add a privacy policy to make Google happy

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -64,6 +64,8 @@ custom_categories:
     - KaraokeController
     - MicroKaraokeController
     - ModerationController
+    - PerformerController
+    - PersonalEventController
     - PhonecallController
     - PhotostreamController
     - TestController
@@ -285,6 +287,9 @@ custom_categories:
       - SiteKaraokeController
       - SiteLoginController
       - SiteModController
+      - SitePerformerController
+      - SitePhotostreamController
+      - SitePrivateEventController
       - SiteSeamailController
       - SiteTwitarrController
       - SiteUserController
@@ -295,6 +300,7 @@ custom_categories:
       - CalendarSessionFixerMiddleware
       - DisabledAPISectionMiddleware
       - DisabledSiteSectionMiddleware
+      - MinUserAccessLevelMiddleware
       - NotificationsMiddleware
       - RequireAdminMiddleware
       - RequireModeratorMiddleware
@@ -302,6 +308,8 @@ custom_categories:
       - RequireTwitarrTeamMiddleware
       - RequireVerifiedMiddleware
       - SiteErrorMiddleware
+      - SiteMinUserAccessLevelMiddleware
+      - SiteNoRouteErrorMiddleware
       - SiteRequireAdminMiddleware
       - SiteRequireModeratorMiddleware
       - SiteRequireTHOMiddleware

--- a/docs/Swiftarr/Privacy.md
+++ b/docs/Swiftarr/Privacy.md
@@ -1,0 +1,63 @@
+Privacy Policy
+==============
+
+The Twitarr Developers ("we," "us," or "our") are committed to protecting your privacy. This Privacy Policy outlines how we collect, use, and safeguard your personal information when you use our applications. By using Twitarr ("Platform"), you agree to the practices described in this Privacy Policy.
+
+This policy covers Twitarr the service and it's associated client applications Tricordarr (Android) and The Kraken (iOS).
+
+Information We Collect
+----------------------
+
+We may collect the following types of information from you:
+
+### Personal Information
+* Name
+* Email address
+* User ID
+
+### Messages
+* Content of messages sent and received within the Platform.
+
+### Photos
+* Photos you upload, share, or interact with in the Platform.
+
+### Calendar
+* Events that you create or interact with in the Platform.
+
+### Automatically Collected Information
+* Device information (e.g., device model, operating system).
+
+How We Use Your Information
+---------------------------
+We use the collected information to:
+* Provide and improve the Platform's functionality.
+* Facilitate communication and sharing features.
+* Respond to user inquiries and support requests.
+* Comply with obligations.
+
+How We Share Your Information
+-----------------------------
+We do not sell your personal information to third parties. However, we may share your information with event and/or cruise management when requested or to protect our rights and interests.
+
+Data Retention
+--------------
+We retain your information only for as long as necessary to fulfill the purposes outlined in this Privacy Policy or as required.
+
+Your Rights and Choices
+-----------------------
+You can access and update your personal information through the Platform settings or by contacting us.
+
+### Account Deletion
+To request account deletion, contact the administrator of your Twitarr server. If this is on JoCo Cruise you can email The Home Office at [info@jococruise.com](mailto:info@jococruise.com). They will process your request within a reasonable timeframe, subject to applicable requirements.
+
+Security
+--------
+We implement appropriate technical and organizational measures to protect your personal information against unauthorized access, disclosure, alteration, or destruction. However, no method of transmission or storage is completely secure, and we cannot guarantee absolute security.
+
+Changes to This Privacy Policy
+------------------------------
+We may update this Privacy Policy from time to time. Any changes will be effective when committed to this repository. Your continued use of the Platform after the update constitutes your acceptance of the revised Privacy Policy.
+
+Contact
+-------
+If you have any questions or concerns about this Privacy Policy, please contact us by opening an [Issue](https://github.com/jocosocial/swiftarr/issues) on this repository.

--- a/docs/Swiftarr/Privacy.md
+++ b/docs/Swiftarr/Privacy.md
@@ -3,7 +3,7 @@ Privacy Policy
 
 The Twitarr Developers ("we," "us," or "our") are committed to protecting your privacy. This Privacy Policy outlines how we collect, use, and safeguard your personal information when you use our applications. By using Twitarr ("Platform"), you agree to the practices described in this Privacy Policy.
 
-This policy covers Twitarr the service and it's associated client applications Tricordarr (Android) and The Kraken (iOS).
+This policy covers Twit-arr the service and its associated client applications Tricordarr (Android) and The Kraken (iOS).
 
 Information We Collect
 ----------------------

--- a/docs/Swiftarr/Privacy.md
+++ b/docs/Swiftarr/Privacy.md
@@ -1,7 +1,7 @@
 Privacy Policy
 ==============
 
-The Twitarr Developers ("we," "us," or "our") are committed to protecting your privacy. This Privacy Policy outlines how we collect, use, and safeguard your personal information when you use our applications. By using Twitarr ("Platform"), you agree to the practices described in this Privacy Policy.
+The Twit-arr Developers ("we," "us," or "our") are committed to protecting your privacy. This Privacy Policy outlines how we collect, use, and safeguard your personal information when you use our applications. By using Twit-arr ("Platform"), you agree to the practices described in this Privacy Policy.
 
 This policy covers Twit-arr the service and its associated client applications Tricordarr (Android) and The Kraken (iOS).
 


### PR DESCRIPTION
I had an update to Tricordarr get rejected because they didn't like my nonexistent privacy policy and account deletion request procedure. I made a link to this one and it got approved so it seems good enough. ChatGPT wrote most of it for me. I hate legalese.

Oh and other misc doc structure improvements