### PR TITLE
ForumListData should not include IDs for deleted events

### DIFF
--- a/Sources/swiftarr/Controllers/EventController.swift
+++ b/Sources/swiftarr/Controllers/EventController.swift
@@ -158,7 +158,7 @@ struct EventController: APIRouteCollection {
 			event = try await Event.query(on: req.db).filter(\.$uid == paramVal).first()
 		}
 		guard let event = event else {
-			throw Abort(.badRequest, reason: "No event with this UID or database ID found.")
+			throw Abort(.notFound, reason: "No event with this UID or database ID found.")
 		}
 		if !Settings.shared.disabledFeatures.isFeatureDisabled(.performers) {
 			let _ = try await event.$performers.get(on: req.db)

--- a/Sources/swiftarr/Controllers/ForumController.swift
+++ b/Sources/swiftarr/Controllers/ForumController.swift
@@ -1679,7 +1679,9 @@ extension ForumController {
 				lastPoster: lastPosterHeader,
 				isFavorite: forceIsFavorite ?? thisForumReaderPivot?.isFavorite ?? false,
 				isMuted: forceIsMuted ?? thisForumReaderPivot?.isMuted ?? false,
-				event: joinedEvent
+				// https://github.com/jocosocial/swiftarr/issues/314
+				// If the joined event has been deleted, we do not want to include its ID in the forum list data.
+				event: joinedEvent?.deletedAt == nil ? joinedEvent : nil
 			)
 		}
 		return returnListData


### PR DESCRIPTION
Fixes #314 

- For event forum categories, do not include the event id on forums where the event has been soft deleted
- When accessing an event, if the event is not found, return not found instead of bad request