### PR TITLE
374: Add user access level and roles to whoami

### DIFF
--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -253,7 +253,7 @@ public struct CurrentUserData: Content {
 	/// The current user's access level (role).
 	var accessLevel: UserAccessLevel
 	/// A list of the user's roles
-	var roles: [UserRoleType]?
+	var roles: [UserRoleType]
 }
 
 /// Used to return the day's theme.

--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -250,6 +250,10 @@ public struct CurrentUserData: Content {
 	let username: String
 	/// Whether the user is currently logged in.
 	var isLoggedIn: Bool
+	/// The current user's access level (role).
+	var accessLevel: UserAccessLevel
+	/// A list of the user's roles
+	var roles: [UserRoleType]?
 }
 
 /// Used to return the day's theme.

--- a/Sources/swiftarr/Controllers/UserController.swift
+++ b/Sources/swiftarr/Controllers/UserController.swift
@@ -309,14 +309,16 @@ struct UserController: APIRouteCollection {
 	///
 	/// Returns the current user's `.id`, `.username` and whether they're currently logged in.
 	///
-	/// - Returns: `CurrentUserData` containing the current user's ID, username and logged in status.
+	/// - Returns: `CurrentUserData` containing the current user's ID, username, logged in status, access level, and roles.
 	func whoamiHandler(_ req: Request) throws -> CurrentUserData {
 		let user = try req.auth.require(UserCacheData.self)
 		let currentUserData = CurrentUserData(
 			userID: user.userID,
 			username: user.username,
 			// if there's a BasicAuthorization header, not logged in
-			isLoggedIn: req.headers.basicAuthorization != nil ? false : true
+			isLoggedIn: req.headers.basicAuthorization != nil ? false : true,
+			accessLevel: user.accessLevel,
+			roles: Array(user.userRoles)
 		)
 		return currentUserData
 	}

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -186,3 +186,6 @@ associated AddedToChat field value increase.
 
 ## Jan 03, 2025
 * `/api/v3/boardgames/recommend` is now a `POST` rather than a `GET` with the same request body.
+
+## Feb 13, 2025
+* `/api/v3/user/whoami` now includes `accessLevel` and `roles` for the current user


### PR DESCRIPTION
Fixes #374 

Sample whoami responses:

With two roles:
```
{"accessLevel":"admin","roles":["karaokemanager","karaokeambassador"],"userID":"47B0FDB3-8FDF-4FE3-BB51-1BF809D63A32","isLoggedIn":true,"username":"admin"}
```

With no roles:
```
{"roles":[],"isLoggedIn":true,"username":"admin","userID":"47B0FDB3-8FDF-4FE3-BB51-1BF809D63A32","accessLevel":"admin"}
```