### PR TITLE
Hunt admin page visibility

### DIFF
--- a/Sources/swiftarr/Resources/Views/admin/root.html
+++ b/Sources/swiftarr/Resources/Views/admin/root.html
@@ -79,6 +79,9 @@
 				<a class="list-group-item list-group-item-action" href="/admin/performer/root">
 					<b>Performers</b>: Manage performers and link them to their events.
 				</a>
+				<a class="list-group-item list-group-item-action" href="/admin/hunts">
+					<b>Puzzle Hunts</b>: Administer puzzle hunt settings.
+				</a>
 				#if(trunk.username == "admin"):
 					<a class="list-group-item list-group-item-action" href="/admin/bulkuser">
 						<b>User</b>: Bulk user import/export.
@@ -88,9 +91,6 @@
 					</a>
 					<a class="list-group-item list-group-item-action" href="/admin/boardgames">
 						<b>Board Games</b>: Administer board game settings.
-					</a>
-					<a class="list-group-item list-group-item-action" href="/admin/hunts">
-						<b>Puzzle Hunts</b>: Administer puzzle hunt settings.
 					</a>
 					<a class="list-group-item list-group-item-action" href="/admin/timezonechanges">
 						<b>Time Zones</b>: Every time zone change we undergo during the cruise.


### PR DESCRIPTION
Make hunt admin page link visible on admin page even if not logged in as admin, since twitarrteam has access to it.

Fixes #422 