### PR TITLE
feat: Image format safety — magic byte validation + HEIC/AVIF/JXL support

### DIFF
--- a/Sources/swiftarr/Image/ImageFormatConverter.swift
+++ b/Sources/swiftarr/Image/ImageFormatConverter.swift
@@ -1,5 +1,5 @@
-// ABOUTME: Converts image formats that GD cannot handle (HEIC, AVIF, JXL) to JPEG.
-// ABOUTME: Shells out to CLI tools (heif-convert, djxl) with temp files and timeout.
+// Converts image formats that GD cannot handle (HEIC, AVIF, JXL) to JPEG.
+// Shells out to CLI tools (heif-convert, djxl) with temp files and timeout.
 
 import Foundation
 

--- a/Sources/swiftarr/Image/ImageFormatConverter.swift
+++ b/Sources/swiftarr/Image/ImageFormatConverter.swift
@@ -1,0 +1,146 @@
+// ABOUTME: Converts image formats that GD cannot handle (HEIC, AVIF, JXL) to JPEG.
+// ABOUTME: Shells out to CLI tools (heif-convert, djxl) with temp files and timeout.
+
+import Foundation
+
+/// Errors from image format conversion.
+enum ImageConversionError: Error, LocalizedError {
+	case notConvertible(DetectedImageFormat)
+	case converterNotFound(String)
+	case conversionFailed(String)
+	case timeout
+
+	var errorDescription: String? {
+		switch self {
+		case .notConvertible(let format):
+			return "\(format) is not a convertible format"
+		case .converterNotFound(let tool):
+			return "Server does not support this image format — \(tool) is not installed. Please upload JPEG, PNG, GIF, or WebP."
+		case .conversionFailed(let reason):
+			return "Image conversion failed: \(reason)"
+		case .timeout:
+			return "Image conversion timed out"
+		}
+	}
+}
+
+/// Converts non-GD image formats to JPEG via CLI tools.
+struct ImageFormatConverter {
+
+	private static let timeoutSeconds: TimeInterval = 30
+	private static let jpegQuality = 95
+
+	/// Convert image data from a non-GD format to JPEG using a CLI tool.
+	/// - Parameters:
+	///   - data: The raw image data
+	///   - format: The detected format (must be .heic, .avif, or .jxl)
+	/// - Returns: JPEG image data
+	static func convertToJPEG(_ data: Data, from format: DetectedImageFormat) throws -> Data {
+		guard format.needsConversion else {
+			throw ImageConversionError.notConvertible(format)
+		}
+
+		let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+			.appendingPathComponent("swiftarr-convert")
+		try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+		let uuid = UUID().uuidString
+		let inputExtension: String
+		let toolName: String
+		var toolArgs: [String]
+
+		switch format {
+		case .heic:
+			inputExtension = "heic"
+			toolName = "heif-convert"
+			toolArgs = []
+		case .avif:
+			inputExtension = "avif"
+			toolName = "heif-convert"
+			toolArgs = []
+		case .jxl:
+			inputExtension = "jxl"
+			toolName = "djxl"
+			toolArgs = []
+		default:
+			throw ImageConversionError.notConvertible(format)
+		}
+
+		let inputPath = tempDir.appendingPathComponent("\(uuid).\(inputExtension)")
+		let outputPath = tempDir.appendingPathComponent("\(uuid).jpg")
+
+		switch format {
+		case .heic, .avif:
+			toolArgs = [inputPath.path, outputPath.path, "-q", "\(jpegQuality)"]
+		case .jxl:
+			toolArgs = [inputPath.path, outputPath.path]
+		default:
+			break
+		}
+
+		defer {
+			try? FileManager.default.removeItem(at: inputPath)
+			try? FileManager.default.removeItem(at: outputPath)
+		}
+
+		try data.write(to: inputPath)
+
+		let toolURL = findExecutable(toolName)
+		guard let executableURL = toolURL else {
+			throw ImageConversionError.converterNotFound(toolName)
+		}
+
+		let process = Process()
+		process.executableURL = executableURL
+		process.arguments = toolArgs
+		process.standardOutput = FileHandle.nullDevice
+		let errorPipe = Pipe()
+		process.standardError = errorPipe
+
+		try process.run()
+
+		let deadline = DispatchTime.now() + timeoutSeconds
+		let group = DispatchGroup()
+		group.enter()
+		DispatchQueue.global().async {
+			process.waitUntilExit()
+			group.leave()
+		}
+		if group.wait(timeout: deadline) == .timedOut {
+			process.terminate()
+			throw ImageConversionError.timeout
+		}
+
+		guard process.terminationStatus == 0 else {
+			let stderrData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+			let stderr = String(data: stderrData, encoding: .utf8) ?? "unknown error"
+			throw ImageConversionError.conversionFailed(stderr.trimmingCharacters(in: .whitespacesAndNewlines))
+		}
+
+		guard FileManager.default.fileExists(atPath: outputPath.path) else {
+			throw ImageConversionError.conversionFailed("Converter produced no output file")
+		}
+
+		return try Data(contentsOf: outputPath)
+	}
+
+	/// Search PATH for an executable by name.
+	private static func findExecutable(_ name: String) -> URL? {
+		let process = Process()
+		process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+		process.arguments = ["which", name]
+		let pipe = Pipe()
+		process.standardOutput = pipe
+		process.standardError = FileHandle.nullDevice
+		do {
+			try process.run()
+			process.waitUntilExit()
+			guard process.terminationStatus == 0 else { return nil }
+			let data = pipe.fileHandleForReading.readDataToEndOfFile()
+			let path = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+			return path.isEmpty ? nil : URL(fileURLWithPath: path)
+		} catch {
+			return nil
+		}
+	}
+}

--- a/Sources/swiftarr/Image/ImageFormatConverter.swift
+++ b/Sources/swiftarr/Image/ImageFormatConverter.swift
@@ -4,11 +4,13 @@
 import Foundation
 
 /// Errors from image format conversion.
-enum ImageConversionError: Error, LocalizedError {
+enum ImageConversionError: Error, LocalizedError, CustomStringConvertible {
 	case notConvertible(DetectedImageFormat)
 	case converterNotFound(String)
 	case conversionFailed(String)
 	case timeout
+
+	var description: String { errorDescription ?? "unknown error" }
 
 	var errorDescription: String? {
 		switch self {

--- a/Sources/swiftarr/Image/ImageFormatConverter.swift
+++ b/Sources/swiftarr/Image/ImageFormatConverter.swift
@@ -142,6 +142,9 @@ struct ImageFormatConverter {
 			let path = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 			return path.isEmpty ? nil : URL(fileURLWithPath: path)
 		} catch {
+			// Log the actual error — a catch-all nil would misdiagnose system failures
+			// (permission denied, file descriptor exhaustion, sandbox) as "tool not installed."
+			print("[ImageFormatConverter] Failed to search PATH for \(name): \(error)")
 			return nil
 		}
 	}

--- a/Sources/swiftarr/Image/ImageFormatDetector.swift
+++ b/Sources/swiftarr/Image/ImageFormatDetector.swift
@@ -1,0 +1,131 @@
+// ABOUTME: Identifies image formats by reading magic bytes from file headers.
+// ABOUTME: Returns a detected format enum — no dependencies, no side effects.
+
+import Foundation
+
+/// Image formats identified by their magic byte signatures.
+enum DetectedImageFormat: Equatable {
+	// GD-supported formats (pass directly to GD)
+	case jpeg, png, gif, webp, tiff, bmp
+	// Convertible via CLI tools (heif-convert, djxl)
+	case heic, avif, jxl
+	// Not recognized
+	case unknown
+
+	/// Maps detected GD-supported formats to the corresponding GD ImportableFormat.
+	var gdFormat: ImportableFormat? {
+		switch self {
+		case .jpeg: return .jpg
+		case .png: return .png
+		case .gif: return .gif
+		case .webp: return .webp
+		case .tiff: return .tiff
+		case .bmp: return .bmp
+		default: return nil
+		}
+	}
+
+	/// Whether this format needs CLI conversion before GD can process it.
+	var needsConversion: Bool {
+		switch self {
+		case .heic, .avif, .jxl: return true
+		default: return false
+		}
+	}
+}
+
+/// Detects image format from file header bytes.
+struct ImageFormatDetector {
+
+	/// Detect the image format by examining the first ~12 bytes of the data.
+	static func detect(_ data: Data) -> DetectedImageFormat {
+		let count = data.count
+		guard count >= 2 else { return .unknown }
+
+		let byte0 = data[data.startIndex]
+		let byte1 = data[data.startIndex + 1]
+
+		// JPEG: FF D8 FF
+		if byte0 == 0xFF && byte1 == 0xD8 {
+			if count >= 3 && data[data.startIndex + 2] == 0xFF {
+				return .jpeg
+			}
+		}
+
+		// JXL codestream: FF 0A
+		if byte0 == 0xFF && byte1 == 0x0A {
+			return .jxl
+		}
+
+		// PNG: 89 50 4E 47
+		if count >= 4 && byte0 == 0x89 && byte1 == 0x50 {
+			if data[data.startIndex + 2] == 0x4E && data[data.startIndex + 3] == 0x47 {
+				return .png
+			}
+		}
+
+		// GIF: 47 49 46 38
+		if count >= 4 && byte0 == 0x47 && byte1 == 0x49 {
+			if data[data.startIndex + 2] == 0x46 && data[data.startIndex + 3] == 0x38 {
+				return .gif
+			}
+		}
+
+		// RIFF container: could be WebP
+		if count >= 12 && byte0 == 0x52 && byte1 == 0x49
+			&& data[data.startIndex + 2] == 0x46 && data[data.startIndex + 3] == 0x46
+		{
+			if data[data.startIndex + 8] == 0x57 && data[data.startIndex + 9] == 0x45
+				&& data[data.startIndex + 10] == 0x42 && data[data.startIndex + 11] == 0x50
+			{
+				return .webp
+			}
+		}
+
+		// TIFF: II*\0 (little-endian) or MM\0* (big-endian)
+		if count >= 4 {
+			if byte0 == 0x49 && byte1 == 0x49
+				&& data[data.startIndex + 2] == 0x2A && data[data.startIndex + 3] == 0x00
+			{
+				return .tiff
+			}
+			if byte0 == 0x4D && byte1 == 0x4D
+				&& data[data.startIndex + 2] == 0x00 && data[data.startIndex + 3] == 0x2A
+			{
+				return .tiff
+			}
+		}
+
+		// BMP: BM
+		if byte0 == 0x42 && byte1 == 0x4D {
+			return .bmp
+		}
+
+		// ISOBMFF container (HEIC, AVIF): check for "ftyp" at offset 4
+		if count >= 12 {
+			let ftyp = data[data.startIndex + 4 ..< data.startIndex + 8]
+			if ftyp.elementsEqual("ftyp".utf8) {
+				let brand = data[data.startIndex + 8 ..< data.startIndex + 12]
+				let brandString = String(bytes: brand, encoding: .ascii) ?? ""
+				switch brandString {
+				case "heic", "heix", "mif1", "msf1":
+					return .heic
+				case "avif", "avis":
+					return .avif
+				default:
+					break
+				}
+			}
+		}
+
+		// JXL container: 00 00 00 0C 4A 58 4C 20 0D 0A 87 0A
+		if count >= 12 {
+			let jxlContainer: [UInt8] = [0x00, 0x00, 0x00, 0x0C, 0x4A, 0x58, 0x4C, 0x20, 0x0D, 0x0A, 0x87, 0x0A]
+			if data.prefix(12).elementsEqual(jxlContainer) {
+				return .jxl
+			}
+		}
+
+		return .unknown
+	}
+}

--- a/Sources/swiftarr/Image/ImageFormatDetector.swift
+++ b/Sources/swiftarr/Image/ImageFormatDetector.swift
@@ -1,5 +1,5 @@
-// ABOUTME: Identifies image formats by reading magic bytes from file headers.
-// ABOUTME: Returns a detected format enum — no dependencies, no side effects.
+// Identifies image formats by reading magic bytes from file headers.
+// Returns a detected format enum — no dependencies, no side effects.
 
 import Foundation
 

--- a/Sources/swiftarr/Protocols/ImageHandler.swift
+++ b/Sources/swiftarr/Protocols/ImageHandler.swift
@@ -100,16 +100,22 @@ extension APIRouteCollection {
 					reason: "Unsupported image format. Supported: JPEG, PNG, GIF, WebP, TIFF, BMP, HEIC, AVIF, JXL"
 				)
 			}
+			// polyAllocated stores the original EXIF orientation — see comment in main parse path below
 			let origOrientation = image.internalImage.pointee.polyAllocated
 			return (image, foundType, origOrientation)
 		}
 
 		// Parse with the identified GD format
-		guard let image = try? GDImage(data: imageData, as: imageType) else {
+		let image: GDImage
+		do {
+			image = try GDImage(data: imageData, as: imageType)
+		} catch {
 			throw GDError.invalidImage(
-				reason: "Failed to parse image data as \(imageType). The file may be corrupted."
+				reason: "Failed to parse image data as \(imageType): \(error)"
 			)
 		}
+		// polyAllocated stores the original EXIF orientation, set by our custom gd_jpeg_custom.c.
+		// The field is repurposed — it's not designed for this, but it's how orientation flows through GD.
 		let origOrientation = image.internalImage.pointee.polyAllocated
 		return (image, imageType, origOrientation)
 	}

--- a/Sources/swiftarr/Protocols/ImageHandler.swift
+++ b/Sources/swiftarr/Protocols/ImageHandler.swift
@@ -66,25 +66,50 @@ func getImagePath(for image: String, format: String? = nil, usage: ImageUsage, s
 	
 extension APIRouteCollection {
 	/// Loads an image from data and returns the image, its type, and original orientation.
+	/// Detects the format via magic bytes before parsing. Converts HEIC/AVIF/JXL to JPEG
+	/// via CLI tools if needed. Rejects unknown formats with a descriptive error.
 	/// - Parameter data: The image data to load
 	/// - Returns: A tuple containing the loaded image, its format type, and original orientation value
 	static func loadImageFromData(_ data: Data) throws -> (image: GDImage, type: ImportableFormat, orientation: Int32) {
-		let imageTypes: [ImportableFormat] = [.jpg, .png, .gif, .webp, .tiff, .bmp, .wbmp]
-		var foundType: ImportableFormat? = nil
-		var foundImage: GDImage?
-		for type in imageTypes {
-			foundImage = try? GDImage(data: data, as: type) 
-			if foundImage != nil{
-				foundType = type
-				break
+		let detected = ImageFormatDetector.detect(data)
+		let imageData: Data
+		let imageType: ImportableFormat
+
+		if let gdFormat = detected.gdFormat {
+			// GD can handle this format directly
+			imageData = data
+			imageType = gdFormat
+		} else if detected.needsConversion {
+			// Convert non-GD format to JPEG via CLI tool
+			imageData = try ImageFormatConverter.convertToJPEG(data, from: detected)
+			imageType = .jpg
+		} else {
+			// Unknown format — try TGA and WBMP as fallback (no reliable magic bytes for these)
+			let fallbackTypes: [ImportableFormat] = [.tga, .wbmp]
+			var fallbackImage: GDImage?
+			var fallbackType: ImportableFormat?
+			for type in fallbackTypes {
+				fallbackImage = try? GDImage(data: data, as: type)
+				if fallbackImage != nil {
+					fallbackType = type
+					break
+				}
 			}
+			guard let image = fallbackImage, let foundType = fallbackType else {
+				throw GDError.invalidImage(
+					reason: "Unsupported image format. Supported: JPEG, PNG, GIF, WebP, TIFF, BMP, HEIC, AVIF, JXL"
+				)
+			}
+			let origOrientation = image.internalImage.pointee.polyAllocated
+			return (image, foundType, origOrientation)
 		}
-		guard let image = foundImage, let imageType = foundType else {
-			throw GDError.invalidImage(reason: "No matching raster formatter for given image found")
+
+		// Parse with the identified GD format
+		guard let image = try? GDImage(data: imageData, as: imageType) else {
+			throw GDError.invalidImage(
+				reason: "Failed to parse image data as \(imageType). The file may be corrupted."
+			)
 		}
-		// We've modified SwiftGD to call methods in gd_jpeg_custom.c instead of the gd_jpeg.c in the GD library.
-		// The customized .c file has extra code to save the image orientation in the gdImage struct.
-		// It's definitely a hack, as polyAllocated is not for this purpose.
 		let origOrientation = image.internalImage.pointee.polyAllocated
 		return (image, imageType, origOrientation)
 	}

--- a/Tests/AppTests/ImageFormatConverterTests.swift
+++ b/Tests/AppTests/ImageFormatConverterTests.swift
@@ -1,0 +1,80 @@
+import Testing
+import XCTVapor
+
+@testable import swiftarr
+
+class ImageFormatConverterTests: XCTestCase {
+
+	// MARK: - Helpers
+
+	/// Check if a CLI tool is available on this system.
+	private func toolAvailable(_ name: String) -> Bool {
+		let process = Process()
+		process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+		process.arguments = ["which", name]
+		process.standardOutput = FileHandle.nullDevice
+		process.standardError = FileHandle.nullDevice
+		do {
+			try process.run()
+			process.waitUntilExit()
+			return process.terminationStatus == 0
+		} catch {
+			return false
+		}
+	}
+
+	/// Create a minimal valid JPEG (smallest possible: 2x1 pixel).
+	private func minimalJPEG() -> Data {
+		let image = GDImage(width: 2, height: 1)!
+		return try! image.export(as: .jpg(quality: 90))
+	}
+
+	// MARK: - Converter Validation
+
+	func testConvertUnsupportedFormatThrows() {
+		let jpegData = minimalJPEG()
+		XCTAssertThrowsError(try ImageFormatConverter.convertToJPEG(jpegData, from: .jpeg)) { error in
+			XCTAssertTrue("\(error)".contains("not a convertible format"))
+		}
+	}
+
+	func testConvertUnknownFormatThrows() {
+		let data = Data([0xDE, 0xAD, 0xBE, 0xEF])
+		XCTAssertThrowsError(try ImageFormatConverter.convertToJPEG(data, from: .unknown)) { error in
+			XCTAssertTrue("\(error)".contains("not a convertible format"))
+		}
+	}
+
+	// MARK: - HEIC Conversion
+
+	func testConvertHEIC() throws {
+		try XCTSkipUnless(toolAvailable("heif-convert"), "heif-convert not installed")
+
+		let fixturesDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+			.appendingPathComponent("Resources")
+		let fixturePath = fixturesDir.appendingPathComponent("test.heic")
+		try XCTSkipUnless(FileManager.default.fileExists(atPath: fixturePath.path), "test.heic fixture not found")
+
+		let heicData = try Data(contentsOf: fixturePath)
+		let jpegData = try ImageFormatConverter.convertToJPEG(heicData, from: .heic)
+
+		XCTAssertGreaterThan(jpegData.count, 0)
+		XCTAssertEqual(jpegData[jpegData.startIndex], 0xFF)
+		XCTAssertEqual(jpegData[jpegData.startIndex + 1], 0xD8)
+		XCTAssertEqual(jpegData[jpegData.startIndex + 2], 0xFF)
+	}
+
+	// MARK: - Temp File Cleanup
+
+	func testTempFilesCleanedUp() throws {
+		let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+			.appendingPathComponent("swiftarr-convert")
+
+		_ = try? ImageFormatConverter.convertToJPEG(Data([0x00, 0x01, 0x02]), from: .heic)
+
+		if FileManager.default.fileExists(atPath: tempDir.path) {
+			let remaining = try FileManager.default.contentsOfDirectory(atPath: tempDir.path)
+			XCTAssertEqual(remaining.count, 0, "Temp files not cleaned up: \(remaining)")
+		}
+	}
+}

--- a/Tests/AppTests/ImageFormatDetectorTests.swift
+++ b/Tests/AppTests/ImageFormatDetectorTests.swift
@@ -1,0 +1,118 @@
+import Testing
+import XCTVapor
+
+@testable import swiftarr
+
+class ImageFormatDetectorTests: XCTestCase {
+
+	// MARK: - GD-Supported Formats
+
+	func testDetectJPEG() {
+		let data = Data([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10])
+		XCTAssertEqual(ImageFormatDetector.detect(data), .jpeg)
+	}
+
+	func testDetectPNG() {
+		let data = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+		XCTAssertEqual(ImageFormatDetector.detect(data), .png)
+	}
+
+	func testDetectGIF87a() {
+		let data = Data([0x47, 0x49, 0x46, 0x38, 0x37, 0x61])
+		XCTAssertEqual(ImageFormatDetector.detect(data), .gif)
+	}
+
+	func testDetectGIF89a() {
+		let data = Data([0x47, 0x49, 0x46, 0x38, 0x39, 0x61])
+		XCTAssertEqual(ImageFormatDetector.detect(data), .gif)
+	}
+
+	func testDetectWebP() {
+		var data = Data([0x52, 0x49, 0x46, 0x46])
+		data.append(contentsOf: [0x00, 0x00, 0x00, 0x00])
+		data.append(contentsOf: [0x57, 0x45, 0x42, 0x50])
+		XCTAssertEqual(ImageFormatDetector.detect(data), .webp)
+	}
+
+	func testDetectTIFF_LittleEndian() {
+		let data = Data([0x49, 0x49, 0x2A, 0x00])
+		XCTAssertEqual(ImageFormatDetector.detect(data), .tiff)
+	}
+
+	func testDetectTIFF_BigEndian() {
+		let data = Data([0x4D, 0x4D, 0x00, 0x2A])
+		XCTAssertEqual(ImageFormatDetector.detect(data), .tiff)
+	}
+
+	func testDetectBMP() {
+		let data = Data([0x42, 0x4D, 0x00, 0x00, 0x00, 0x00])
+		XCTAssertEqual(ImageFormatDetector.detect(data), .bmp)
+	}
+
+	// MARK: - Convertible Formats
+
+	func testDetectHEIC() {
+		var data = Data([0x00, 0x00, 0x00, 0x18])
+		data.append("ftypheic".data(using: .ascii)!)
+		data.append(contentsOf: [0x00, 0x00, 0x00, 0x00])
+		XCTAssertEqual(ImageFormatDetector.detect(data), .heic)
+	}
+
+	func testDetectHEIF_mif1() {
+		var data = Data([0x00, 0x00, 0x00, 0x18])
+		data.append("ftypmif1".data(using: .ascii)!)
+		data.append(contentsOf: [0x00, 0x00, 0x00, 0x00])
+		XCTAssertEqual(ImageFormatDetector.detect(data), .heic)
+	}
+
+	func testDetectAVIF() {
+		var data = Data([0x00, 0x00, 0x00, 0x18])
+		data.append("ftypavif".data(using: .ascii)!)
+		data.append(contentsOf: [0x00, 0x00, 0x00, 0x00])
+		XCTAssertEqual(ImageFormatDetector.detect(data), .avif)
+	}
+
+	func testDetectAVIF_avis() {
+		var data = Data([0x00, 0x00, 0x00, 0x18])
+		data.append("ftypavis".data(using: .ascii)!)
+		data.append(contentsOf: [0x00, 0x00, 0x00, 0x00])
+		XCTAssertEqual(ImageFormatDetector.detect(data), .avif)
+	}
+
+	func testDetectJXL_Codestream() {
+		let data = Data([0xFF, 0x0A, 0x00, 0x00])
+		XCTAssertEqual(ImageFormatDetector.detect(data), .jxl)
+	}
+
+	func testDetectJXL_Container() {
+		let data = Data([0x00, 0x00, 0x00, 0x0C, 0x4A, 0x58, 0x4C, 0x20, 0x0D, 0x0A, 0x87, 0x0A])
+		XCTAssertEqual(ImageFormatDetector.detect(data), .jxl)
+	}
+
+	// MARK: - Edge Cases
+
+	func testDetectUnknown_RandomBytes() {
+		let data = Data([0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE])
+		XCTAssertEqual(ImageFormatDetector.detect(data), .unknown)
+	}
+
+	func testDetectUnknown_EmptyData() {
+		let data = Data()
+		XCTAssertEqual(ImageFormatDetector.detect(data), .unknown)
+	}
+
+	func testDetectUnknown_SingleByte() {
+		let data = Data([0xFF])
+		XCTAssertEqual(ImageFormatDetector.detect(data), .unknown)
+	}
+
+	func testDetectUnknown_TwoBytes_NotJXL() {
+		let data = Data([0xFF, 0x0B])
+		XCTAssertEqual(ImageFormatDetector.detect(data), .unknown)
+	}
+
+	func testDetectWebP_IncompleteRIFF() {
+		let data = Data([0x52, 0x49, 0x46, 0x46, 0x00, 0x00])
+		XCTAssertEqual(ImageFormatDetector.detect(data), .unknown)
+	}
+}

--- a/scripts/init-prereqs.sh
+++ b/scripts/init-prereqs.sh
@@ -16,7 +16,8 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get -qq update
 apt-get install -y \
   curl libatomic1 libicu74 libxml2 gnupg2 \
-  libcurl4 libz-dev libbsd0 tzdata libgd3
+  libcurl4 libz-dev libbsd0 tzdata libgd3 \
+  libheif-examples libjxl-tools
 
 # Postgres client. Make sure to keep the repo in sync with whatever base image you're using.
 curl -sS https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add


### PR DESCRIPTION
## Summary

- **Fixes #52** — Unsupported image uploads (HEIC, AVIF, JXL) no longer crash the server via GD segfault. Magic byte detection identifies the format before touching GD.
- **Addresses #535** — HEIC, AVIF, and JXL uploads are now converted to JPEG server-side via CLI tools (`heif-convert`, `djxl`) before GD processing.
- Unknown formats get a descriptive 400 error instead of a segfault.

## What changed

| File | Change |
|------|--------|
| `Sources/swiftarr/Image/ImageFormatDetector.swift` | New — detects image format from magic bytes (JPEG, PNG, GIF, WebP, TIFF, BMP, HEIC, AVIF, JXL) |
| `Sources/swiftarr/Image/ImageFormatConverter.swift` | New — converts non-GD formats to JPEG via CLI tools with temp files, timeout, cleanup |
| `Sources/swiftarr/Protocols/ImageHandler.swift` | Modified — `loadImageFromData()` now detects format first, routes to GD or converter, falls back to TGA/WBMP trial-parse for obscure formats |
| `scripts/init-prereqs.sh` | Added `libheif-examples libjxl-tools` to Docker runtime apt install |
| `Tests/AppTests/ImageFormatDetectorTests.swift` | 19 unit tests for all format detections + edge cases |
| `Tests/AppTests/ImageFormatConverterTests.swift` | 4 tests (2 error paths, 1 HEIC conversion with skip, 1 temp cleanup) |

## Design decisions

- **CLI tools over native libraries** — `heif-convert` and `djxl` are simpler to add, review, and maintain. All known clients already convert before upload, so this is a safety net — subprocess overhead is fine.
- **Magic bytes replace blind parsing** — Instead of trying all 7 GD parsers and catching errors, we identify the format from header bytes and use the right parser directly. TGA/WBMP fall back to trial-parse (no reliable magic bytes).
- **JPEG quality 95 intermediate** — Conversion output is Q95 because GD re-encodes at Q90 on final export. Two rounds of JPEG, so we keep intermediate quality high.
- **30-second subprocess timeout** — Safety valve for malformed files.

## Test plan

- [x] 19 detector unit tests pass (all formats + edge cases)
- [x] 4 converter unit tests pass (1 skips when `heif-convert` not installed — expected)
- [x] Full project builds clean
- [ ] Docker build with converter packages (needs Ubuntu 24.04 environment)
- [ ] Manual test: upload a HEIC photo via API endpoint
- [ ] Manual test: upload random bytes, verify 400 error