### PR TITLE
fix: Return 409 for duplicate daily theme days instead of 500

### DIFF
--- a/Sources/swiftarr/Controllers/AdminController.swift
+++ b/Sources/swiftarr/Controllers/AdminController.swift
@@ -1,4 +1,5 @@
 import FluentSQL
+import PostgresNIO
 import Vapor
 
 /// The collection of `/api/v3/admin` route endpoints and handler functions related to admin tasks.
@@ -85,7 +86,12 @@ struct AdminController: APIRouteCollection {
 		let filenames = try await processImages(imageArray, usage: .dailyTheme, on: req)
 		let filename = filenames.isEmpty ? nil : filenames[0]
 		let dailyTheme = DailyTheme(title: data.title, info: data.info, image: filename, day: data.cruiseDay)
-		try await dailyTheme.save(on: req.db)
+		do {
+			try await dailyTheme.save(on: req.db)
+		}
+		catch let error as PostgresError where error.code == .uniqueViolation {
+			throw Abort(.conflict, reason: "A daily theme for day \(data.cruiseDay) already exists. Edit the existing theme instead.")
+		}
 		return .created
 	}
 
@@ -109,7 +115,12 @@ struct AdminController: APIRouteCollection {
 		dailyTheme.info = data.info
 		dailyTheme.image = filenames.isEmpty ? nil : filenames[0]
 		dailyTheme.cruiseDay = data.cruiseDay
-		try await dailyTheme.save(on: req.db)
+		do {
+			try await dailyTheme.save(on: req.db)
+		}
+		catch let error as PostgresError where error.code == .uniqueViolation {
+			throw Abort(.conflict, reason: "A daily theme for day \(data.cruiseDay) already exists.")
+		}
 		return .created
 	}
 

--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -258,7 +258,7 @@ public struct CurrentUserData: Content {
 
 /// Used to return the day's theme.
 ///
-/// Returned by: `GET /api/v3/notifications/dailythemes`
+/// Returned by: `GET /api/v3/notification/dailythemes`
 ///
 public struct DailyThemeData: Content {
 	/// The theme's ID Probably only useful for admins in order to edit or delete themes.


### PR DESCRIPTION
## Summary

- Catch `PostgresError.uniqueViolation` on daily theme create and edit endpoints, returning a **409 Conflict** with a descriptive message instead of an unhandled **500 Internal Server Error**
- Fix endpoint typo in `DailyThemeData` doc comment: `notifications` → `notification`

Fixes #482

## Changes

**`Sources/swiftarr/Controllers/AdminController.swift`**
- `addDailyThemeHandler`: wrap `dailyTheme.save()` in do/catch for unique violation → 409
- `editDailyThemeHandler`: same treatment for day changes that collide
- Add `import PostgresNIO` (matches pattern in KaraokeController, BoardgameController)

**`Sources/swiftarr/Controllers/Structs/ControllerStructs.swift`**
- Fix doc comment: `GET /api/v3/notifications/dailythemes` → `GET /api/v3/notification/dailythemes`

## Test plan

- [ ] Create a daily theme for day 1
- [ ] Try to create another theme for day 1 → expect 409 with message
- [ ] Edit an existing theme to a day that's already taken → expect 409
- [ ] Normal create/edit still works → expect 201