### PR TITLE
fix: Small fixes batch — page titles, HTTPS default, cancelled LFG notifications

### DIFF
--- a/Sources/swiftarr/Helpers/Settings.swift
+++ b/Sources/swiftarr/Helpers/Settings.swift
@@ -82,7 +82,7 @@ final class Settings: Encodable, @unchecked Sendable {
 	
 	/// The URL to use when checking for automatic schedule updates. Genearlly a sched.com URL of the form `https://jococruise2024.sched.com/all.ics`
 	/// Should always point to an URL that returns an iCalendar formatted file.
-	@StoredSettingsValue("scheduleUpdateURL", defaultValue: "http://jococruise2025.sched.com/all.ics") var scheduleUpdateURL: String
+	@StoredSettingsValue("scheduleUpdateURL", defaultValue: "https://jococruise2025.sched.com/all.ics") var scheduleUpdateURL: String
 
 	// MARK: Limits
 	/// The maximum number of alt accounts per primary user account.

--- a/Sources/swiftarr/Jobs/EventJobs.swift
+++ b/Sources/swiftarr/Jobs/EventJobs.swift
@@ -140,6 +140,7 @@ public struct UserEventNotificationJob: AsyncScheduledJob {
 		let upcomingFezzes = try await FriendlyFez.query(on: context.application.db)
 			.filter(\.$startTime == filterStartTime)
 			.filter(\.$fezType !~ [.open, .closed])
+			.filter(\.$cancelled == false)
 			.all()
 		for fez in upcomingFezzes {
 			let fezID = try fez.requireID()

--- a/Sources/swiftarr/Site/SiteAdminController.swift
+++ b/Sources/swiftarr/Site/SiteAdminController.swift
@@ -1228,12 +1228,13 @@ struct SiteAdminController: SiteControllerUtils {
 				searchResults: [UserHeader]?,
 				role: String?
 			) throws {
-				trunk = .init(req, title: "Karaoke Managers", tab: .admin)
+				let roleName = UserRoleType(fromString: role)?.label ?? "User Roles"
+				trunk = .init(req, title: roleName, tab: .admin)
 				self.currentMgrs = currentMgrs
 				self.userSearch = searchStr
 				self.searchResults = searchResults
 				self.role = role
-				self.rolename = UserRoleType(fromString: role)?.label ?? "User Roles"
+				self.rolename = roleName
 			}
 		}
 		let ctx = try KaraokeManagersViewContext(

--- a/Sources/swiftarr/Site/SiteUserController.swift
+++ b/Sources/swiftarr/Site/SiteUserController.swift
@@ -591,7 +591,7 @@ struct SiteUserController: SiteControllerUtils {
 			var searchResults: [UserHeader]?
 
 			init(_ req: Request, currentMgrs: [UserHeader], searchStr: String, searchResults: [UserHeader]?) throws {
-				trunk = .init(req, title: "Karaoke Managers", tab: .admin)
+				trunk = .init(req, title: "Shutternauts", tab: .admin)
 				self.currentMgrs = currentMgrs
 				self.userSearch = searchStr
 				self.searchResults = searchResults


### PR DESCRIPTION
## Summary

Three small independent fixes bundled together:

- **Fixes #494** — UserRoles page title showed "Karaoke Managers" regardless of selected role. Now shows the actual role name. Also fixes Shutternauts page showing "Karaoke Managers".
- **Fixes #511** — Default schedule update URL used `http://` — changed to `https://`. Mobile clients can't make non-TLS requests without special entitlements.
- **Fixes #514** — Cancelled LFGs still generated "starting soon" notifications. Added `.filter(\.$cancelled == false)` to the upcoming fez query.

## Changes

| File | Fix |
|------|-----|
| `Sources/swiftarr/Site/SiteAdminController.swift` | Use selected role name as page title (#494) |
| `Sources/swiftarr/Site/SiteUserController.swift` | Use "Shutternauts" as page title (#494) |
| `Sources/swiftarr/Helpers/Settings.swift` | `http://` → `https://` in default sched URL (#511) |
| `Sources/swiftarr/Jobs/EventJobs.swift` | Filter cancelled fezzes from notifications (#514) |

## Test plan

- [ ] Visit `/admin/userroles` — title should show selected role, not "Karaoke Managers"
- [ ] Visit shutternauts page — title should show "Shutternauts"
- [ ] Fresh deploy: verify schedule URL defaults to HTTPS
- [ ] Cancel an LFG, verify no "starting soon" notification fires for it