### PR TITLE
js: allow scrolling elements into view on load

### DIFF
--- a/Sources/swiftarr/Resources/Assets/js/swiftarr.js
+++ b/Sources/swiftarr/Resources/Assets/js/swiftarr.js
@@ -321,6 +321,10 @@ function updateInputFieldCharCounts(inputElement) {
 	}
 }
 
+// scrolls tagged elements into view on first load
+document.querySelector("[data-scroll-into-view]")
+  ?.scrollIntoView({ behavior: "instant", block: "center" });
+
 // Updates a photo card when its file input field changes (mostly, shows the photo selected).
 for (let input of document.querySelectorAll('.image-upload-input')) {
 	let card = input.closest('.card');

--- a/Sources/swiftarr/Resources/Views/Fez/seamailThread.html
+++ b/Sources/swiftarr/Resources/Views/Fez/seamailThread.html
@@ -55,7 +55,7 @@
 					#extend("Fez/fezPost")
 				#endfor
 				#if(showDivider):
-					<hr class="newline">
+					<hr class="newline" data-scroll-into-view>
 				#endif
 				<span id="newposts"></span>
 				#for(fezPost in newPosts):


### PR DESCRIPTION
Hola! I talked to somebody at the farewell party on JoCo 2026, so hi! I was hoping to contribute a few little frontend improvements and wanted to start with something simple: having Seamail messages scroll down to the `new` message indicator on first load. That way on long threads users don't need to scroll all the way down first to see new content.

This PR adds 2 things:
- the capability to add a `data-scroll-into-view` attribute on any element and have that element focused on first load. I'm keeping it simple for now and hardcoding `instant` scroll timing and `center` positioning
- On seamail posts: if we render a `new` post indicator, scroll that element into view on load


I tested this on Safari, FF, and Chrome and all work really well :) I noticed there's a `.newline` `<hr>` in a few templates but I'm not entirely sure how to repro the other cases. Any suggestions on other things to try? Or... what's a fez in this codebase? 

Let me know if y'all have any advice or suggestions! I'm hoping to work on a few more things after this one :)