### PR TITLE
ci+test: run swift test in CI, add pure-helper test coverage (depends on #548)

### DIFF
--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -31,37 +31,6 @@ jobs:
     runs-on: ubuntu-24.04
     container:
       image: swift:6.2-noble
-    services:
-      postgres:
-        image: postgres:14
-        env:
-          POSTGRES_USER: swiftarr
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: swiftarr-test
-        ports:
-          - 5433:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-      redis:
-        image: redis:7
-        ports:
-          - 6380:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-    env:
-      DATABASE_HOSTNAME: postgres
-      DATABASE_PORT: 5432
-      DATABASE_USER: swiftarr
-      DATABASE_PASSWORD: password
-      DATABASE_DB: swiftarr
-      REDIS_HOSTNAME: redis
-      REDIS_PORT: 6379
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -75,4 +44,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-swift-
       - name: Run tests
-        run: swift test --enable-test-discovery
+        # Limited to pure-helper test classes that don't require app/DB spinup.
+        # SettingsTests and ClientControllerTests need a migrated+seeded database
+        # which a pristine CI postgres can't satisfy without infrastructure work
+        # outside the scope of this PR.
+        run: swift test --enable-test-discovery --filter "GeometryTests|ValidatingJSONDecoderTests|CruiseDateTests|ThemeCookieTests"

--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -48,4 +48,4 @@ jobs:
         # SettingsTests and ClientControllerTests need a migrated+seeded database
         # which a pristine CI postgres can't satisfy without infrastructure work
         # outside the scope of this PR.
-        run: swift test --enable-test-discovery --filter "GeometryTests|ValidatingJSONDecoderTests|CruiseDateTests|ThemeCookieTests|CryptoHelperTests|DisabledFeaturesGroupTests|EventParserTests|TimeZoneChangeSetTests|UserStructValidationTests|ContentStructValidationTests|FezAndEventValidationTests|AdminStructValidationTests|DateExtensionTests|SettingsCalendarTests"
+        run: swift test --enable-test-discovery --filter "GeometryTests|ValidatingJSONDecoderTests|CruiseDateTests|ThemeCookieTests|CryptoHelperTests|DisabledFeaturesGroupTests|EventParserTests|TimeZoneChangeSetTests|UserStructValidationTests|ContentStructValidationTests|FezAndEventValidationTests|AdminStructValidationTests|DateExtensionTests|SettingsCalendarTests|ContentFilterableTests"

--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -48,4 +48,4 @@ jobs:
         # SettingsTests and ClientControllerTests need a migrated+seeded database
         # which a pristine CI postgres can't satisfy without infrastructure work
         # outside the scope of this PR.
-        run: swift test --enable-test-discovery --filter "GeometryTests|ValidatingJSONDecoderTests|CruiseDateTests|ThemeCookieTests|CryptoHelperTests|DisabledFeaturesGroupTests|EventParserTests|TimeZoneChangeSetTests"
+        run: swift test --enable-test-discovery --filter "GeometryTests|ValidatingJSONDecoderTests|CruiseDateTests|ThemeCookieTests|CryptoHelperTests|DisabledFeaturesGroupTests|EventParserTests|TimeZoneChangeSetTests|UserStructValidationTests"

--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -48,4 +48,4 @@ jobs:
         # SettingsTests and ClientControllerTests need a migrated+seeded database
         # which a pristine CI postgres can't satisfy without infrastructure work
         # outside the scope of this PR.
-        run: swift test --enable-test-discovery --filter "GeometryTests|ValidatingJSONDecoderTests|CruiseDateTests|ThemeCookieTests"
+        run: swift test --enable-test-discovery --filter "GeometryTests|ValidatingJSONDecoderTests|CruiseDateTests|ThemeCookieTests|CryptoHelperTests|DisabledFeaturesGroupTests"

--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -48,4 +48,4 @@ jobs:
         # SettingsTests and ClientControllerTests need a migrated+seeded database
         # which a pristine CI postgres can't satisfy without infrastructure work
         # outside the scope of this PR.
-        run: swift test --enable-test-discovery --filter "GeometryTests|ValidatingJSONDecoderTests|CruiseDateTests|ThemeCookieTests|CryptoHelperTests|DisabledFeaturesGroupTests"
+        run: swift test --enable-test-discovery --filter "GeometryTests|ValidatingJSONDecoderTests|CruiseDateTests|ThemeCookieTests|CryptoHelperTests|DisabledFeaturesGroupTests|EventParserTests|TimeZoneChangeSetTests"

--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -26,3 +26,53 @@ jobs:
         run: scripts/stack.sh -e production logs web
       - name: Test For Health
         run: .github/workflows/check_health.sh -e production
+
+  Test:
+    runs-on: ubuntu-24.04
+    container:
+      image: swift:6.2-noble
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: swiftarr
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: swiftarr
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7
+        ports:
+          - 6380:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_HOSTNAME: postgres
+      DATABASE_PORT: 5432
+      DATABASE_USER: swiftarr
+      DATABASE_PASSWORD: password
+      DATABASE_DB: swiftarr
+      REDIS_HOSTNAME: redis
+      REDIS_PORT: 6379
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install image system libraries
+        run: apt-get update && apt-get install -y libgd-dev libvips-dev
+      - name: Restore SwiftPM cache
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: ${{ runner.os }}-swift-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swift-
+      - name: Run tests
+        run: swift test --enable-test-discovery

--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -48,4 +48,4 @@ jobs:
         # SettingsTests and ClientControllerTests need a migrated+seeded database
         # which a pristine CI postgres can't satisfy without infrastructure work
         # outside the scope of this PR.
-        run: swift test --enable-test-discovery --filter "GeometryTests|ValidatingJSONDecoderTests|CruiseDateTests|ThemeCookieTests|CryptoHelperTests|DisabledFeaturesGroupTests|EventParserTests|TimeZoneChangeSetTests|UserStructValidationTests"
+        run: swift test --enable-test-discovery --filter "GeometryTests|ValidatingJSONDecoderTests|CruiseDateTests|ThemeCookieTests|CryptoHelperTests|DisabledFeaturesGroupTests|EventParserTests|TimeZoneChangeSetTests|UserStructValidationTests|ContentStructValidationTests"

--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -37,7 +37,7 @@ jobs:
         env:
           POSTGRES_USER: swiftarr
           POSTGRES_PASSWORD: password
-          POSTGRES_DB: swiftarr
+          POSTGRES_DB: swiftarr-test
         ports:
           - 5433:5432
         options: >-

--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -48,4 +48,4 @@ jobs:
         # SettingsTests and ClientControllerTests need a migrated+seeded database
         # which a pristine CI postgres can't satisfy without infrastructure work
         # outside the scope of this PR.
-        run: swift test --enable-test-discovery --filter "GeometryTests|ValidatingJSONDecoderTests|CruiseDateTests|ThemeCookieTests|CryptoHelperTests|DisabledFeaturesGroupTests|EventParserTests|TimeZoneChangeSetTests|UserStructValidationTests|ContentStructValidationTests"
+        run: swift test --enable-test-discovery --filter "GeometryTests|ValidatingJSONDecoderTests|CruiseDateTests|ThemeCookieTests|CryptoHelperTests|DisabledFeaturesGroupTests|EventParserTests|TimeZoneChangeSetTests|UserStructValidationTests|ContentStructValidationTests|FezAndEventValidationTests"

--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -48,4 +48,4 @@ jobs:
         # SettingsTests and ClientControllerTests need a migrated+seeded database
         # which a pristine CI postgres can't satisfy without infrastructure work
         # outside the scope of this PR.
-        run: swift test --enable-test-discovery --filter "GeometryTests|ValidatingJSONDecoderTests|CruiseDateTests|ThemeCookieTests|CryptoHelperTests|DisabledFeaturesGroupTests|EventParserTests|TimeZoneChangeSetTests|UserStructValidationTests|ContentStructValidationTests|FezAndEventValidationTests"
+        run: swift test --enable-test-discovery --filter "GeometryTests|ValidatingJSONDecoderTests|CruiseDateTests|ThemeCookieTests|CryptoHelperTests|DisabledFeaturesGroupTests|EventParserTests|TimeZoneChangeSetTests|UserStructValidationTests|ContentStructValidationTests|FezAndEventValidationTests|AdminStructValidationTests|DateExtensionTests|SettingsCalendarTests"

--- a/Tests/AppTests/AdminStructValidationTests.swift
+++ b/Tests/AppTests/AdminStructValidationTests.swift
@@ -1,0 +1,66 @@
+import XCTVapor
+@testable import swiftarr
+
+class AdminStructValidationTests: XCTestCase {
+
+	private let decoder = ValidatingJSONDecoder()
+
+	private func validationErrors<T: Decodable>(_ type: T.Type, _ json: String) throws -> [String] {
+		let data = json.data(using: .utf8)!
+		let result = try decoder.validate(type, from: data)
+		return result?.validationFailures.map { $0.errorString } ?? []
+	}
+
+	private func iso8601ms(_ date: Date) -> String {
+		ISO8601DateFormatter([.withInternetDateTime, .withFractionalSeconds]).string(from: date)
+	}
+
+	// MARK: - AnnouncementCreateData
+
+	func testAnnouncement_Valid() throws {
+		let future = iso8601ms(Date().addingTimeInterval(3600))
+		let json = #"{"text":"hello","displayUntil":"\#(future)"}"#
+		XCTAssertEqual(try validationErrors(AnnouncementCreateData.self, json), [])
+	}
+
+	func testAnnouncement_TextEmpty() throws {
+		let future = iso8601ms(Date().addingTimeInterval(3600))
+		let json = #"{"text":"","displayUntil":"\#(future)"}"#
+		let errs = try validationErrors(AnnouncementCreateData.self, json)
+		XCTAssertTrue(errs.contains("Text cannot be empty"), "errs=\(errs)")
+	}
+
+	func testAnnouncement_TextTooLong() throws {
+		let long = String(repeating: "a", count: 2000)
+		let future = iso8601ms(Date().addingTimeInterval(3600))
+		let json = #"{"text":"\#(long)","displayUntil":"\#(future)"}"#
+		let errs = try validationErrors(AnnouncementCreateData.self, json)
+		XCTAssertTrue(errs.contains("Announcement text has a 2000 char limit"), "errs=\(errs)")
+	}
+
+	func testAnnouncement_DisplayUntilInPast_Fails() throws {
+		let past = iso8601ms(Date().addingTimeInterval(-3600))
+		let json = #"{"text":"hello","displayUntil":"\#(past)"}"#
+		let errs = try validationErrors(AnnouncementCreateData.self, json)
+		XCTAssertTrue(errs.contains("Announcement DisplayUntil date must be in the future."), "errs=\(errs)")
+	}
+
+	// MARK: - HuntCreateData
+
+	func testHunt_Valid_OnePuzzle() throws {
+		let json = #"""
+		{
+			"title":"Hunt",
+			"description":"desc",
+			"puzzles":[{"title":"P1","body":"clue","answer":"42","hints":{}}]
+		}
+		"""#
+		XCTAssertEqual(try validationErrors(HuntCreateData.self, json), [])
+	}
+
+	func testHunt_NoPuzzles_Fails() throws {
+		let json = #"{"title":"Hunt","description":"desc","puzzles":[]}"#
+		let errs = try validationErrors(HuntCreateData.self, json)
+		XCTAssertTrue(errs.contains("Puzzles cannot be empty"), "errs=\(errs)")
+	}
+}

--- a/Tests/AppTests/ContentFilterableTests.swift
+++ b/Tests/AppTests/ContentFilterableTests.swift
@@ -1,0 +1,129 @@
+import XCTVapor
+@testable import swiftarr
+
+class ContentFilterableTests: XCTestCase {
+
+	// Minimal ContentFilterable conformance for testing.
+	private struct TestContent: ContentFilterable {
+		let strings: [String]
+		init(_ strings: String...) { self.strings = strings }
+		func contentTextStrings() -> [String] { strings }
+	}
+
+	// MARK: - buildCleanWordsArray
+
+	func testBuildCleanWordsArray_LowercasesAndStripsPunctuation() {
+		let result = TestContent.buildCleanWordsArray("Hello, World!")
+		XCTAssertEqual(result, ["hello", "world"])
+	}
+
+	func testBuildCleanWordsArray_DropsDigitsAndSymbols() {
+		// Filter keeps only letters and whitespace, so "abc123 xyz" becomes "abc xyz".
+		let result = TestContent.buildCleanWordsArray("abc123 xyz")
+		XCTAssertEqual(result, ["abc", "xyz"])
+	}
+
+	func testBuildCleanWordsArray_Deduplicates() {
+		let result = TestContent.buildCleanWordsArray("the the THE")
+		XCTAssertEqual(result, ["the"])
+	}
+
+	func testBuildCleanWordsArray_EmptyString_ReturnsEmptySet() {
+		XCTAssertEqual(TestContent.buildCleanWordsArray(""), [])
+	}
+
+	// MARK: - getMentionsSet
+
+	func testGetMentionsSet_FindsSingleMention() {
+		XCTAssertEqual(TestContent.getMentionsSet(for: "hi @skyler"), ["skyler"])
+	}
+
+	func testGetMentionsSet_FindsMultipleMentions() {
+		XCTAssertEqual(
+			TestContent.getMentionsSet(for: "@heidi likes @sam"),
+			["heidi", "sam"]
+		)
+	}
+
+	func testGetMentionsSet_ExcludesTrailingPunctuation() {
+		// Period is a valid username separator inside, but trailing period at the end
+		// of a sentence should not be part of the captured username.
+		XCTAssertEqual(TestContent.getMentionsSet(for: "ping @sam."), ["sam"])
+	}
+
+	func testGetMentionsSet_AllowsSeparatorInsideUsername() {
+		XCTAssertEqual(TestContent.getMentionsSet(for: "@sky.ler is here"), ["sky.ler"])
+	}
+
+	func testGetMentionsSet_EmptyOnNoAtSign() {
+		XCTAssertEqual(TestContent.getMentionsSet(for: "no mentions here"), [])
+	}
+
+	func testGetMentionsSet_RequiresWhitespaceOrStartBeforeAt() {
+		// "foo@bar" should NOT yield 'bar' — the @ must be preceded by start-of-string or whitespace.
+		XCTAssertEqual(TestContent.getMentionsSet(for: "email foo@bar.com"), [])
+	}
+
+	// MARK: - getHashtags
+
+	func testGetHashtags_FindsSimpleHashtag() {
+		XCTAssertEqual(TestContent("loving #cribbage today").getHashtags(), ["cribbage"])
+	}
+
+	func testGetHashtags_RequiresAtLeastTwoCharsAfterHash() {
+		// "#a" is too short (total of 2 chars including #); "#ab" is exactly the minimum.
+		XCTAssertEqual(TestContent("#a #ab").getHashtags(), ["ab"])
+	}
+
+	func testGetHashtags_DropsTrailingPunctuation() {
+		XCTAssertEqual(TestContent("#cribbage!").getHashtags(), ["cribbage"])
+	}
+
+	func testGetHashtags_IgnoresEmbeddedHash() {
+		// '#' must be at the start of a whitespace-delimited word.
+		XCTAssertEqual(TestContent("not a #hashtag is foo#bar").getHashtags(), ["hashtag"])
+	}
+
+	func testGetHashtags_RejectsHashtagOver50Chars() {
+		let long = "#" + String(repeating: "a", count: 50) // total 51 chars → over the 50-char cap
+		XCTAssertEqual(TestContent(long).getHashtags(), [])
+	}
+
+	// MARK: - containsMutewords
+
+	func testContainsMutewords_TrueWhenWordPresent() {
+		let content = TestContent("watch out for spoilers ahead")
+		XCTAssertTrue(content.containsMutewords(using: ["spoiler"]))
+	}
+
+	func testContainsMutewords_CaseInsensitive() {
+		let content = TestContent("Watch out for SPOILERS")
+		XCTAssertTrue(content.containsMutewords(using: ["spoiler"]))
+	}
+
+	func testContainsMutewords_FalseWhenNoMatch() {
+		let content = TestContent("just a normal post")
+		XCTAssertFalse(content.containsMutewords(using: ["spoiler", "ending"]))
+	}
+
+	func testContainsMutewords_EmptyMutewords_ReturnsFalse() {
+		XCTAssertFalse(TestContent("anything").containsMutewords(using: []))
+	}
+
+	// MARK: - filterOutStrings
+
+	func testFilterOutStrings_NilWords_ReturnsSelf() {
+		let content = TestContent("anything goes here")
+		XCTAssertNotNil(content.filterOutStrings(using: nil))
+	}
+
+	func testFilterOutStrings_NoMatch_ReturnsSelf() {
+		let content = TestContent("anything goes here")
+		XCTAssertNotNil(content.filterOutStrings(using: ["spoiler"]))
+	}
+
+	func testFilterOutStrings_HasMatch_ReturnsNil() {
+		let content = TestContent("contains a spoiler")
+		XCTAssertNil(content.filterOutStrings(using: ["spoiler"]))
+	}
+}

--- a/Tests/AppTests/ContentStructValidationTests.swift
+++ b/Tests/AppTests/ContentStructValidationTests.swift
@@ -1,0 +1,100 @@
+import XCTVapor
+@testable import swiftarr
+
+// Tests for the RCFValidatable conformances on content-creation request structs:
+// ForumCreateData, NoteCreateData, PostContentData.
+class ContentStructValidationTests: XCTestCase {
+
+	private let decoder = ValidatingJSONDecoder()
+
+	private func validationErrors<T: Decodable>(_ type: T.Type, _ json: String) throws -> [String] {
+		let data = json.data(using: .utf8)!
+		let result = try decoder.validate(type, from: data)
+		return result?.validationFailures.map { $0.errorString } ?? []
+	}
+
+	private let validFirstPost = #"{"text":"hello","images":[],"postAsModerator":false,"postAsTwitarrTeam":false}"#
+
+	// MARK: - ForumCreateData
+
+	func testForumCreate_Valid() throws {
+		let json = #"{"title":"My Forum","firstPost":\#(validFirstPost)}"#
+		XCTAssertEqual(try validationErrors(ForumCreateData.self, json), [])
+	}
+
+	func testForumCreate_TitleTooShort() throws {
+		let json = #"{"title":"x","firstPost":\#(validFirstPost)}"#
+		let errs = try validationErrors(ForumCreateData.self, json)
+		XCTAssertTrue(errs.contains("forum title has a 2 character minimum"), "errs=\(errs)")
+	}
+
+	func testForumCreate_TitleTooLong() throws {
+		let title = String(repeating: "a", count: 101)
+		let json = #"{"title":"\#(title)","firstPost":\#(validFirstPost)}"#
+		let errs = try validationErrors(ForumCreateData.self, json)
+		XCTAssertTrue(errs.contains("forum title has a 100 character limit"), "errs=\(errs)")
+	}
+
+	// MARK: - NoteCreateData
+
+	func testNoteCreate_Valid() throws {
+		XCTAssertEqual(try validationErrors(NoteCreateData.self, #"{"note":"hi"}"#), [])
+	}
+
+	func testNoteCreate_Empty() throws {
+		let errs = try validationErrors(NoteCreateData.self, #"{"note":""}"#)
+		XCTAssertTrue(errs.contains("post text cannot be empty."), "errs=\(errs)")
+	}
+
+	func testNoteCreate_TooLong() throws {
+		let long = String(repeating: "a", count: 1000)
+		let errs = try validationErrors(NoteCreateData.self, #"{"note":"\#(long)"}"#)
+		XCTAssertTrue(errs.contains(where: { $0.contains("over the 1000 character limit") }), "errs=\(errs)")
+	}
+
+	func testNoteCreate_TooManyLines() throws {
+		// 26 lines (25 newlines) — over the 25-line limit. Use JSON-escaped \n.
+		let lines = (1...26).map { "L\($0)" }.joined(separator: "\\n")
+		let errs = try validationErrors(NoteCreateData.self, #"{"note":"\#(lines)"}"#)
+		XCTAssertTrue(errs.contains("posts are limited to 25 lines of text"), "errs=\(errs)")
+	}
+
+	func testNoteCreate_CRLFNormalizedBeforeLineCount() throws {
+		// Spec: \r\n is normalized to \r before counting lines, so this is 25 lines, not 50.
+		let segments = (1...25).map { "L\($0)" }.joined(separator: "\\r\\n")
+		let errs = try validationErrors(NoteCreateData.self, #"{"note":"\#(segments)"}"#)
+		// Should NOT trip the 25-line limit.
+		XCTAssertFalse(errs.contains("posts are limited to 25 lines of text"), "errs=\(errs)")
+	}
+
+	// MARK: - PostContentData
+
+	func testPostContent_Valid() throws {
+		let errs = try validationErrors(PostContentData.self, #"{"text":"hello","images":[],"postAsModerator":false,"postAsTwitarrTeam":false}"#)
+		XCTAssertEqual(errs, [])
+	}
+
+	func testPostContent_Empty() throws {
+		let errs = try validationErrors(PostContentData.self, #"{"text":"","images":[],"postAsModerator":false,"postAsTwitarrTeam":false}"#)
+		XCTAssertTrue(errs.contains("post text cannot be empty."), "errs=\(errs)")
+	}
+
+	func testPostContent_TextTooLong() throws {
+		let long = String(repeating: "a", count: 2048)
+		let errs = try validationErrors(PostContentData.self, #"{"text":"\#(long)","images":[],"postAsModerator":false,"postAsTwitarrTeam":false}"#)
+		XCTAssertTrue(errs.contains(where: { $0.contains("over the 2048 character limit") }), "errs=\(errs)")
+	}
+
+	func testPostContent_TooManyImages() throws {
+		let nineImages = (1...9).map { _ in #"{"filename":null,"image":null}"# }.joined(separator: ",")
+		let json = #"{"text":"hi","images":[\#(nineImages)],"postAsModerator":false,"postAsTwitarrTeam":false}"#
+		let errs = try validationErrors(PostContentData.self, json)
+		XCTAssertTrue(errs.contains("posts are limited to 8 image attachments"), "errs=\(errs)")
+	}
+
+	func testPostContent_TooManyLines() throws {
+		let lines = (1...26).map { "L\($0)" }.joined(separator: "\\n")
+		let errs = try validationErrors(PostContentData.self, #"{"text":"\#(lines)","images":[],"postAsModerator":false,"postAsTwitarrTeam":false}"#)
+		XCTAssertTrue(errs.contains("posts are limited to 25 lines of text"), "errs=\(errs)")
+	}
+}

--- a/Tests/AppTests/CruiseDateTests.swift
+++ b/Tests/AppTests/CruiseDateTests.swift
@@ -76,4 +76,29 @@ class CruiseDateTests: XCTestCase {
 	func testFixtureSetUpAppliesCruiseStart() {
 		XCTAssertEqual(Settings.shared.cruiseStartDate(), embarkationDate)
 	}
+
+	// MARK: - Mid-week projection (non-DST input → non-DST cruise day)
+
+	func testGetDateInCruiseWeek_WednesdayInput_ProjectsToWednesdayInCruiseWeek() {
+		// 2024-08-14 is a Wednesday (weekday=4) outside the cruise window.
+		// Cruise embarks Saturday 2024-03-09; the Wednesday during the cruise is 2024-03-13.
+		let testDate = ISO8601DateFormatter().date(from: "2024-08-14T16:00:00Z")!
+		let result = Settings.shared.getDateInCruiseWeek(from: testDate)
+		let cal = Calendar(identifier: .gregorian)
+		var comps = cal.dateComponents(in: TimeZone(identifier: "America/New_York")!, from: result)
+		// Should land in the 2024-03-09..03-16 window, on a Wednesday.
+		XCTAssertEqual(comps.year, 2024)
+		XCTAssertEqual(comps.month, 3)
+		XCTAssertEqual(comps.day, 13)
+	}
+
+	// MARK: - getCurrentFilterDate strips sub-second precision
+
+	func testGetCurrentFilterDate_StripsSubsecondPrecision() {
+		let dateWithFractional = Date(timeIntervalSince1970: 1_710_000_000.5678)
+		let stripped = Settings.shared.getCurrentFilterDate(from: dateWithFractional)
+		// Sub-second portion must be zero — this is the function's whole reason for existing.
+		let nanos = Calendar(identifier: .gregorian).component(.nanosecond, from: stripped)
+		XCTAssertEqual(nanos, 0)
+	}
 }

--- a/Tests/AppTests/CruiseDateTests.swift
+++ b/Tests/AppTests/CruiseDateTests.swift
@@ -1,0 +1,79 @@
+import XCTVapor
+@testable import swiftarr
+
+// Pure tests for Settings.shared.getDateInCruiseWeek that don't require app/DB spinup.
+// They override Settings.shared.cruiseStartDateComponents in setUp so the fixture
+// date is stable regardless of what the in-source default happens to be.
+class CruiseDateTests: XCTestCase {
+
+	// Fixture cruise: embarks 2024-03-09 (Saturday), 8 days, departs from US Eastern timezone.
+	// Mid-cruise date 2024-03-12 06:00 UTC is during DST (UTC-4).
+	private let fixtureStartComponents = DateComponents(year: 2024, month: 3, day: 9)
+	private let embarkationDate = ISO8601DateFormatter().date(from: "2024-03-09T05:00:00Z")!
+
+	private var savedComponents: DateComponents!
+	private var savedLength: Int!
+	private var savedDayOfWeek: Int!
+
+	override func setUp() {
+		super.setUp()
+		savedComponents = Settings.shared.cruiseStartDateComponents
+		savedLength = Settings.shared.cruiseLengthInDays
+		savedDayOfWeek = Settings.shared.cruiseStartDayOfWeek
+		Settings.shared.cruiseStartDateComponents = fixtureStartComponents
+		Settings.shared.cruiseLengthInDays = 8
+		// Calendar weekday: Sunday=1, Saturday=7. The fixture cruise embarks on a Saturday,
+		// so this must align with cruiseStartDateComponents above.
+		Settings.shared.cruiseStartDayOfWeek = 7
+	}
+
+	override func tearDown() {
+		Settings.shared.cruiseStartDateComponents = savedComponents
+		Settings.shared.cruiseLengthInDays = savedLength
+		Settings.shared.cruiseStartDayOfWeek = savedDayOfWeek
+		super.tearDown()
+	}
+
+	// MARK: - Within the cruise week — date returns unchanged
+
+	func testGetDateInCruiseWeek_WithinCruiseWeek_ReturnsSameDate() {
+		let testDate = embarkationDate
+		let result = Settings.shared.getDateInCruiseWeek(from: testDate)
+		XCTAssertEqual(result, testDate)
+	}
+
+	// MARK: - Date in the past — projects forward into cruise week
+
+	func testGetDateInCruiseWeek_PastDate_ProjectsIntoCruiseWeek() {
+		// 2023-07-08 is a Saturday well before the fixture cruise.
+		let testDate = ISO8601DateFormatter().date(from: "2023-07-08T04:00:00Z")!
+		let result = Settings.shared.getDateInCruiseWeek(from: testDate)
+		XCTAssertEqual(result, embarkationDate)
+	}
+
+	// MARK: - Date in the future — projects back into cruise week
+
+	func testGetDateInCruiseWeek_FutureDate_ProjectsIntoCruiseWeek() {
+		// 2025-01-11 is a Saturday well after the fixture cruise.
+		// Outside DST so "midnight Eastern" is UTC-5 == 05:00:00Z.
+		let testDate = ISO8601DateFormatter().date(from: "2025-01-11T05:00:00Z")!
+		let result = Settings.shared.getDateInCruiseWeek(from: testDate)
+		XCTAssertEqual(result, embarkationDate)
+	}
+
+	// MARK: - DST boundary
+
+	func testGetDateInCruiseWeek_DSTSundayWithinCruise_ReturnsSameDate() {
+		// 2024-03-10 is the DST transition Sunday during the fixture cruise.
+		// "11:00 UTC" is 07:00 EDT (UTC-4) — midnight on the cruise day shifted by 7h.
+		let dstDate = ISO8601DateFormatter().date(from: "2024-03-10T11:00:00Z")!
+		let result = Settings.shared.getDateInCruiseWeek(from: dstDate)
+		XCTAssertEqual(result, dstDate)
+	}
+
+	// MARK: - Sanity check that fixture took effect
+
+	func testFixtureSetUpAppliesCruiseStart() {
+		XCTAssertEqual(Settings.shared.cruiseStartDate(), embarkationDate)
+	}
+}

--- a/Tests/AppTests/CryptoHelperTests.swift
+++ b/Tests/AppTests/CryptoHelperTests.swift
@@ -1,0 +1,47 @@
+import XCTVapor
+@testable import swiftarr
+
+class CryptoHelperTests: XCTestCase {
+
+	// Known SHA-256 outputs from RFC 6234 / NIST examples.
+
+	func testSHA256_EmptyString() {
+		XCTAssertEqual(
+			CryptoHelper.sha256Hash(of: ""),
+			"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+		)
+	}
+
+	func testSHA256_AbcString() {
+		XCTAssertEqual(
+			CryptoHelper.sha256Hash(of: "abc"),
+			"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+		)
+	}
+
+	func testSHA256_LongerString() {
+		XCTAssertEqual(
+			CryptoHelper.sha256Hash(of: "The quick brown fox jumps over the lazy dog"),
+			"d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592"
+		)
+	}
+
+	func testSHA256_Deterministic() {
+		let a = CryptoHelper.sha256Hash(of: "swiftarr")
+		let b = CryptoHelper.sha256Hash(of: "swiftarr")
+		XCTAssertEqual(a, b)
+	}
+
+	func testSHA256_DifferentInputsProduceDifferentHashes() {
+		let a = CryptoHelper.sha256Hash(of: "swiftarr")
+		let b = CryptoHelper.sha256Hash(of: "Swiftarr")
+		XCTAssertNotEqual(a, b)
+	}
+
+	func testSHA256_OutputIsLowercaseHex64Chars() {
+		let hash = CryptoHelper.sha256Hash(of: "anything")
+		XCTAssertEqual(hash.count, 64)
+		XCTAssertEqual(hash, hash.lowercased())
+		XCTAssertNil(hash.rangeOfCharacter(from: CharacterSet(charactersIn: "0123456789abcdef").inverted))
+	}
+}

--- a/Tests/AppTests/DateExtensionTests.swift
+++ b/Tests/AppTests/DateExtensionTests.swift
@@ -1,0 +1,43 @@
+import XCTVapor
+@testable import swiftarr
+
+class DateExtensionTests: XCTestCase {
+
+	// MARK: - Date.iso8601ms encoding
+
+	func testDateIso8601ms_IncludesFractionalSeconds() {
+		let date = Date(timeIntervalSince1970: 1_710_000_000.123)
+		let str = date.iso8601ms
+		// The "ms" formatter must include a "." with fractional seconds.
+		XCTAssertTrue(str.contains("."), "got \(str)")
+		XCTAssertTrue(str.hasSuffix("Z"), "got \(str)")
+	}
+
+	// MARK: - String.iso8601ms parsing
+
+	func testStringIso8601ms_ParsesValidString() {
+		let parsed = "2024-03-12T15:00:00.000Z".iso8601ms
+		XCTAssertNotNil(parsed)
+	}
+
+	func testStringIso8601ms_RejectsStringWithoutMilliseconds() {
+		// Strict format — without fractional seconds, parser returns nil.
+		let parsed = "2024-03-12T15:00:00Z".iso8601ms
+		XCTAssertNil(parsed)
+	}
+
+	func testStringIso8601ms_RejectsGarbage() {
+		XCTAssertNil("not a date".iso8601ms)
+	}
+
+	// MARK: - Round-trip
+
+	func testIso8601ms_RoundTrip() {
+		let original = Date(timeIntervalSince1970: 1_710_000_000.123)
+		let str = original.iso8601ms
+		let parsed = str.iso8601ms
+		XCTAssertNotNil(parsed)
+		// Equality at millisecond precision.
+		XCTAssertEqual(parsed!.timeIntervalSince1970, original.timeIntervalSince1970, accuracy: 0.001)
+	}
+}

--- a/Tests/AppTests/DisabledFeaturesGroupTests.swift
+++ b/Tests/AppTests/DisabledFeaturesGroupTests.swift
@@ -1,0 +1,75 @@
+import XCTVapor
+@testable import swiftarr
+
+class DisabledFeaturesGroupTests: XCTestCase {
+
+	// MARK: - isFeatureDisabled
+
+	func testIsFeatureDisabled_EmptyGroup_ReturnsFalse() {
+		let group = DisabledFeaturesGroup(value: [:])
+		XCTAssertFalse(group.isFeatureDisabled(.forums))
+		XCTAssertFalse(group.isFeatureDisabled(.forums, inApp: .swiftarr))
+	}
+
+	func testIsFeatureDisabled_FeatureDisabledForAllApps_ReturnsTrue() {
+		let group = DisabledFeaturesGroup(value: [.all: [.forums]])
+		XCTAssertTrue(group.isFeatureDisabled(.forums))
+		XCTAssertTrue(group.isFeatureDisabled(.forums, inApp: .swiftarr))
+	}
+
+	func testIsFeatureDisabled_AllFeaturesDisabledForAllApps_ReturnsTrue() {
+		let group = DisabledFeaturesGroup(value: [.all: [.all]])
+		XCTAssertTrue(group.isFeatureDisabled(.forums))
+		XCTAssertTrue(group.isFeatureDisabled(.seamail, inApp: .tricordarr))
+	}
+
+	func testIsFeatureDisabled_FeatureDisabledForSpecificApp_ReturnsTrueForThatApp() {
+		let group = DisabledFeaturesGroup(value: [.swiftarr: [.forums]])
+		XCTAssertTrue(group.isFeatureDisabled(.forums, inApp: .swiftarr))
+	}
+
+	func testIsFeatureDisabled_FeatureDisabledForSpecificApp_ReturnsFalseForOtherApp() {
+		let group = DisabledFeaturesGroup(value: [.swiftarr: [.forums]])
+		XCTAssertFalse(group.isFeatureDisabled(.forums, inApp: .tricordarr))
+	}
+
+	func testIsFeatureDisabled_FeatureDisabledForApp_ReturnsFalseWhenNoAppGiven() {
+		// Per-app disables don't apply when the caller didn't specify which app they're asking about.
+		let group = DisabledFeaturesGroup(value: [.swiftarr: [.forums]])
+		XCTAssertFalse(group.isFeatureDisabled(.forums))
+	}
+
+	func testIsFeatureDisabled_AllFeaturesDisabledForSpecificApp_ReturnsTrueForThatApp() {
+		let group = DisabledFeaturesGroup(value: [.swiftarr: [.all]])
+		XCTAssertTrue(group.isFeatureDisabled(.forums, inApp: .swiftarr))
+		XCTAssertTrue(group.isFeatureDisabled(.seamail, inApp: .swiftarr))
+	}
+
+	func testIsFeatureDisabled_DifferentFeatureNotInDisabledList_ReturnsFalse() {
+		let group = DisabledFeaturesGroup(value: [.all: [.forums]])
+		XCTAssertFalse(group.isFeatureDisabled(.seamail))
+	}
+
+	// MARK: - buildDisabledFeatureArray
+
+	func testBuildDisabledFeatureArray_EmptyGroup_ReturnsEmptyArray() {
+		let group = DisabledFeaturesGroup(value: [:])
+		XCTAssertEqual(group.buildDisabledFeatureArray().count, 0)
+	}
+
+	func testBuildDisabledFeatureArray_FlattensAppFeaturePairs() {
+		let group = DisabledFeaturesGroup(value: [
+			.swiftarr: [.forums, .seamail],
+			.tricordarr: [.schedule],
+		])
+		let array = group.buildDisabledFeatureArray()
+		XCTAssertEqual(array.count, 3)
+		// Order is non-deterministic since Set iteration order is unspecified — assert as a set.
+		let pairs = Set(array.map { "\($0.appName.rawValue):\($0.featureName.rawValue)" })
+		XCTAssertEqual(pairs, [
+			"swiftarr:forums",
+			"swiftarr:seamail",
+			"tricordarr:schedule",
+		])
+	}
+}

--- a/Tests/AppTests/EventParserTests.swift
+++ b/Tests/AppTests/EventParserTests.swift
@@ -1,0 +1,45 @@
+import XCTVapor
+@testable import swiftarr
+
+class EventParserTests: XCTestCase {
+
+	private let parser = EventParser()
+
+	// MARK: - unescapedTextValue
+
+	func testUnescapedTextValue_PassesThroughPlainText() {
+		XCTAssertEqual(parser.unescapedTextValue("hello world"), "hello world")
+	}
+
+	func testUnescapedTextValue_DecodesAmpersandEntity() {
+		XCTAssertEqual(parser.unescapedTextValue("Tom &amp; Jerry"), "Tom & Jerry")
+	}
+
+	func testUnescapedTextValue_DecodesEscapedComma() {
+		XCTAssertEqual(parser.unescapedTextValue(#"alpha\,beta"#), "alpha,beta")
+	}
+
+	func testUnescapedTextValue_DecodesEscapedSemicolon() {
+		XCTAssertEqual(parser.unescapedTextValue(#"alpha\;beta"#), "alpha;beta")
+	}
+
+	func testUnescapedTextValue_DecodesLowercaseNewlineEscape() {
+		XCTAssertEqual(parser.unescapedTextValue(#"line1\nline2"#), "line1\nline2")
+	}
+
+	func testUnescapedTextValue_DecodesUppercaseNewlineEscape() {
+		// RFC 5545 allows both \n and \N
+		XCTAssertEqual(parser.unescapedTextValue(#"line1\Nline2"#), "line1\nline2")
+	}
+
+	func testUnescapedTextValue_DecodesEscapedBackslash() {
+		XCTAssertEqual(parser.unescapedTextValue(#"path\\to\\file"#), #"path\to\file"#)
+	}
+
+	func testUnescapedTextValue_HandlesMultipleEscapesInOneString() {
+		XCTAssertEqual(
+			parser.unescapedTextValue(#"Hello\, world\nLine 2 &amp; more"#),
+			"Hello, world\nLine 2 & more"
+		)
+	}
+}

--- a/Tests/AppTests/FezAndEventValidationTests.swift
+++ b/Tests/AppTests/FezAndEventValidationTests.swift
@@ -1,0 +1,161 @@
+import XCTVapor
+@testable import swiftarr
+
+// Tests for FezContentData and PersonalEventContentData validation logic.
+// FezContentData has interesting branching by fezType plus startTime/endTime
+// throw-based 24-hour cap; PersonalEventContentData has a similar 24-hour cap.
+class FezAndEventValidationTests: XCTestCase {
+
+	private let decoder = ValidatingJSONDecoder()
+
+	private func validationErrors<T: Decodable>(_ type: T.Type, _ json: String) throws -> [String] {
+		let data = json.data(using: .utf8)!
+		let result = try decoder.validate(type, from: data)
+		return result?.validationFailures.map { $0.errorString } ?? []
+	}
+
+	// MARK: - FezContentData base fixture
+
+	private func fezJSON(
+		fezType: String = "activity",
+		title: String = "Card games",
+		info: String = "Looking for cribbage partners",
+		location: String? = "Card Room",
+		startTime: String? = nil,
+		endTime: String? = nil
+	) -> String {
+		var fields = [
+			#""fezType":"\#(fezType)""#,
+			#""title":"\#(title)""#,
+			#""info":"\#(info)""#,
+			#""minCapacity":2"#,
+			#""maxCapacity":4"#,
+			#""initialUsers":[]"#,
+		]
+		if let location { fields.append(#""location":"\#(location)""#) }
+		if let startTime { fields.append(#""startTime":"\#(startTime)""#) }
+		if let endTime { fields.append(#""endTime":"\#(endTime)""#) }
+		return "{" + fields.joined(separator: ",") + "}"
+	}
+
+	// MARK: - FezContentData — title bounds (always checked)
+
+	func testFez_TitleTooShort() throws {
+		let errs = try validationErrors(FezContentData.self, fezJSON(title: "x"))
+		XCTAssertTrue(errs.contains("title field has a 2 character minimum"), "errs=\(errs)")
+	}
+
+	func testFez_TitleTooLong() throws {
+		let title = String(repeating: "a", count: 101)
+		let errs = try validationErrors(FezContentData.self, fezJSON(title: title))
+		XCTAssertTrue(errs.contains("title field has a 100 character limit"), "errs=\(errs)")
+	}
+
+	// MARK: - FezContentData — info/location only validated for non-chat types
+
+	func testFez_OpenChatType_SkipsInfoCheck() throws {
+		// 'open' chat type → info not required to be ≥2 chars
+		let errs = try validationErrors(FezContentData.self, fezJSON(fezType: "open", info: "x"))
+		XCTAssertFalse(errs.contains("info field has a 2 character minimum"), "errs=\(errs)")
+	}
+
+	func testFez_ClosedChatType_SkipsInfoCheck() throws {
+		let errs = try validationErrors(FezContentData.self, fezJSON(fezType: "closed", info: ""))
+		XCTAssertFalse(errs.contains("info field has a 2 character minimum"), "errs=\(errs)")
+	}
+
+	func testFez_ActivityType_InfoTooShort() throws {
+		let errs = try validationErrors(FezContentData.self, fezJSON(fezType: "activity", info: "x"))
+		XCTAssertTrue(errs.contains("info field has a 2 character minimum"), "errs=\(errs)")
+	}
+
+	func testFez_ActivityType_LocationTooShort() throws {
+		let errs = try validationErrors(FezContentData.self, fezJSON(fezType: "activity", location: "ab"))
+		XCTAssertTrue(errs.contains("location field has a 3 character minimum"), "errs=\(errs)")
+	}
+
+	func testFez_ActivityType_HappyPath() throws {
+		XCTAssertEqual(try validationErrors(FezContentData.self, fezJSON()), [])
+	}
+
+	// MARK: - FezContentData — startTime/endTime throw paths
+
+	func testFez_StartTimeWithoutEndTime_Throws() {
+		let json = fezJSON(startTime: "2024-03-12T15:00:00.000Z")
+		XCTAssertThrowsError(try validationErrors(FezContentData.self, json))
+	}
+
+	func testFez_EndMoreThan24HoursAfterStart_Throws() {
+		let json = fezJSON(
+			startTime: "2024-03-12T15:00:00.000Z",
+			endTime: "2024-03-13T16:00:00.000Z" // 25h later
+		)
+		XCTAssertThrowsError(try validationErrors(FezContentData.self, json))
+	}
+
+	func testFez_EndExactly24HoursAfterStart_OK() throws {
+		let json = fezJSON(
+			startTime: "2024-03-12T15:00:00.000Z",
+			endTime: "2024-03-13T15:00:00.000Z" // exactly 24h
+		)
+		XCTAssertEqual(try validationErrors(FezContentData.self, json), [])
+	}
+
+	// MARK: - PersonalEventContentData
+
+	private func eventJSON(
+		title: String = "My event",
+		startTime: String = "2024-03-12T15:00:00.000Z",
+		endTime: String = "2024-03-12T16:00:00.000Z"
+	) -> String {
+		return #"{"title":"\#(title)","startTime":"\#(startTime)","endTime":"\#(endTime)","participants":[]}"#
+	}
+
+	func testPersonalEvent_HappyPath() throws {
+		XCTAssertEqual(try validationErrors(PersonalEventContentData.self, eventJSON()), [])
+	}
+
+	func testPersonalEvent_TitleTooShort() throws {
+		let errs = try validationErrors(PersonalEventContentData.self, eventJSON(title: "x"))
+		XCTAssertTrue(errs.contains("title field has a 2 character minimum"), "errs=\(errs)")
+	}
+
+	func testPersonalEvent_TitleTooLong() throws {
+		let title = String(repeating: "a", count: 101)
+		let errs = try validationErrors(PersonalEventContentData.self, eventJSON(title: title))
+		XCTAssertTrue(errs.contains("title field has a 100 character limit"), "errs=\(errs)")
+	}
+
+	func testPersonalEvent_LongerThan24Hours_Throws() {
+		let json = eventJSON(
+			startTime: "2024-03-12T15:00:00.000Z",
+			endTime: "2024-03-13T16:00:00.000Z"
+		)
+		XCTAssertThrowsError(try validationErrors(PersonalEventContentData.self, json))
+	}
+
+	// MARK: - UserRecoveryData
+
+	private func recoveryJSON(username: String = "skyler", recoveryKey: String = "abc123", newPassword: String = "newpass1") -> String {
+		return #"{"username":"\#(username)","recoveryKey":"\#(recoveryKey)","newPassword":"\#(newPassword)"}"#
+	}
+
+	func testRecovery_HappyPath() throws {
+		XCTAssertEqual(try validationErrors(UserRecoveryData.self, recoveryJSON()), [])
+	}
+
+	func testRecovery_RecoveryKeyTooShort() throws {
+		let errs = try validationErrors(UserRecoveryData.self, recoveryJSON(recoveryKey: "abc"))
+		XCTAssertTrue(errs.contains("password/recovery code has a 6 character minimum"), "errs=\(errs)")
+	}
+
+	func testRecovery_NewPasswordTooShort() throws {
+		let errs = try validationErrors(UserRecoveryData.self, recoveryJSON(newPassword: "abc"))
+		XCTAssertTrue(errs.contains("password has a 6 character minimum length"), "errs=\(errs)")
+	}
+
+	func testRecovery_BadUsername_PropagatesUsernameValidations() throws {
+		let errs = try validationErrors(UserRecoveryData.self, recoveryJSON(username: "x"))
+		XCTAssertTrue(errs.contains("username has a 2 character minimum"), "errs=\(errs)")
+	}
+}

--- a/Tests/AppTests/GeometryTests.swift
+++ b/Tests/AppTests/GeometryTests.swift
@@ -1,0 +1,103 @@
+import XCTVapor
+@testable import swiftarr
+
+class GeometryTests: XCTestCase {
+
+	// MARK: - 6-character hex (RRGGBB)
+
+	func testColor_SixCharHex_NoPrefix() throws {
+		let color = try Color(hex: "ff0000")
+		XCTAssertEqual(color.redComponent, 1.0, accuracy: 0.001)
+		XCTAssertEqual(color.greenComponent, 0.0, accuracy: 0.001)
+		XCTAssertEqual(color.blueComponent, 0.0, accuracy: 0.001)
+		XCTAssertEqual(color.alphaComponent, 1.0, accuracy: 0.001)
+	}
+
+	func testColor_SixCharHex_WithHashPrefix() throws {
+		let color = try Color(hex: "#00ff00")
+		XCTAssertEqual(color.redComponent, 0.0, accuracy: 0.001)
+		XCTAssertEqual(color.greenComponent, 1.0, accuracy: 0.001)
+		XCTAssertEqual(color.blueComponent, 0.0, accuracy: 0.001)
+		XCTAssertEqual(color.alphaComponent, 1.0, accuracy: 0.001)
+	}
+
+	// MARK: - 8-character hex with trailing alpha (RRGGBBAA)
+
+	func testColor_EightCharHex_TrailingAlpha() throws {
+		let color = try Color(hex: "ff000080")
+		XCTAssertEqual(color.redComponent, 1.0, accuracy: 0.001)
+		XCTAssertEqual(color.greenComponent, 0.0, accuracy: 0.001)
+		XCTAssertEqual(color.blueComponent, 0.0, accuracy: 0.001)
+		XCTAssertEqual(color.alphaComponent, 128.0 / 255.0, accuracy: 0.001)
+	}
+
+	// MARK: - 8-character hex with leading alpha (AARRGGBB)
+
+	func testColor_EightCharHex_LeadingAlpha() throws {
+		let color = try Color(hex: "80ff0000", leadingAlpha: true)
+		XCTAssertEqual(color.alphaComponent, 128.0 / 255.0, accuracy: 0.001)
+		XCTAssertEqual(color.redComponent, 1.0, accuracy: 0.001)
+		XCTAssertEqual(color.greenComponent, 0.0, accuracy: 0.001)
+		XCTAssertEqual(color.blueComponent, 0.0, accuracy: 0.001)
+	}
+
+	// MARK: - 3-character short hex (RGB → RRGGBB)
+
+	func testColor_ThreeCharShortHex() throws {
+		let color = try Color(hex: "f00")
+		XCTAssertEqual(color.redComponent, 1.0, accuracy: 0.001)
+		XCTAssertEqual(color.greenComponent, 0.0, accuracy: 0.001)
+		XCTAssertEqual(color.blueComponent, 0.0, accuracy: 0.001)
+		XCTAssertEqual(color.alphaComponent, 1.0, accuracy: 0.001)
+	}
+
+	// MARK: - 4-character short hex with trailing alpha (RGBA → RRGGBBAA)
+
+	func testColor_FourCharShortHex_TrailingAlpha() throws {
+		let color = try Color(hex: "f008")
+		XCTAssertEqual(color.redComponent, 1.0, accuracy: 0.001)
+		XCTAssertEqual(color.alphaComponent, Double(0x88) / 255.0, accuracy: 0.001)
+	}
+
+	// MARK: - Invalid input
+
+	func testColor_InvalidLengthThrows() {
+		XCTAssertThrowsError(try Color(hex: "ff")) { error in
+			guard case ImageError.invalidColor = error else {
+				return XCTFail("Expected ImageError.invalidColor, got \(error)")
+			}
+		}
+	}
+
+	func testColor_InvalidCharactersThrow() {
+		XCTAssertThrowsError(try Color(hex: "zzzzzz")) { error in
+			guard case ImageError.invalidColor = error else {
+				return XCTFail("Expected ImageError.invalidColor, got \(error)")
+			}
+		}
+	}
+
+	func testColor_EmptyStringThrows() {
+		XCTAssertThrowsError(try Color(hex: "")) { error in
+			guard case ImageError.invalidColor = error else {
+				return XCTFail("Expected ImageError.invalidColor, got \(error)")
+			}
+		}
+	}
+
+	// MARK: - Boundary values
+
+	func testColor_AllBlack() throws {
+		let color = try Color(hex: "000000")
+		XCTAssertEqual(color.redComponent, 0.0, accuracy: 0.001)
+		XCTAssertEqual(color.greenComponent, 0.0, accuracy: 0.001)
+		XCTAssertEqual(color.blueComponent, 0.0, accuracy: 0.001)
+	}
+
+	func testColor_AllWhite() throws {
+		let color = try Color(hex: "ffffff")
+		XCTAssertEqual(color.redComponent, 1.0, accuracy: 0.001)
+		XCTAssertEqual(color.greenComponent, 1.0, accuracy: 0.001)
+		XCTAssertEqual(color.blueComponent, 1.0, accuracy: 0.001)
+	}
+}

--- a/Tests/AppTests/GeometryTests.swift
+++ b/Tests/AppTests/GeometryTests.swift
@@ -100,4 +100,105 @@ class GeometryTests: XCTestCase {
 		XCTAssertEqual(color.greenComponent, 1.0, accuracy: 0.001)
 		XCTAssertEqual(color.blueComponent, 1.0, accuracy: 0.001)
 	}
+
+	// MARK: - Color int initializer (RGBA layout)
+
+	func testColor_IntInit_RGBA() {
+		// 0xFF000080: R=FF, G=00, B=00, A=80
+		let color = Color(hex: 0xFF000080)
+		XCTAssertEqual(color.redComponent, 1.0, accuracy: 0.001)
+		XCTAssertEqual(color.greenComponent, 0.0, accuracy: 0.001)
+		XCTAssertEqual(color.blueComponent, 0.0, accuracy: 0.001)
+		XCTAssertEqual(color.alphaComponent, 128.0 / 255.0, accuracy: 0.001)
+	}
+
+	func testColor_IntInit_RGBA_Opaque() {
+		// 0x00FF00FF: R=00, G=FF, B=00, A=FF (fully opaque green)
+		let color = Color(hex: 0x00FF00FF)
+		XCTAssertEqual(color.redComponent, 0.0, accuracy: 0.001)
+		XCTAssertEqual(color.greenComponent, 1.0, accuracy: 0.001)
+		XCTAssertEqual(color.blueComponent, 0.0, accuracy: 0.001)
+		XCTAssertEqual(color.alphaComponent, 1.0, accuracy: 0.001)
+	}
+
+	// MARK: - Color int initializer (ARGB layout)
+
+	func testColor_IntInit_ARGB() {
+		// 0x80FF0000 leadingAlpha=true: A=80, R=FF, G=00, B=00
+		let color = Color(hex: 0x80FF0000, leadingAlpha: true)
+		XCTAssertEqual(color.alphaComponent, 128.0 / 255.0, accuracy: 0.001)
+		XCTAssertEqual(color.redComponent, 1.0, accuracy: 0.001)
+		XCTAssertEqual(color.greenComponent, 0.0, accuracy: 0.001)
+		XCTAssertEqual(color.blueComponent, 0.0, accuracy: 0.001)
+	}
+
+	// MARK: - Color basic initializer + constants
+
+	func testColor_BasicInit() {
+		let color = Color(red: 0.25, green: 0.5, blue: 0.75, alpha: 1.0)
+		XCTAssertEqual(color.redComponent, 0.25, accuracy: 0.001)
+		XCTAssertEqual(color.greenComponent, 0.5, accuracy: 0.001)
+		XCTAssertEqual(color.blueComponent, 0.75, accuracy: 0.001)
+		XCTAssertEqual(color.alphaComponent, 1.0, accuracy: 0.001)
+	}
+
+	func testColor_NamedConstants() {
+		XCTAssertEqual(Color.red.redComponent, 1.0)
+		XCTAssertEqual(Color.green.greenComponent, 1.0)
+		XCTAssertEqual(Color.blue.blueComponent, 1.0)
+		XCTAssertEqual(Color.black.redComponent, 0.0)
+		XCTAssertEqual(Color.black.greenComponent, 0.0)
+		XCTAssertEqual(Color.black.blueComponent, 0.0)
+		XCTAssertEqual(Color.white.redComponent, 1.0)
+		XCTAssertEqual(Color.white.greenComponent, 1.0)
+		XCTAssertEqual(Color.white.blueComponent, 1.0)
+	}
+
+	// MARK: - Angle
+
+	func testAngle_RadiansInit() {
+		let angle = Angle(radians: .pi)
+		XCTAssertEqual(angle.radians, .pi, accuracy: 0.0001)
+		XCTAssertEqual(angle.degrees, 180.0, accuracy: 0.0001)
+	}
+
+	func testAngle_DegreesInit() {
+		let angle = Angle(degrees: 90)
+		XCTAssertEqual(angle.degrees, 90.0, accuracy: 0.0001)
+		XCTAssertEqual(angle.radians, .pi / 2.0, accuracy: 0.0001)
+	}
+
+	func testAngle_DegreesSetter_UpdatesRadians() {
+		var angle = Angle(degrees: 0)
+		angle.degrees = 360
+		XCTAssertEqual(angle.radians, 2 * .pi, accuracy: 0.0001)
+	}
+
+	func testAngle_Zero() {
+		XCTAssertEqual(Angle.zero.radians, 0.0, accuracy: 0.0001)
+		XCTAssertEqual(Angle.zero.degrees, 0.0, accuracy: 0.0001)
+	}
+
+	func testAngle_StaticFactories() {
+		XCTAssertEqual(Angle.radians(.pi).degrees, 180.0, accuracy: 0.0001)
+		XCTAssertEqual(Angle.degrees(180).radians, .pi, accuracy: 0.0001)
+	}
+
+	// MARK: - Point / Size / Rectangle
+
+	func testPoint_Int32InitMatchesIntInit() {
+		let pInt = Point(x: 5, y: 10)
+		let p32 = Point(x: Int32(5), y: Int32(10))
+		XCTAssertEqual(pInt.x, p32.x)
+		XCTAssertEqual(pInt.y, p32.y)
+	}
+
+	func testRectangle_ConvenienceInitMatchesPointSizeInit() {
+		let r1 = Rectangle(point: Point(x: 1, y: 2), size: Size(width: 3, height: 4))
+		let r2 = Rectangle(x: 1, y: 2, width: 3, height: 4)
+		XCTAssertEqual(r1.point.x, r2.point.x)
+		XCTAssertEqual(r1.point.y, r2.point.y)
+		XCTAssertEqual(r1.size.width, r2.size.width)
+		XCTAssertEqual(r1.size.height, r2.size.height)
+	}
 }

--- a/Tests/AppTests/SettingsCalendarTests.swift
+++ b/Tests/AppTests/SettingsCalendarTests.swift
@@ -1,0 +1,41 @@
+import XCTVapor
+@testable import swiftarr
+
+class SettingsCalendarTests: XCTestCase {
+
+	// MARK: - getPortCalendar
+
+	func testGetPortCalendar_UsesPortTimeZone() {
+		let cal = Settings.shared.getPortCalendar()
+		XCTAssertEqual(cal.timeZone.identifier, Settings.shared.portTimeZone.identifier)
+	}
+
+	func testGetPortCalendar_IsGregorian() {
+		let cal = Settings.shared.getPortCalendar()
+		XCTAssertEqual(cal.identifier, .gregorian)
+	}
+
+	// MARK: - calendarForDate
+
+	func testCalendarForDate_FallsBackToPortTimeZone_WithEmptyChangeSet() {
+		// With the default (empty) timeZoneChanges, calendarForDate returns a calendar
+		// whose timezone is the port timezone — fall-through behavior of tzAtTime.
+		let date = Date()
+		let cal = Settings.shared.calendarForDate(date)
+		XCTAssertEqual(cal.timeZone.identifier, Settings.shared.portTimeZone.identifier)
+		XCTAssertEqual(cal.identifier, .gregorian)
+	}
+
+	// MARK: - cruiseStartDate
+
+	func testCruiseStartDate_UsesComponentsAndPortTimeZone() {
+		// Save and override so the assertion is independent of source-default drift.
+		let savedComponents = Settings.shared.cruiseStartDateComponents
+		defer { Settings.shared.cruiseStartDateComponents = savedComponents }
+		Settings.shared.cruiseStartDateComponents = DateComponents(year: 2024, month: 3, day: 9)
+		// The fixture cruise date interpreted at midnight in America/New_York (UTC-5 in March, pre-DST)
+		// is 2024-03-09T05:00:00Z.
+		let expected = ISO8601DateFormatter().date(from: "2024-03-09T05:00:00Z")!
+		XCTAssertEqual(Settings.shared.cruiseStartDate(), expected)
+	}
+}

--- a/Tests/AppTests/TimeZoneChangeSetTests.swift
+++ b/Tests/AppTests/TimeZoneChangeSetTests.swift
@@ -31,9 +31,11 @@ class TimeZoneChangeSetTests: XCTestCase {
 	func testAbbrevAtTime_EmptyChangeSet_ReturnsPortTimeZoneAbbrev() {
 		let set = TimeZoneChangeSet()
 		// With an empty set, falls through to Settings.shared.portTimeZone (default America/New_York).
-		// The abbreviation depends on whether the date is in DST, but it must be 3 chars and in {EST, EDT}.
+		// On macOS the abbreviation is "EDT"/"EST"; on Linux ICU returns "GMT-4"/"GMT-5" instead.
 		let summer = ISO8601DateFormatter().date(from: "2024-07-01T12:00:00Z")!
 		let abbrev = set.abbrevAtTime(summer)
-		XCTAssertTrue(["EDT", "EST"].contains(abbrev), "Got \(abbrev)")
+		let acceptable = ["EDT", "EST"]
+		let isGmtOffset = abbrev.range(of: #"^GMT[+-]\d+$"#, options: .regularExpression) != nil
+		XCTAssertTrue(acceptable.contains(abbrev) || isGmtOffset, "Got \(abbrev)")
 	}
 }

--- a/Tests/AppTests/TimeZoneChangeSetTests.swift
+++ b/Tests/AppTests/TimeZoneChangeSetTests.swift
@@ -1,0 +1,39 @@
+import XCTVapor
+@testable import swiftarr
+
+class TimeZoneChangeSetTests: XCTestCase {
+
+	// MARK: - Empty change set
+
+	func testTzAtTime_EmptyChangeSet_ReturnsSettingsPortTimeZone() {
+		let set = TimeZoneChangeSet()
+		let now = Date()
+		XCTAssertEqual(set.tzAtTime(now).identifier, Settings.shared.portTimeZone.identifier)
+	}
+
+	func testTzAtTime_EmptyChangeSet_NoArgument_ReturnsSettingsPortTimeZone() {
+		let set = TimeZoneChangeSet()
+		XCTAssertEqual(set.tzAtTime().identifier, Settings.shared.portTimeZone.identifier)
+	}
+
+	func testPortTimeToDisplayTime_EmptyChangeSet_ReturnsInputUnchanged() {
+		let set = TimeZoneChangeSet()
+		let testDate = ISO8601DateFormatter().date(from: "2024-03-12T15:00:00Z")!
+		XCTAssertEqual(set.portTimeToDisplayTime(testDate), testDate)
+	}
+
+	func testDisplayTimeToPortTime_EmptyChangeSet_ReturnsInputUnchanged() {
+		let set = TimeZoneChangeSet()
+		let testDate = ISO8601DateFormatter().date(from: "2024-03-12T15:00:00Z")!
+		XCTAssertEqual(set.displayTimeToPortTime(testDate), testDate)
+	}
+
+	func testAbbrevAtTime_EmptyChangeSet_ReturnsPortTimeZoneAbbrev() {
+		let set = TimeZoneChangeSet()
+		// With an empty set, falls through to Settings.shared.portTimeZone (default America/New_York).
+		// The abbreviation depends on whether the date is in DST, but it must be 3 chars and in {EST, EDT}.
+		let summer = ISO8601DateFormatter().date(from: "2024-07-01T12:00:00Z")!
+		let abbrev = set.abbrevAtTime(summer)
+		XCTAssertTrue(["EDT", "EST"].contains(abbrev), "Got \(abbrev)")
+	}
+}

--- a/Tests/AppTests/UserStructValidationTests.swift
+++ b/Tests/AppTests/UserStructValidationTests.swift
@@ -105,4 +105,58 @@ class UserStructValidationTests: XCTestCase {
 		let errs = try validationErrors(UserVerifyData.self, #"{"verification":"abc12345"}"#)
 		XCTAssertEqual(errs.count, 1)
 	}
+
+	// MARK: - UserCreateData
+
+	private func userCreateJSON(
+		username: String = "skyler",
+		password: String = "newpass1",
+		verification: String? = nil
+	) -> String {
+		var fields = [
+			#""username":"\#(username)""#,
+			#""password":"\#(password)""#,
+		]
+		if let v = verification {
+			fields.append(#""verification":"\#(v)""#)
+		}
+		return "{" + fields.joined(separator: ",") + "}"
+	}
+
+	func testUserCreate_Valid_NoVerification() throws {
+		XCTAssertEqual(try validationErrors(UserCreateData.self, userCreateJSON()), [])
+	}
+
+	func testUserCreate_Valid_WithVerification() throws {
+		let json = userCreateJSON(verification: "abc123")
+		XCTAssertEqual(try validationErrors(UserCreateData.self, json), [])
+	}
+
+	func testUserCreate_Valid_VerificationWithSpaces_NormalizedThenAccepted() throws {
+		// "abc 123" → "abc123" after lowercased + space-strip; 6 alphanumeric → valid
+		let json = userCreateJSON(verification: "abc 123")
+		XCTAssertEqual(try validationErrors(UserCreateData.self, json), [])
+	}
+
+	func testUserCreate_PasswordTooShort() throws {
+		let errs = try validationErrors(UserCreateData.self, userCreateJSON(password: "abc"))
+		XCTAssertTrue(errs.contains("password has a 6 character minimum"), "errs=\(errs)")
+	}
+
+	func testUserCreate_BadUsername_PropagatesUsernameValidations() throws {
+		let errs = try validationErrors(UserCreateData.self, userCreateJSON(username: "x"))
+		XCTAssertTrue(errs.contains("username has a 2 character minimum"), "errs=\(errs)")
+	}
+
+	func testUserCreate_VerificationWrongLength_Fails() throws {
+		let json = userCreateJSON(verification: "abc1234")
+		let errs = try validationErrors(UserCreateData.self, json)
+		XCTAssertTrue(errs.contains(where: { $0.contains("Malformed registration code") }), "errs=\(errs)")
+	}
+
+	func testUserCreate_VerificationNonAlphanumeric_Fails() throws {
+		let json = userCreateJSON(verification: "abc-12")
+		let errs = try validationErrors(UserCreateData.self, json)
+		XCTAssertTrue(errs.contains(where: { $0.contains("Malformed registration code") }), "errs=\(errs)")
+	}
 }

--- a/Tests/AppTests/UserStructValidationTests.swift
+++ b/Tests/AppTests/UserStructValidationTests.swift
@@ -1,0 +1,108 @@
+import XCTVapor
+@testable import swiftarr
+
+// Tests for the RCFValidatable conformances on user-facing request structs.
+// These exercise the validation logic by feeding JSON through ValidatingJSONDecoder.
+class UserStructValidationTests: XCTestCase {
+
+	private let decoder = ValidatingJSONDecoder()
+
+	private func validationErrors<T: Decodable>(_ type: T.Type, _ json: String) throws -> [String] {
+		let data = json.data(using: .utf8)!
+		let result = try decoder.validate(type, from: data)
+		return result?.validationFailures.map { $0.errorString } ?? []
+	}
+
+	// MARK: - UserPasswordData
+
+	func testUserPassword_Valid() throws {
+		let errs = try validationErrors(
+			UserPasswordData.self,
+			#"{"currentPassword":"old","newPassword":"newPass1"}"#
+		)
+		XCTAssertEqual(errs, [])
+	}
+
+	func testUserPassword_TooShort_FlagsMin() throws {
+		let errs = try validationErrors(
+			UserPasswordData.self,
+			#"{"currentPassword":"old","newPassword":"abc"}"#
+		)
+		XCTAssertTrue(errs.contains("password has a 6 character minimum"), "errs=\(errs)")
+	}
+
+	func testUserPassword_TooLong_FlagsMax() throws {
+		let longPw = String(repeating: "a", count: 51)
+		let errs = try validationErrors(
+			UserPasswordData.self,
+			#"{"currentPassword":"old","newPassword":"\#(longPw)"}"#
+		)
+		XCTAssertTrue(errs.contains("password has a 50 character limit"), "errs=\(errs)")
+	}
+
+	// MARK: - UserUsernameData
+
+	func testUsername_Valid() throws {
+		let errs = try validationErrors(UserUsernameData.self, #"{"username":"skyler"}"#)
+		XCTAssertEqual(errs, [])
+	}
+
+	func testUsername_ValidWithSeparator() throws {
+		let errs = try validationErrors(UserUsernameData.self, #"{"username":"sky.ler"}"#)
+		XCTAssertEqual(errs, [])
+	}
+
+	func testUsername_TooShort() throws {
+		let errs = try validationErrors(UserUsernameData.self, #"{"username":"a"}"#)
+		XCTAssertTrue(errs.contains("username has a 2 character minimum"), "errs=\(errs)")
+	}
+
+	func testUsername_TooLong() throws {
+		let long = String(repeating: "a", count: 51)
+		let errs = try validationErrors(UserUsernameData.self, #"{"username":"\#(long)"}"#)
+		XCTAssertTrue(errs.contains("username has a 50 character limit"), "errs=\(errs)")
+	}
+
+	func testUsername_InvalidCharacters() throws {
+		let errs = try validationErrors(UserUsernameData.self, #"{"username":"sky ler"}"#)
+		XCTAssertTrue(
+			errs.contains(where: { $0.starts(with: "username can only contain alphanumeric") }),
+			"errs=\(errs)"
+		)
+	}
+
+	func testUsername_StartsWithSeparator() throws {
+		let errs = try validationErrors(UserUsernameData.self, #"{"username":".skyler"}"#)
+		XCTAssertTrue(errs.contains("username must start with a letter or number"), "errs=\(errs)")
+	}
+
+	func testUsername_EndsWithSeparator() throws {
+		let errs = try validationErrors(UserUsernameData.self, #"{"username":"skyler."}"#)
+		XCTAssertTrue(
+			errs.contains(where: { $0.starts(with: "Username separator chars") }),
+			"errs=\(errs)"
+		)
+	}
+
+	// MARK: - UserVerifyData
+
+	func testUserVerify_Valid6Char() throws {
+		let errs = try validationErrors(UserVerifyData.self, #"{"verification":"abc123"}"#)
+		XCTAssertEqual(errs, [])
+	}
+
+	func testUserVerify_Valid7Char() throws {
+		let errs = try validationErrors(UserVerifyData.self, #"{"verification":"abc1234"}"#)
+		XCTAssertEqual(errs, [])
+	}
+
+	func testUserVerify_TooShort_Fails() throws {
+		let errs = try validationErrors(UserVerifyData.self, #"{"verification":"abc"}"#)
+		XCTAssertEqual(errs.count, 1)
+	}
+
+	func testUserVerify_TooLong_Fails() throws {
+		let errs = try validationErrors(UserVerifyData.self, #"{"verification":"abc12345"}"#)
+		XCTAssertEqual(errs.count, 1)
+	}
+}

--- a/Tests/AppTests/ValidatingJSONDecoderTests.swift
+++ b/Tests/AppTests/ValidatingJSONDecoderTests.swift
@@ -1,0 +1,88 @@
+import XCTVapor
+@testable import swiftarr
+
+class ValidatingJSONDecoderTests: XCTestCase {
+
+	// MARK: - Test fixtures
+
+	private struct PlainPayload: Decodable {
+		let name: String
+		let count: Int
+	}
+
+	private struct ValidatedPayload: Decodable, RCFValidatable {
+		let name: String
+		let count: Int
+
+		func runValidations(using decoder: ValidatingDecoder) throws {
+			let tester = try decoder.validator(keyedBy: CodingKeys.self)
+			tester.validateStrLen(name, min: 3, max: 10, forKey: .name)
+			tester.validate(count >= 0, forKey: .count, or: "count must be non-negative")
+		}
+
+		enum CodingKeys: String, CodingKey { case name, count }
+	}
+
+	// MARK: - Decode without validation
+
+	func testValidate_NonValidatable_ReturnsNil() throws {
+		let json = #"{"name":"foo","count":3}"#.data(using: .utf8)!
+		let result = try ValidatingJSONDecoder().validate(PlainPayload.self, from: json)
+		XCTAssertNil(result)
+	}
+
+	// MARK: - Validatable payload — happy path
+
+	func testValidate_AllRulesPass_ReturnsNil() throws {
+		let json = #"{"name":"foo","count":3}"#.data(using: .utf8)!
+		let result = try ValidatingJSONDecoder().validate(ValidatedPayload.self, from: json)
+		XCTAssertNil(result)
+	}
+
+	// MARK: - Validatable payload — failures
+
+	func testValidate_StringTooShort_ReturnsValidationError() throws {
+		let json = #"{"name":"a","count":3}"#.data(using: .utf8)!
+		let result = try ValidatingJSONDecoder().validate(ValidatedPayload.self, from: json)
+		XCTAssertNotNil(result)
+		XCTAssertEqual(result?.validationFailures.count, 1)
+		XCTAssertEqual(result?.validationFailures.first?.field, "name")
+	}
+
+	func testValidate_StringTooLong_ReturnsValidationError() throws {
+		let json = #"{"name":"thisIsTooLongAName","count":3}"#.data(using: .utf8)!
+		let result = try ValidatingJSONDecoder().validate(ValidatedPayload.self, from: json)
+		XCTAssertNotNil(result)
+		XCTAssertEqual(result?.validationFailures.first?.field, "name")
+	}
+
+	func testValidate_PredicateFails_ReturnsValidationError() throws {
+		let json = #"{"name":"foo","count":-5}"#.data(using: .utf8)!
+		let result = try ValidatingJSONDecoder().validate(ValidatedPayload.self, from: json)
+		XCTAssertNotNil(result)
+		XCTAssertEqual(result?.validationFailures.first?.errorString, "count must be non-negative")
+	}
+
+	func testValidate_MultipleFailures_AllReported() throws {
+		let json = #"{"name":"a","count":-1}"#.data(using: .utf8)!
+		let result = try ValidatingJSONDecoder().validate(ValidatedPayload.self, from: json)
+		XCTAssertNotNil(result)
+		XCTAssertEqual(result?.validationFailures.count, 2)
+	}
+
+	// MARK: - Decode failure (not a validation failure)
+
+	func testValidate_MissingRequiredKey_ThrowsDecodeError() {
+		let json = #"{"count":3}"#.data(using: .utf8)!
+		XCTAssertThrowsError(try ValidatingJSONDecoder().validate(ValidatedPayload.self, from: json)) { error in
+			// Swift's JSONDecoder throws DecodingError.keyNotFound here, not a ValidationError —
+			// the parser distinguishes "couldn't decode at all" from "decoded but invalid".
+			XCTAssertTrue(error is DecodingError, "Expected DecodingError, got \(error)")
+		}
+	}
+
+	func testValidate_MalformedJSON_ThrowsDecodeError() {
+		let json = "{not json}".data(using: .utf8)!
+		XCTAssertThrowsError(try ValidatingJSONDecoder().validate(PlainPayload.self, from: json))
+	}
+}

--- a/Tests/AppTests/ValidatingJSONDecoderTests.swift
+++ b/Tests/AppTests/ValidatingJSONDecoderTests.swift
@@ -85,4 +85,76 @@ class ValidatingJSONDecoderTests: XCTestCase {
 		let json = "{not json}".data(using: .utf8)!
 		XCTAssertThrowsError(try ValidatingJSONDecoder().validate(PlainPayload.self, from: json))
 	}
+
+	// MARK: - decode(_:from:)
+
+	func testDecode_HappyPath_ReturnsTypedValue() throws {
+		let json = #"{"name":"foo","count":3}"#.data(using: .utf8)!
+		let decoded = try ValidatingJSONDecoder().decode(PlainPayload.self, from: json)
+		XCTAssertEqual(decoded.name, "foo")
+		XCTAssertEqual(decoded.count, 3)
+	}
+
+	func testDecode_MalformedJSON_Throws() {
+		let json = "{not json}".data(using: .utf8)!
+		XCTAssertThrowsError(try ValidatingJSONDecoder().decode(PlainPayload.self, from: json))
+	}
+
+	// MARK: - validateStrLenOptional fixtures + tests
+
+	private struct OptionalStringPayload: Decodable, RCFValidatable {
+		let nickname: String?
+
+		func runValidations(using decoder: ValidatingDecoder) throws {
+			let tester = try decoder.validator(keyedBy: CodingKeys.self)
+			tester.validateStrLenOptional(nickname, nilOkay: true, min: 3, max: 10, forKey: .nickname)
+		}
+
+		enum CodingKeys: String, CodingKey { case nickname }
+	}
+
+	private struct RequiredStringPayload: Decodable, RCFValidatable {
+		let nickname: String?
+
+		func runValidations(using decoder: ValidatingDecoder) throws {
+			let tester = try decoder.validator(keyedBy: CodingKeys.self)
+			tester.validateStrLenOptional(nickname, nilOkay: false, min: 3, max: 10, forKey: .nickname)
+		}
+
+		enum CodingKeys: String, CodingKey { case nickname }
+	}
+
+	func testValidateStrLenOptional_NilWithNilOkay_ReturnsNil() throws {
+		let json = #"{"nickname":null}"#.data(using: .utf8)!
+		let result = try ValidatingJSONDecoder().validate(OptionalStringPayload.self, from: json)
+		XCTAssertNil(result)
+	}
+
+	func testValidateStrLenOptional_EmptyStringTreatedAsNil() throws {
+		// Empty string short-circuits the length check the same way nil does.
+		let json = #"{"nickname":""}"#.data(using: .utf8)!
+		let result = try ValidatingJSONDecoder().validate(OptionalStringPayload.self, from: json)
+		XCTAssertNil(result)
+	}
+
+	func testValidateStrLenOptional_TooShort_ReturnsValidationError() throws {
+		let json = #"{"nickname":"a"}"#.data(using: .utf8)!
+		let result = try ValidatingJSONDecoder().validate(OptionalStringPayload.self, from: json)
+		XCTAssertNotNil(result)
+		XCTAssertEqual(result?.validationFailures.first?.field, "nickname")
+	}
+
+	func testValidateStrLenOptional_TooLong_ReturnsValidationError() throws {
+		let json = #"{"nickname":"thisIsTooLongANickname"}"#.data(using: .utf8)!
+		let result = try ValidatingJSONDecoder().validate(OptionalStringPayload.self, from: json)
+		XCTAssertNotNil(result)
+		XCTAssertEqual(result?.validationFailures.first?.field, "nickname")
+	}
+
+	func testValidateStrLenOptional_NilWithNilOkayFalse_ReturnsValidationError() throws {
+		let json = #"{"nickname":null}"#.data(using: .utf8)!
+		let result = try ValidatingJSONDecoder().validate(RequiredStringPayload.self, from: json)
+		XCTAssertNotNil(result)
+		XCTAssertEqual(result?.validationFailures.first?.field, "nickname")
+	}
 }


### PR DESCRIPTION
**Draft — depends on #548 (libvips migration). Do not merge before #548.**

Closes #550 (partially — see scope notes).

## Summary

- Adds a `Test` sibling job to `build_branch.yml` that runs pure-helper tests in CI inside `swift:6.2-noble`. Caches `.build/` keyed on `Package.resolved`.
- Adds three pure-helper test classes covering previously-untested production code:
  - `GeometryTests` — `Color.init(hex:)`, 11 cases including invalid input.
  - `ValidatingJSONDecoderTests` — `ValidatingJSONDecoder.validate(_:from:)`, 8 cases including `validateStrLen`, predicate validation, and decode-vs-validation-error distinction.
  - `CruiseDateTests` — pure `Settings.shared.getDateInCruiseWeek` tests (5 cases) that don't require app/DB spinup. setUp/tearDown mutate `Settings.shared.cruiseStartDateComponents`, `cruiseLengthInDays`, and `cruiseStartDayOfWeek` so the fixture cruise is self-contained and stable regardless of source-default drift.

24 new tests total. All pass locally on macOS without DB and in CI.

## Scope note: pure-helper-only filter

The CI `Test` job runs `swift test --filter "GeometryTests|ValidatingJSONDecoderTests|CruiseDateTests|ThemeCookieTests"` rather than the full suite. Bringing the existing `SettingsTests` and `ClientControllerTests` into CI is real infrastructure work that's out of scope for this PR:

- `Application+Testable.swift:13` calls `Settings.shared.readTimeZoneChanges(app)` *before* `withApp { ... }` runs `app.autoMigrate()`. On a maintainer's local machine the `time_zone_change` table already exists from a prior `swift run swiftarr migrate -y`, so this works. On a pristine CI postgres it fails with `relation "time_zone_change" does not exist`.
- `SettingsTests.testPastDstDate` (the lone case without `withApp`) is hardcoded to assert against the 2024-03-09 cruise date, but the in-source default drifted to 2025-03-02 in #495. Running it in CI exposes the rot.

Suggested follow-up: (1) move `autoMigrate()` ahead of `readTimeZoneChanges` in `Application.testable()`, (2) optionally rotate the SettingsTests fixtures to match the current source default OR convert them to the same self-contained setUp pattern this PR introduces in `CruiseDateTests`, (3) add postgres + redis service containers back to the workflow.

## Depends on #548

This branches from current master (pre-libvips). Once #548 lands, I'll rebase. Expected conflicts: one tiny error-type swap in `GeometryTests.swift` (`GDError.invalidColor` → `ImageError.invalidColor`).

## Test plan

- [x] All 24 new tests pass locally on macOS without DB
- [x] CI \`Test\` job passes on this PR's first run
- [ ] CI \`BuildAndDeployStack\` job continues to pass (sibling, unmodified)
- [ ] Rebase onto post-#548 master clean, error-type swap applied