### PR TITLE
build: unpin FileType from fork now that upstream 2.2.1 ships the Linux fix

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c148b58a72ae2967335017fa5cfc22b94243c7190775ac73ae1fc74ca432e3d6",
+  "originHash" : "2a1acb8a02fa0ae4e5ebeae0d89849f4c293f58ff807d4f1cab502458d8f02dc",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -40,9 +40,10 @@
     {
       "identity" : "filetype",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/penguinboi/FileType",
+      "location" : "https://github.com/velocityzen/FileType",
       "state" : {
-        "revision" : "acfd132f56e1c436276af13682a934d9364e3323"
+        "revision" : "2dd39f2fdde25681fbf8184ad83f6226bf86ca0a",
+        "version" : "2.2.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,10 +31,7 @@ let package = Package(
 	    // Cross-platform QR Code generator. Linux doesn't have access to Core Image
 		.package(url: "https://github.com/ApolloZhu/swift_qrcodejs.git", from: "2.2.2"),
 		// FileType is a Swift port of file-type, used to detect image formats from magic bytes.
-		// Pinned to a fork until https://github.com/velocityzen/FileType/pull/3 is merged
-		// upstream — the fork renames its system zlib module to avoid colliding with
-		// ZIPFoundation's CZlib, which fails the Linux build.
-		.package(url: "https://github.com/penguinboi/FileType", revision: "acfd132f56e1c436276af13682a934d9364e3323"),
+		.package(url: "https://github.com/velocityzen/FileType", from: "2.2.1"),
 	],
 	targets: [
 		.systemLibrary(name: "Cvips", pkgConfig: "vips", providers: [.apt(["libvips-dev"]), .brew(["vips"]), .yum(["vips-devel"])]),


### PR DESCRIPTION
## What

Switches the `FileType` dependency from my personal fork back to upstream `velocityzen/FileType`, pinned `from: "2.2.1"`.

## Why

The fork (`penguinboi/FileType@acfd132`) existed for one reason: it renamed FileType's system zlib module (`CZlib` → `FTZlib`) so it wouldn't collide with ZIPFoundation's own `CZlib` module and break the Linux build.

Upstream has since merged that exact rename ([velocityzen/FileType#3](https://github.com/velocityzen/FileType/pull/3), merged 2026-06-21) and shipped it in **tag 2.2.1**, whose `Sources/` contains the renamed `FTZlib` module. So Swiftarr can depend on upstream directly again — no more reliance on a personal fork, and `from:` restores normal SemVer range resolution to match every other dependency in the manifest.

## Changes

- `Package.swift` — fork+revision pin → `.package(url: "https://github.com/velocityzen/FileType", from: "2.2.1")`; removed the now-obsolete "pinned to a fork" comment.
- `Package.resolved` — regenerated. Only the FileType pin moves (fork → upstream 2.2.1); no other dependency versions change.

## Verification

- `swift build` — clean (full `swiftarr` target links; FileType 2.2.1 and ZIPFoundation — the old collision pair — compile together).
- Pure-helper test suite (`swift test --filter …`, same set CI runs) — **170 tests, 0 failures**.
- Local build is macOS; the collision this addresses is Linux-specific, so the `swift:6.2-noble` CI job here is the definitive check.