### PR TITLE
fix: Small fixes batch — cruise weekday derivation, PostContentData flag defaults, ISO 8601 parsing

### DIFF
--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -1794,6 +1794,18 @@ public struct PostContentData: Content {
 	var postAsTwitarrTeam: Bool = false
 }
 
+extension PostContentData {
+	/// Decodes a post. `postAsModerator` and `postAsTwitarrTeam` may be omitted from the JSON,
+	/// in which case they decode as FALSE, matching their documented default semantics.
+	public init(from decoder: Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		text = try container.decode(String.self, forKey: .text)
+		images = try container.decode([ImageUploadData].self, forKey: .images)
+		postAsModerator = try container.decodeIfPresent(Bool.self, forKey: .postAsModerator) ?? false
+		postAsTwitarrTeam = try container.decodeIfPresent(Bool.self, forKey: .postAsTwitarrTeam) ?? false
+	}
+}
+
 extension PostContentData: RCFValidatable {
 	func runValidations(using decoder: ValidatingDecoder) throws {
 		let tester = try decoder.validator(keyedBy: CodingKeys.self)

--- a/Sources/swiftarr/Extensions/Foundation+Extensions.swift
+++ b/Sources/swiftarr/Extensions/Foundation+Extensions.swift
@@ -50,21 +50,31 @@ extension Date {
 	}
 }
 
+/// Parses an ISO 8601 internet date-time, with or without fractional seconds.
+/// Swiftarr always emits fractional seconds but accepts timestamps that omit them.
+@available(OSX 10.13, *)
+private func dateFromISO8601(_ string: String) -> Date? {
+	if let date = ISO8601DateFormatter([.withInternetDateTime, .withFractionalSeconds]).date(from: string) {
+		return date
+	}
+	return ISO8601DateFormatter([.withInternetDateTime]).date(from: string)
+}
+
 @available(OSX 10.13, *)
 extension String {
-	/// Returns a `Date?` from an iso8601 string representation with milliseconds.
+	/// Returns a `Date?` from an iso8601 string representation, with or without fractional seconds.
 	var iso8601ms: Date? {
-		return ISO8601DateFormatter([.withInternetDateTime, .withFractionalSeconds]).date(from: self)
+		return dateFromISO8601(self)
 	}
 }
 
 @available(OSX 10.13, *)
 extension JSONDecoder.DateDecodingStrategy {
-	/// Custom decoding strategy for iso8601 strings with milliseconds.
+	/// Custom decoding strategy for iso8601 strings, with or without fractional seconds.
 	static let iso8601ms = custom {
 		let container = try $0.singleValueContainer()
 		let string = try container.decode(String.self)
-		guard let date = ISO8601DateFormatter([.withInternetDateTime, .withFractionalSeconds]).date(from: string) else {
+		guard let date = dateFromISO8601(string) else {
 			throw DecodingError.dataCorruptedError(
 				in: container,
 				debugDescription: "invalid format: " + string

--- a/Sources/swiftarr/Helpers/Settings.swift
+++ b/Sources/swiftarr/Helpers/Settings.swift
@@ -120,12 +120,23 @@ final class Settings: Encodable, @unchecked Sendable {
 	/// A Date set to midnight on the day the cruise ship leaves port, in the timezone the ship leaves from. Used by the Events Controller for date arithimetic.
 	/// The default here should get overwritten in configure.swift. This is purely for convenience to set the start date via
 	/// configure.swift. This setting should not be referenced anywhere. That's what `cruiseStartDate()` below is for.
-	/// This must align with cruiseStartDayOfWeek set immediately below.
+	/// `cruiseStartDayOfWeek` is derived from this value.
 	@SettingsValue var cruiseStartDateComponents: DateComponents = DateComponents(year: 2025, month: 3, day: 2)
 
-	/// The day of week when the cruise embarks, expressed as number as Calendar's .weekday uses them: Range 1...7, Sunday == 1.
-	/// Doing DateComponents(year: 2024, month: 3, day: 9).weekday! didnt work here. Hmm....
-	@SettingsValue var cruiseStartDayOfWeek: Int = 1
+	/// The day of week when the cruise embarks, derived from `cruiseStartDateComponents`.
+	/// Expressed as a number as Calendar's .weekday uses them: Range 1...7, Sunday == 1.
+	var cruiseStartDayOfWeek: Int {
+		let start = cruiseStartDateComponents
+		var ymd = DateComponents()
+		ymd.year = start.year
+		ymd.month = start.month
+		ymd.day = start.day
+		let cal = Calendar(identifier: .gregorian)
+		guard let startDate = cal.date(from: ymd), let weekday = cal.dateComponents([.weekday], from: startDate).weekday else {
+			fatalError("cruiseStartDateComponents must contain a resolvable year/month/day to derive cruiseStartDayOfWeek.")
+		}
+		return weekday
+	}
 
 	/// The length in days of the cruise, includes partial days. A cruise that embarks on Saturday and returns the next Saturday should have a value of 8.
 	@SettingsValue var cruiseLengthInDays: Int = 8

--- a/Sources/swiftarr/configure.swift
+++ b/Sources/swiftarr/configure.swift
@@ -184,9 +184,9 @@ struct SwiftarrConfigurator {
 			}
 			Settings.shared.portTimeZone = portTimeZone
 		}
-		// This sets both the cruiseStartDateComponents and cruiseStartDayOfWeek from the same
-		// SWIFTARR_START_DATE value. If you don't specify this env var, the defaults in Settings.swift
-		// take over. That isn't quite as intelligent.
+		// This sets the cruiseStartDateComponents from the SWIFTARR_START_DATE value
+		// (cruiseStartDayOfWeek is derived from the components). If you don't specify this
+		// env var, the defaults in Settings.swift take over.
 		if let cruiseStartDate = Environment.get("SWIFTARR_START_DATE"), cruiseStartDate != "" {
 			let startFormatter = DateFormatter()
 			startFormatter.dateFormat = "yyyy-MM-dd"  // 2023-03-05
@@ -195,13 +195,9 @@ struct SwiftarrConfigurator {
 			}
 			Settings.shared.cruiseStartDateComponents = Calendar(identifier: .gregorian)
 				.dateComponents(
-					[.year, .month, .day, .weekday],
+					[.year, .month, .day],
 					from: date
 				)
-			guard let cruiseStartDayOfWeek = Settings.shared.cruiseStartDateComponents.weekday else {
-				fatalError("Cannot determine day-of-week from SWIFTARR_START_DATE.")
-			}
-			Settings.shared.cruiseStartDayOfWeek = cruiseStartDayOfWeek
 		}
 
 		// Late Day Flip in Site UI

--- a/Tests/AppTests/ContentStructValidationTests.swift
+++ b/Tests/AppTests/ContentStructValidationTests.swift
@@ -97,4 +97,18 @@ class ContentStructValidationTests: XCTestCase {
 		let errs = try validationErrors(PostContentData.self, #"{"text":"\#(lines)","images":[],"postAsModerator":false,"postAsTwitarrTeam":false}"#)
 		XCTAssertTrue(errs.contains("posts are limited to 25 lines of text"), "errs=\(errs)")
 	}
+
+	func testPostContent_OmittedModeratorFlagsDecodeAsFalse() throws {
+		let data = #"{"text":"hello","images":[]}"#.data(using: .utf8)!
+		let post = try decoder.decode(PostContentData.self, from: data)
+		XCTAssertFalse(post.postAsModerator)
+		XCTAssertFalse(post.postAsTwitarrTeam)
+	}
+
+	func testPostContent_PresentModeratorFlagsAreRespected() throws {
+		let data = #"{"text":"hello","images":[],"postAsModerator":true,"postAsTwitarrTeam":true}"#.data(using: .utf8)!
+		let post = try decoder.decode(PostContentData.self, from: data)
+		XCTAssertTrue(post.postAsModerator)
+		XCTAssertTrue(post.postAsTwitarrTeam)
+	}
 }

--- a/Tests/AppTests/CruiseDateTests.swift
+++ b/Tests/AppTests/CruiseDateTests.swift
@@ -13,24 +13,18 @@ class CruiseDateTests: XCTestCase {
 
 	private var savedComponents: DateComponents!
 	private var savedLength: Int!
-	private var savedDayOfWeek: Int!
 
 	override func setUp() {
 		super.setUp()
 		savedComponents = Settings.shared.cruiseStartDateComponents
 		savedLength = Settings.shared.cruiseLengthInDays
-		savedDayOfWeek = Settings.shared.cruiseStartDayOfWeek
 		Settings.shared.cruiseStartDateComponents = fixtureStartComponents
 		Settings.shared.cruiseLengthInDays = 8
-		// Calendar weekday: Sunday=1, Saturday=7. The fixture cruise embarks on a Saturday,
-		// so this must align with cruiseStartDateComponents above.
-		Settings.shared.cruiseStartDayOfWeek = 7
 	}
 
 	override func tearDown() {
 		Settings.shared.cruiseStartDateComponents = savedComponents
 		Settings.shared.cruiseLengthInDays = savedLength
-		Settings.shared.cruiseStartDayOfWeek = savedDayOfWeek
 		super.tearDown()
 	}
 
@@ -100,5 +94,16 @@ class CruiseDateTests: XCTestCase {
 		// Sub-second portion must be zero — this is the function's whole reason for existing.
 		let nanos = Calendar(identifier: .gregorian).component(.nanosecond, from: stripped)
 		XCTAssertEqual(nanos, 0)
+	}
+
+	// MARK: - cruiseStartDayOfWeek derivation
+
+	func testCruiseStartDayOfWeek_DerivedFromStartDateComponents() {
+		// setUp pinned the fixture start to 2024-03-09, a Saturday.
+		XCTAssertEqual(Settings.shared.cruiseStartDayOfWeek, 7)
+		// Changing the start date must change the weekday with no separate bookkeeping.
+		// 2025-03-02 is a Sunday.
+		Settings.shared.cruiseStartDateComponents = DateComponents(year: 2025, month: 3, day: 2)
+		XCTAssertEqual(Settings.shared.cruiseStartDayOfWeek, 1)
 	}
 }

--- a/Tests/AppTests/DateExtensionTests.swift
+++ b/Tests/AppTests/DateExtensionTests.swift
@@ -20,10 +20,11 @@ class DateExtensionTests: XCTestCase {
 		XCTAssertNotNil(parsed)
 	}
 
-	func testStringIso8601ms_RejectsStringWithoutMilliseconds() {
-		// Strict format — without fractional seconds, parser returns nil.
+	func testStringIso8601ms_ParsesStringWithoutMilliseconds() {
 		let parsed = "2024-03-12T15:00:00Z".iso8601ms
-		XCTAssertNil(parsed)
+		XCTAssertNotNil(parsed)
+		// Same instant as its fractional-seconds twin.
+		XCTAssertEqual(parsed, "2024-03-12T15:00:00.000Z".iso8601ms)
 	}
 
 	func testStringIso8601ms_RejectsGarbage() {
@@ -39,5 +40,21 @@ class DateExtensionTests: XCTestCase {
 		XCTAssertNotNil(parsed)
 		// Equality at millisecond precision.
 		XCTAssertEqual(parsed!.timeIntervalSince1970, original.timeIntervalSince1970, accuracy: 0.001)
+	}
+
+	// MARK: - JSONDecoder.DateDecodingStrategy.iso8601ms
+
+	func testIso8601msDecodingStrategy_AcceptsBothForms() throws {
+		let decoder = JSONDecoder()
+		decoder.dateDecodingStrategy = .iso8601ms
+		let json = #"["2024-03-12T15:00:00.000Z","2024-03-12T15:00:00Z"]"#
+		let dates = try decoder.decode([Date].self, from: json.data(using: .utf8)!)
+		XCTAssertEqual(dates[0], dates[1])
+	}
+
+	func testIso8601msDecodingStrategy_StillRejectsGarbage() {
+		let decoder = JSONDecoder()
+		decoder.dateDecodingStrategy = .iso8601ms
+		XCTAssertThrowsError(try decoder.decode([Date].self, from: #"["not a date"]"#.data(using: .utf8)!))
 	}
 }

--- a/Tests/AppTests/SettingsTests.swift
+++ b/Tests/AppTests/SettingsTests.swift
@@ -73,9 +73,11 @@ class SettingsTests: XCTestCase, SwiftarrBaseTest {
 	// This date is in the past but is still within daylight time (UTC-4)
     // 2023 July 09 is a Sunday
 	func testPastDstDate() async throws {
-		let testDate = ISO8601DateFormatter().date(from: "2023-07-09T11:00:00Z")!
-		let resultDate = Settings.shared.getDateInCruiseWeek(from: testDate)
-		XCTAssertEqual(dstDate, resultDate)
+		try await withApp { app in
+			let testDate = ISO8601DateFormatter().date(from: "2023-07-09T11:00:00Z")!
+			let resultDate = Settings.shared.getDateInCruiseWeek(from: testDate)
+			XCTAssertEqual(dstDate, resultDate)
+		}
 	}
 
 	// This date is in the past but back in standard time (UTC-5).


### PR DESCRIPTION
Four small fixes for quirks surfaced while writing the pure-helper tests in #551. Each is an independent commit with its own test coverage; the new tests all run in the existing CI test filter.

## 1. Derive `cruiseStartDayOfWeek` from `cruiseStartDateComponents`

The stored value had to be manually kept in sync with the weekday of `cruiseStartDateComponents` — `configure.swift` did this when `SWIFTARR_START_DATE` was set, but nothing enforced it for the in-source defaults or for code setting the two properties independently. A mismatch silently produced wrong dates from `getDateInCruiseWeek`. It's now a computed property derived from the components (stripped to year/month/day before resolving, so a stale `.weekday` inside the stored components can't shift the result). One less thing to keep aligned when setting up a new sailing.

## 2. `PostContentData` decodes omitted moderator flags as false

The doc comments on `postAsModerator`/`postAsTwitarrTeam` promise they default to false, but synthesized `Decodable` threw `keyNotFound` when clients omitted them. They now decode via `decodeIfPresent` with a `false` default. The custom `init(from:)` lives in an extension so the memberwise initializer (used by the Site controllers) is preserved, and `decodeIfPresent` goes through the existing `ValidatingKeyedContainer` path.

## 3. `iso8601ms` parsing accepts ISO 8601 without fractional seconds

`String.iso8601ms` and the `iso8601ms` date-decoding strategy required fractional seconds — `"2024-03-12T15:00:00Z"` (valid ISO 8601) returned nil / threw. Both now try the fractional form first and fall back to plain internet date-time. Strictly additive: every previously-valid input parses to the same value. Encoding is unchanged and always emits fractional seconds.

## 4. `testPastDstDate` wrapped in `withApp`

It was the only test in `SettingsTests` reading `Settings.shared` without app configuration, making it dependent on test execution order. Now wrapped like its eight siblings.

Heads-up while in there: `SettingsTests` as a whole asserts the 2024 sailing (embarkation 2024-03-09, Grand Turk) while the seed data now ships the 2026 sailing, so the class needs a matching private config to pass anywhere. Happy to file/take a follow-up issue on making it self-contained if there's interest.

## Testing

- CI test filter: 175 tests, 0 failures (5 new: 1 CruiseDateTests, 2 ContentStructValidationTests, 2 DateExtensionTests)
- `swift build` clean; memberwise-init call sites unaffected