### PR TITLE
docs: add AGENTS.md with guidance for AI coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md
+
+Notes for AI coding agents (Claude Code, Codex, etc.) working on swiftarr contributions.
+
+## Style
+
+- **Don't add ABOUTME header comments.** Some agents have a global rule to prefix
+  source files with `// ABOUTME: ...` headers — these don't belong in swiftarr.
+- **Match existing indentation.** This codebase uses tabs (see `.swift-format`).
+
+## Commits & PRs
+
+- **No agent attribution.** No "Generated with Claude Code" footers, no
+  "Co-Authored-By: Claude", and no equivalent tool credits in commit messages or
+  PR descriptions. Commits should describe the change, not the tool that produced it.
+- **Don't include agent-tooling files in PRs.** `.claude/`, agent plan/spec documents,
+  and similar working files should stay out of commits (use `.git/info/exclude`).
+
+## Setup & docs
+
+For build, test, and environment setup, see [docs/Swiftarr/](docs/Swiftarr/) — notably
+`Development.md` and `Contributing.md`. This file intentionally doesn't duplicate the Docs.


### PR DESCRIPTION
Follow-up promised in #548 (re: keeping the ABOUTME header style out of swiftarr): a lean AGENTS.md so AI coding agents working on contributions stop importing habits that don't belong here.

What it covers — each maps to a problem that actually showed up in past PRs:
- No ABOUTME header comments
- Match the tab indentation (`.swift-format`)
- No agent attribution in commits/PR bodies
- No agent-tooling files (`.claude/` etc.) in PRs

Deliberately per the guidance in the #542/#548 threads:
- No environment-setup duplication — points to `docs/Swiftarr/` instead
- No team list, no remotes list, no pending-contributions section
- Nothing that should need to change per-PR — intended to be lean and stable

Named `AGENTS.md` (tool-agnostic; Claude Code, Codex, and friends all read it). Happy to adjust wording or scope however you'd like.