### PR TITLE
fix: three crash/safety fixes (empty schedule feed, ?limit=0, image buffer lifetime)

### DIFF
--- a/Sources/swiftarr/Controllers/FezController.swift
+++ b/Sources/swiftarr/Controllers/FezController.swift
@@ -1279,7 +1279,9 @@ extension FezController {
 		let readCount = pivot?.readCount ?? 0
 		let hiddenCount = pivot?.hiddenCount ?? 0
 		let limit = (req.query[Int.self, at: "limit"] ?? 50).clamped(to: 0...Settings.shared.maximumTwarrts)
-		let start = (req.query[Int.self, at: "start"] ?? ((readCount - 1) / limit) * limit)
+		// `limit` can be 0; guard the division so ?limit=0 doesn't trap on `(readCount - 1) / limit`.
+		let defaultStart = limit > 0 ? ((readCount - 1) / limit) * limit : 0
+		let start = (req.query[Int.self, at: "start"] ?? defaultStart)
 			.clamped(to: 0...fez.postCount)
 		// get posts
 		let posts = try await FezPost.query(on: req.db)

--- a/Sources/swiftarr/Helpers/EventParser.swift
+++ b/Sources/swiftarr/Helpers/EventParser.swift
@@ -14,6 +14,10 @@ final class EventParser {
 	/// - Returns: `[Event]` containing the events.
 	func parse(_ dataString: String) throws -> [Event] {
 		var icsArray = dataString.split(whereSeparator: \.isNewline)
+		// Empty input would make the unfold loop below build an invalid `1..<0` range and trap.
+		guard !icsArray.isEmpty else {
+			return []
+		}
 		// Unfold any folded lines
 		for icsIndex in (1..<icsArray.count).reversed() {
 			if let firstChar = icsArray[icsIndex].first, firstChar.isWhitespace {

--- a/Sources/swiftarr/Image/SwiftarrImage.swift
+++ b/Sources/swiftarr/Image/SwiftarrImage.swift
@@ -7,6 +7,12 @@ public class SwiftarrImage {
 	/// The underlying libvips image pointer.
 	private var vipsImage: UnsafeMutablePointer<VipsImage>
 
+	/// Retains the encoded source buffer for images loaded via `init(data:)`. libvips loads encoded
+	/// buffers lazily and reads pixel data on demand, so the buffer must outlive the image. Holding it
+	/// here ties its lifetime to this instance instead of the caller's local `Data`. Nil for images
+	/// created from owned pixel data or derived from operations.
+	private let sourceData: Data?
+
 	/// Image dimensions.
 	public var size: Size {
 		let w = vips_image_get_width(vipsImage)
@@ -32,6 +38,7 @@ public class SwiftarrImage {
 		guard !data.isEmpty else {
 			throw ImageError.invalidImage(reason: "Image data is empty")
 		}
+		self.sourceData = data
 
 		let loaded: UnsafeMutablePointer<VipsImage>? = data.withUnsafeBytes { rawBuffer in
 			guard let baseAddress = rawBuffer.baseAddress else { return nil }
@@ -83,11 +90,13 @@ public class SwiftarrImage {
 		}
 		g_object_unref(memImage)
 		self.vipsImage = copyOut!
+		self.sourceData = nil
 	}
 
 	/// Internal init from an already-owned VipsImage pointer.
 	private init(vipsImage: UnsafeMutablePointer<VipsImage>) {
 		self.vipsImage = vipsImage
+		self.sourceData = nil
 	}
 
 	// MARK: - Operations

--- a/Tests/AppTests/EventParserTests.swift
+++ b/Tests/AppTests/EventParserTests.swift
@@ -42,4 +42,16 @@ class EventParserTests: XCTestCase {
 			"Hello, world\nLine 2 & more"
 		)
 	}
+
+	// MARK: - parse edge cases
+
+	func testParse_EmptyString_ReturnsEmptyArray() throws {
+		// Empty input must not trap building `1..<0` (server-process crash).
+		XCTAssertEqual(try parser.parse("").count, 0)
+	}
+
+	func testParse_NewlineOnlyString_ReturnsEmptyArray() throws {
+		// split(whereSeparator:) drops empty subsequences, so a newline-only body is also empty.
+		XCTAssertEqual(try parser.parse("\n\n").count, 0)
+	}
 }


### PR DESCRIPTION
Three independent robustness fixes found while auditing the codebase. All are crash/memory-safety only — no behavior or API changes. Each is a separate commit.

### 1. Empty schedule feed traps the server process
`EventParser.parse` builds a `1..<0` Range on empty (or newline-only) input, which traps — taking down the whole process, not just the job. This is reachable from the hourly `UpdateScheduleJob` if `scheduleUpdateURL` returns an empty 200 body; the admin-upload path already substitutes an empty-schedule payload, but the automatic job path had no equivalent guard. Fixed by returning `[]` for empty input. Covered by a new `EventParserTests` case (it crashed the test runner before the fix).

### 2. `?limit=0` divide-by-zero in `buildPostsForFez`
`limit` is clamped to `0...max`, so a client can pass `?limit=0`. With no `start`, the default computes `(readCount - 1) / limit` → integer divide-by-zero → process trap, on the seamail/LFG posts endpoints. Fixed by guarding the division; `limit` semantics are unchanged.

### 3. `SwiftarrImage.init(data:)` doesn't retain the encoded source buffer
libvips loads encoded buffers lazily and reads pixel data on demand, so the source buffer must outlive the image (its own docs: "you must not free buf until you have read pixel data from out"). `init(data:)` held no reference to the `Data`, so once the caller's local went out of scope the buffer could be freed before pixels were decoded — a use-after-free that manifests as a crash or a corrupted image, depending on ARC/optimizer timing. Fixed by retaining the `Data` on the instance, mirroring the deliberate copy already done in the raw-pixel initializer. (Touches the libvips path added in #548.)

### Testing
- `EventParserTests` extended; full CI test filter green (172 tests, 0 failures).
- `swift build` clean.