### PR TITLE
Expose max image size in client settings

### DIFF
--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -2798,6 +2798,8 @@ public struct ClientSettingsData: Content {
 	var minAccessLevel: String
 	/// Maximum number of images allowed per forum post.
 	var maxForumPostImages: Int
+	/// Maximum size of a single uploaded image, in bytes.
+	var maxImageSize: Int
 	/// Unique identifier for this Postgres database installation (from pg_control_system())
 	var installationID: String
 }
@@ -2815,6 +2817,7 @@ extension ClientSettingsData {
 		self.enablePreregistration = Settings.shared.enablePreregistration
 		self.minAccessLevel = Settings.shared.minAccessLevel.rawValue
 		self.maxForumPostImages = Settings.shared.maxForumPostImages
+		self.maxImageSize = Settings.shared.maxImageSize
 		self.installationID = installationID
 	}
 }

--- a/Tests/AppTests/ContentStructValidationTests.swift
+++ b/Tests/AppTests/ContentStructValidationTests.swift
@@ -111,4 +111,14 @@ class ContentStructValidationTests: XCTestCase {
 		XCTAssertTrue(post.postAsModerator)
 		XCTAssertTrue(post.postAsTwitarrTeam)
 	}
+
+	// MARK: - ClientSettingsData
+
+	func testClientSettings_EncodesMaxImageSize() throws {
+		let settings = ClientSettingsData(installationID: "test-installation")
+		let data = try JSONEncoder().encode(settings)
+		let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+		XCTAssertEqual(json["maxImageSize"] as? Int, Settings.shared.maxImageSize)
+	}
 }

--- a/Tests/AppTests/ContentStructValidationTests.swift
+++ b/Tests/AppTests/ContentStructValidationTests.swift
@@ -1,8 +1,7 @@
 import XCTVapor
 @testable import swiftarr
 
-// Tests for the RCFValidatable conformances on content-creation request structs:
-// ForumCreateData, NoteCreateData, PostContentData.
+// Tests for content-creation request validation and lightweight Content response encoding.
 class ContentStructValidationTests: XCTestCase {
 
 	private let decoder = ValidatingJSONDecoder()

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -223,3 +223,6 @@ associated AddedToChat field value increase.
 
 ## Mar 01, 2026
 * `GET /api/v3/fez/joined` with `onlynew=[true,false]` now include/exclude newly added-to fezzes.
+
+## Jul 19, 2026
+* `GET /api/v3/client/settings` now also includes `maxImageSize`, the maximum uploadable image size in bytes.


### PR DESCRIPTION
## Summary

- expose `maxImageSize` in `ClientSettingsData` using the configured upload limit in bytes
- add an encoding regression in the CI-included content struct tests
- document the API response change

## Testing

- `Build Branch` workflow: Test and BuildAndDeployStack passed

Closes #538