### PR TITLE
fix: standardize pagination query bounds

### DIFF
--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -48,4 +48,4 @@ jobs:
         # SettingsTests and ClientControllerTests need a migrated+seeded database
         # which a pristine CI postgres can't satisfy without infrastructure work
         # outside the scope of this PR.
-        run: swift test --enable-test-discovery --filter "GeometryTests|ValidatingJSONDecoderTests|CruiseDateTests|ThemeCookieTests|CryptoHelperTests|DisabledFeaturesGroupTests|EventParserTests|TimeZoneChangeSetTests|UserStructValidationTests|ContentStructValidationTests|FezAndEventValidationTests|AdminStructValidationTests|DateExtensionTests|SettingsCalendarTests|ContentFilterableTests"
+        run: swift test --enable-test-discovery --filter "GeometryTests|ValidatingJSONDecoderTests|CruiseDateTests|ThemeCookieTests|CryptoHelperTests|DisabledFeaturesGroupTests|EventParserTests|TimeZoneChangeSetTests|UserStructValidationTests|ContentStructValidationTests|FezAndEventValidationTests|AdminStructValidationTests|DateExtensionTests|SettingsCalendarTests|ContentFilterableTests|PaginationTests"

--- a/Sources/swiftarr/Controllers/BoardgameController.swift
+++ b/Sources/swiftarr/Controllers/BoardgameController.swift
@@ -47,8 +47,8 @@ struct BoardgameController: APIRouteCollection {
 		}
 		let user = req.auth.get(UserCacheData.self)
 		let filters = try req.query.decode(GameQueryOptions.self)
-		let start = filters.start ?? 0
-		let limit = (filters.limit ?? 50).clamped(to: 0...Settings.shared.maximumTwarrts)
+		let start = Pagination.start(filters.start)
+		let limit = Pagination.limit(filters.limit, maximum: Settings.shared.maximumTwarrts)
 		let query = Boardgame.query(on: req.db).with(\.$expansions)
 		if let search = filters.search {
 			query.fullTextFilter(\.$gameName, search)
@@ -164,8 +164,8 @@ struct BoardgameController: APIRouteCollection {
 	func recommendGames(_ req: Request) async throws -> BoardgameResponseData {
 		let user = req.auth.get(UserCacheData.self)
 		let data = try ValidatingJSONDecoder().decode(BoardgameRecommendationData.self, fromBodyOf: req)
-		let start = (req.query[Int.self, at: "start"] ?? 0)
-		let limit = (req.query[Int.self, at: "limit"] ?? 50).clamped(to: 0...Settings.shared.maximumTwarrts)
+		let start = Pagination.start(req.query[Int.self, at: "start"])
+		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: Settings.shared.maximumTwarrts)
 		let query = Boardgame.query(on: req.db).with(\.$expansions).filter(\.$minPlayers <= data.numPlayers)
 			.filter(\.$maxPlayers >= data.numPlayers)
 			.filter(\.$avgPlayingTime <= data.timeToPlay)

--- a/Sources/swiftarr/Controllers/BoardgameController.swift
+++ b/Sources/swiftarr/Controllers/BoardgameController.swift
@@ -47,8 +47,11 @@ struct BoardgameController: APIRouteCollection {
 		}
 		let user = req.auth.get(UserCacheData.self)
 		let filters = try req.query.decode(GameQueryOptions.self)
-		let start = Pagination.start(filters.start)
-		let limit = Pagination.limit(filters.limit, maximum: Settings.shared.maximumTwarrts)
+		let pagination = Pagination(
+			start: filters.start,
+			limit: filters.limit,
+			maxPageSize: Settings.shared.maximumTwarrts
+		)
 		let query = Boardgame.query(on: req.db).with(\.$expansions)
 		if let search = filters.search {
 			query.fullTextFilter(\.$gameName, search)
@@ -58,9 +61,12 @@ struct BoardgameController: APIRouteCollection {
 				.filter(BoardgameFavorite.self, \.$user.$id == user.userID)
 		}
 		let totalGames = try await query.copy().count()
-		let games = try await query.sort(\.$bggGameName, .ascending).range(start..<(start + limit)).all()
+		let games = try await query.sort(\.$bggGameName, .ascending).range(pagination.range).all()
 		let gamesArray = try await buildBoardgameData(for: user, games: games, on: req.db)
-		return BoardgameResponseData(gameArray: gamesArray, paginator: Paginator(total: totalGames, start: start, limit: limit))
+		return BoardgameResponseData(
+			gameArray: gamesArray,
+			paginator: Paginator(total: totalGames, start: pagination.start, limit: pagination.limit)
+		)
 	}
 
 	/// `GET /api/v3/boardgames/:boardgameID
@@ -164,8 +170,7 @@ struct BoardgameController: APIRouteCollection {
 	func recommendGames(_ req: Request) async throws -> BoardgameResponseData {
 		let user = req.auth.get(UserCacheData.self)
 		let data = try ValidatingJSONDecoder().decode(BoardgameRecommendationData.self, fromBodyOf: req)
-		let start = Pagination.start(req.query[Int.self, at: "start"])
-		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: Settings.shared.maximumTwarrts)
+		let pagination = Pagination(on: req, maxPageSize: Settings.shared.maximumTwarrts)
 		let query = Boardgame.query(on: req.db).with(\.$expansions).filter(\.$minPlayers <= data.numPlayers)
 			.filter(\.$maxPlayers >= data.numPlayers)
 			.filter(\.$avgPlayingTime <= data.timeToPlay)
@@ -201,9 +206,12 @@ struct BoardgameController: APIRouteCollection {
 			.sorted { $0.score > $1.score }
 
 		let orderedPageOfGames = orderedGames.enumerated()
-			.compactMap { (start...(start + limit)).contains($0.0) ? $0.1.game : nil }
+			.compactMap { pagination.range.contains($0.0) ? $0.1.game : nil }
 		let gamesArray = try await buildBoardgameData(for: user, games: orderedPageOfGames, on: req.db)
-		return BoardgameResponseData(gameArray: gamesArray, paginator: Paginator(total: orderedGames.count, start: start, limit: limit))
+		return BoardgameResponseData(
+			gameArray: gamesArray,
+			paginator: Paginator(total: orderedGames.count, start: pagination.start, limit: pagination.limit)
+		)
 	}
 
 	/// `POST /api/v3/boardgames/reload`

--- a/Sources/swiftarr/Controllers/FezController.swift
+++ b/Sources/swiftarr/Controllers/FezController.swift
@@ -41,18 +41,8 @@ struct FezController: APIRouteCollection {
 			return excludeTypes.count > 0 ? excludeTypes : nil
 		}
 
-		func calcStart() -> Int {
-			return Pagination.start(start)
-		}
-
-		func calcLimit() -> Int {
-			return Pagination.limit(limit, maximum: Settings.shared.maximumTwarrts)
-		}
-
-		// Used for: dbQuery.range(urlQuery.calcRange())
-		func calcRange() -> Range<Int> {
-			let rangeStart = calcStart()
-			return rangeStart..<(rangeStart + calcLimit())
+		var pagination: Pagination {
+			return Pagination(start: start, limit: limit, maxPageSize: Settings.shared.maximumTwarrts)
 		}
 	}
 
@@ -124,6 +114,7 @@ struct FezController: APIRouteCollection {
 	/// - Returns: An array of `FezData` containing current fezzes with open slots.
 	func openHandler(_ req: Request) async throws -> FezListData {
 		let urlQuery = try req.query.decode(FezURLQueryStruct.self)
+		let pagination = urlQuery.pagination
 		let cacheUser = try req.auth.require(UserCacheData.self)
 
 		let fezQuery = FriendlyFez.query(on: req.db)
@@ -159,7 +150,7 @@ struct FezController: APIRouteCollection {
 		}
 		let fezCount = try await fezQuery.count()
 		let fezzes = try await fezQuery.sort(\.$startTime, .ascending).sort(\.$title, .ascending)
-			.range(urlQuery.calcRange()).all()
+			.range(pagination.range).all()
 		let fezDataArray: [FezData] = try fezzes.compactMap { fez in
 			// Fezzes are only 'open' if their waitlist is < 1/2 the size of their capacity. A fez with a max of 10 people
 			// could have a waitlist of 5, then it stops showing up in 'open' searches.
@@ -171,7 +162,7 @@ struct FezController: APIRouteCollection {
 			return nil
 		}
 		return FezListData(
-			paginator: Paginator(total: fezCount, start: urlQuery.calcStart(), limit: urlQuery.calcLimit()),
+			paginator: Paginator(total: fezCount, start: pagination.start, limit: pagination.limit),
 			fezzes: fezDataArray
 		)
 	}
@@ -227,9 +218,8 @@ struct FezController: APIRouteCollection {
 	/// - Returns: An array of `FezData` containing all the fezzes created by the user.
 	func ownerHandler(_ req: Request) async throws -> FezListData {
 		let urlQuery = try req.query.decode(FezURLQueryStruct.self)
+		let pagination = urlQuery.pagination
 		let user = try req.auth.require(UserCacheData.self)
-		let start = Pagination.start(req.query[Int.self, at: "start"])
-		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: Settings.shared.maximumTwarrts)
 		let query = FriendlyFez.query(on: req.db).filter(\.$owner.$id == user.userID)
 			.join(FezParticipant.self, on: \FezParticipant.$fez.$id == \FriendlyFez.$id)
 			.filter(FezParticipant.self, \.$user.$id == user.userID)
@@ -267,13 +257,16 @@ struct FezController: APIRouteCollection {
 
 		// get owned fezzes
 		let fezCount = try await query.count()
-		let fezzes = try await query.range(start..<(start + limit)).sort(\.$createdAt, .descending).all()
+		let fezzes = try await query.range(pagination.range).sort(\.$createdAt, .descending).all()
 		// convert to FezData
 		let fezDataArray = try fezzes.map { (fez) -> FezData in
 			let userParticipant = try fez.joined(FezParticipant.self)
 			return try buildFezData(from: fez, with: userParticipant, for: user, on: req)
 		}
-		return FezListData(paginator: Paginator(total: fezCount, start: start, limit: limit), fezzes: fezDataArray)
+		return FezListData(
+			paginator: Paginator(total: fezCount, start: pagination.start, limit: pagination.limit),
+			fezzes: fezDataArray
+		)
 	}
 
 	/// `GET /api/v3/fez/:fez_ID`
@@ -351,6 +344,7 @@ struct FezController: APIRouteCollection {
 	/// closed Seamails or Personal Events as their member lists cannot change.
 	func formerlyJoinedFezHandler(_ req: Request) async throws -> FezListData {
 		let urlQuery = try req.query.decode(FezURLQueryStruct.self)
+		let pagination = urlQuery.pagination
 		let cacheUser = try req.auth.require(UserCacheData.self)
 		let effectiveUser = try getEffectiveUser(user: cacheUser, req: req)
 		// .withDeleted keeps Fluent from filtering out soft-deleted FriendlyFezzes and FezParticipants. The deletedAt filter then matches
@@ -360,12 +354,15 @@ struct FezController: APIRouteCollection {
 				.filter(FriendlyFez.self, \.$fezType !~ [.closed, .personalEvent])
 				.withDeleted().filter(\.$deletedAt < Date())
 		let fezCount = try await query.count()
-		let pivots = try await query.copy().sort(FriendlyFez.self, \.$createdAt, .descending).range(urlQuery.calcRange()).all()
+		let pivots = try await query.copy().sort(FriendlyFez.self, \.$createdAt, .descending).range(pagination.range).all()
 		let fezDataArray = try pivots.map { pivot -> FezData in
 			let fez = try pivot.joined(FriendlyFez.self)
 			return try buildFezData(from: fez, with: nil, for: effectiveUser, on: req)
 		}
-		return FezListData(paginator: Paginator(total: fezCount, start: urlQuery.calcStart(), limit: urlQuery.calcLimit()), fezzes: fezDataArray)
+		return FezListData(
+			paginator: Paginator(total: fezCount, start: pagination.start, limit: pagination.limit),
+			fezzes: fezDataArray
+		)
 	}
 
 	// MARK: Membership
@@ -1008,6 +1005,7 @@ extension FezController {
 	// This is the bulk of the joinedHandler, pulled out into a separate fn. This allows us to modify the urlQuery arguments
 	// before calling.
 	func getJoinedChats(_ req: Request, urlQuery: FezURLQueryStruct) async throws -> FezListData {
+		let pagination = urlQuery.pagination
 		let cacheUser = try req.auth.require(UserCacheData.self)
 		let effectiveUser = try getEffectiveUser(user: cacheUser, req: req)
 
@@ -1106,12 +1104,12 @@ extension FezController {
 		}
 		let fezCount = try await query.count()
 		let pivots = try await query.copy().sort(FezParticipant.self, \.$isMuted, .descending)
-			.sort(FriendlyFez.self, \.$updatedAt, .descending).range(urlQuery.calcRange()).all()
+			.sort(FriendlyFez.self, \.$updatedAt, .descending).range(pagination.range).all()
 		let fezDataArray = try pivots.map { pivot -> FezData in
 			let fez = try pivot.joined(FriendlyFez.self)
 			return try buildFezData(from: fez, with: pivot, for: cacheUser, on: req)
 		}
-		return FezListData(paginator: Paginator(total: fezCount, start: urlQuery.calcStart(), limit: urlQuery.calcLimit()),
+		return FezListData(paginator: Paginator(total: fezCount, start: pagination.start, limit: pagination.limit),
 				fezzes: fezDataArray)
 	}
 
@@ -1278,25 +1276,38 @@ extension FezController {
 	{
 		let readCount = pivot?.readCount ?? 0
 		let hiddenCount = pivot?.hiddenCount ?? 0
-		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: Settings.shared.maximumTwarrts)
-		let defaultStart = ((readCount - 1) / limit) * limit
-		let start = Pagination.start(req.query[Int.self, at: "start"], default: defaultStart)
-			.clamped(to: 0...fez.postCount)
+		let requestedPagination = Pagination(on: req, maxPageSize: Settings.shared.maximumTwarrts)
+		let defaultStart = ((readCount - 1) / requestedPagination.limit) * requestedPagination.limit
+		let pagination = Pagination(
+			start: req.query[Int.self, at: "start"],
+			limit: requestedPagination.limit,
+			defaultStart: defaultStart,
+			maxPageSize: Settings.shared.maximumTwarrts
+		)
+		let boundedPagination = Pagination(
+			start: pagination.start.clamped(to: 0...fez.postCount),
+			limit: pagination.limit,
+			maxPageSize: Settings.shared.maximumTwarrts
+		)
 		// get posts
 		let posts = try await FezPost.query(on: req.db)
 			.filter(\.$fez.$id == fez.requireID())
 			.filter(\.$author.$id !~ user.getBlocks())
 			.filter(\.$author.$id !~ user.getMutes())
 			.sort(\.$createdAt, .ascending)
-			.range(start..<(start + limit))
+			.range(boundedPagination.range)
 			.all()
 		let postDatas = try posts.map { try FezPostData(post: $0, author: req.userCache.getHeader($0.$author.id)) }
-		let paginator = Paginator(total: fez.postCount - hiddenCount, start: start, limit: limit)
+		let paginator = Paginator(
+			total: fez.postCount - hiddenCount,
+			start: boundedPagination.start,
+			limit: boundedPagination.limit
+		)
 
 		// If this batch of posts is farther into the thread than the user has previously read, increase
 		// the user's read count.
-		if let pivot = pivot, start + limit > pivot.readCount {
-			pivot.readCount = min(start + limit, fez.postCount - pivot.hiddenCount)
+		if let pivot = pivot, boundedPagination.range.upperBound > pivot.readCount {
+			pivot.readCount = min(boundedPagination.range.upperBound, fez.postCount - pivot.hiddenCount)
 			try await pivot.save(on: req.db)
 			// If the user has now read all the posts (except those hidden from them) mark this notification as viewed.
 			// Only mark as read for the current user, not all users in the privileged mailbox group.

--- a/Sources/swiftarr/Controllers/FezController.swift
+++ b/Sources/swiftarr/Controllers/FezController.swift
@@ -42,11 +42,11 @@ struct FezController: APIRouteCollection {
 		}
 
 		func calcStart() -> Int {
-			return start ?? 0
+			return Pagination.start(start)
 		}
 
 		func calcLimit() -> Int {
-			return (limit ?? 50).clamped(to: 0...Settings.shared.maximumTwarrts)
+			return Pagination.limit(limit, maximum: Settings.shared.maximumTwarrts)
 		}
 
 		// Used for: dbQuery.range(urlQuery.calcRange())
@@ -228,8 +228,8 @@ struct FezController: APIRouteCollection {
 	func ownerHandler(_ req: Request) async throws -> FezListData {
 		let urlQuery = try req.query.decode(FezURLQueryStruct.self)
 		let user = try req.auth.require(UserCacheData.self)
-		let start = (req.query[Int.self, at: "start"] ?? 0)
-		let limit = (req.query[Int.self, at: "limit"] ?? 50).clamped(to: 0...Settings.shared.maximumTwarrts)
+		let start = Pagination.start(req.query[Int.self, at: "start"])
+		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: Settings.shared.maximumTwarrts)
 		let query = FriendlyFez.query(on: req.db).filter(\.$owner.$id == user.userID)
 			.join(FezParticipant.self, on: \FezParticipant.$fez.$id == \FriendlyFez.$id)
 			.filter(FezParticipant.self, \.$user.$id == user.userID)
@@ -1278,10 +1278,9 @@ extension FezController {
 	{
 		let readCount = pivot?.readCount ?? 0
 		let hiddenCount = pivot?.hiddenCount ?? 0
-		let limit = (req.query[Int.self, at: "limit"] ?? 50).clamped(to: 0...Settings.shared.maximumTwarrts)
-		// `limit` can be 0; guard the division so ?limit=0 doesn't trap on `(readCount - 1) / limit`.
-		let defaultStart = limit > 0 ? ((readCount - 1) / limit) * limit : 0
-		let start = (req.query[Int.self, at: "start"] ?? defaultStart)
+		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: Settings.shared.maximumTwarrts)
+		let defaultStart = ((readCount - 1) / limit) * limit
+		let start = Pagination.start(req.query[Int.self, at: "start"], default: defaultStart)
 			.clamped(to: 0...fez.postCount)
 		// get posts
 		let posts = try await FezPost.query(on: req.db)

--- a/Sources/swiftarr/Controllers/ForumController.swift
+++ b/Sources/swiftarr/Controllers/ForumController.swift
@@ -163,8 +163,8 @@ struct ForumController: APIRouteCollection {
 	/// - Returns: `CategoryData` containing category forums.
 	func categoryForumsHandler(_ req: Request) async throws -> CategoryData {
 		let cacheUser: UserCacheData = try req.auth.require(UserCacheData.self)
-		let start = (req.query[Int.self, at: "start"] ?? 0)
-		let limit = (req.query[Int.self, at: "limit"] ?? 50).clamped(to: 0...Settings.shared.maximumForums)
+		let start = Pagination.start(req.query[Int.self, at: "start"])
+		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: Settings.shared.maximumForums)
 		let category = try await Category.findFromParameter(categoryIDParam, on: req)
 		try guardUserCanAccessCategory(cacheUser, category: category)
 		// remove blocks from results, unless it's an admin category
@@ -291,8 +291,8 @@ struct ForumController: APIRouteCollection {
 			var order: String?
 			
 			mutating func afterDecode() throws {
-				start = start ?? 0
-				limit = (limit ?? 50).clamped(to: 0...Settings.shared.maximumForums)
+				start = Pagination.start(start)
+				limit = Pagination.limit(limit, maximum: Settings.shared.maximumForums)
 				// postgres "_" and "%" are wildcards, so escape for literals
 				search = search?.replacingOccurrences(of: "_", with: "\\_").replacingOccurrences(of: "%", with: "\\%")
 						.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -403,8 +403,8 @@ struct ForumController: APIRouteCollection {
 	/// - Returns: A `ForumSearchData` containing all forums created by the user.
 	func ownerHandler(_ req: Request) async throws -> ForumSearchData {
 		let cacheUser = try req.auth.require(UserCacheData.self)
-		let start = (req.query[Int.self, at: "start"] ?? 0)
-		let limit = (req.query[Int.self, at: "limit"] ?? 50).clamped(to: 0...Settings.shared.maximumForums)
+		let start = Pagination.start(req.query[Int.self, at: "start"])
+		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: Settings.shared.maximumForums)
 		let countQuery = Forum.query(on: req.db).filter(\.$creator.$id == cacheUser.userID)
 			.categoryAccessFilter(for: cacheUser)
 		if let cat = req.query[UUID.self, at: "cat"] {
@@ -437,8 +437,8 @@ struct ForumController: APIRouteCollection {
 	/// - Returns: A `ForumSearchData` containing the user's favorited forums.
 	func favoritesHandler(_ req: Request) async throws -> ForumSearchData {
 		let cacheUser = try req.auth.require(UserCacheData.self)
-		let start = (req.query[Int.self, at: "start"] ?? 0)
-		let limit = (req.query[Int.self, at: "limit"] ?? 50).clamped(to: 0...Settings.shared.maximumForums)
+		let start = Pagination.start(req.query[Int.self, at: "start"])
+		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: Settings.shared.maximumForums)
 		let countQuery = Forum.query(on: req.db).filter(\.$creator.$id !~ cacheUser.getBlocks())
 			.categoryAccessFilter(for: cacheUser)
 			.join(ForumReaders.self, on: \Forum.$id == \ForumReaders.$forum.$id)
@@ -474,8 +474,8 @@ struct ForumController: APIRouteCollection {
 	/// - Returns: A `ForumSearchData` containing the user's muted forums.
 	func mutesHandler(_ req: Request) async throws -> ForumSearchData {
 		let cacheUser = try req.auth.require(UserCacheData.self)
-		let start = (req.query[Int.self, at: "start"] ?? 0)
-		let limit = (req.query[Int.self, at: "limit"] ?? 50).clamped(to: 0...Settings.shared.maximumForums)
+		let start = Pagination.start(req.query[Int.self, at: "start"])
+		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: Settings.shared.maximumForums)
 		let countQuery = Forum.query(on: req.db).filter(\.$creator.$id !~ cacheUser.getBlocks())
 			.categoryAccessFilter(for: cacheUser)
 			.join(ForumReaders.self, on: \Forum.$id == \ForumReaders.$forum.$id)
@@ -511,8 +511,8 @@ struct ForumController: APIRouteCollection {
 	/// - Returns: A `ForumSearchData` containing the user's muted forums.
 	func unreadHandler(_ req: Request) async throws -> ForumSearchData {
 		let cacheUser = try req.auth.require(UserCacheData.self)
-		let start = (req.query[Int.self, at: "start"] ?? 0)
-		let limit = (req.query[Int.self, at: "limit"] ?? 50).clamped(to: 0...Settings.shared.maximumForums)
+		let start = Pagination.start(req.query[Int.self, at: "start"])
+		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: Settings.shared.maximumForums)
 		// https://github.com/jocosocial/swiftarr/issues/217
 		// Lots of swearing, source code reading, and AI hallucinations went into the crafting of this
 		// join. Unfortunately we can't do:
@@ -563,8 +563,8 @@ struct ForumController: APIRouteCollection {
 	/// - Returns: A `ForumSearchData` containing the user's favorited forums.
 	func recentsHandler(_ req: Request) async throws -> ForumSearchData {
 		let cacheUser = try req.auth.require(UserCacheData.self)
-		let start = (req.query[Int.self, at: "start"] ?? 0)
-		let limit = (req.query[Int.self, at: "limit"] ?? 50).clamped(to: 0...Settings.shared.maximumForums)
+		let start = Pagination.start(req.query[Int.self, at: "start"])
+		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: Settings.shared.maximumForums)
 		let countQuery = Forum.query(on: req.db).filter(\.$creator.$id !~ cacheUser.getBlocks())
 				.categoryAccessFilter(for: cacheUser)
 				.join(ForumReaders.self, on: \Forum.$id == \ForumReaders.$forum.$id)
@@ -748,8 +748,8 @@ struct ForumController: APIRouteCollection {
 	func postSearchHandler(_ req: Request) async throws -> PostSearchData {
 		let cacheUser = try req.auth.require(UserCacheData.self)
 		var postFilterMentions: String? = nil
-		let start = (req.query[Int.self, at: "start"] ?? 0)
-		let limit = (req.query[Int.self, at: "limit"] ?? 50).clamped(to: 0...Settings.shared.maximumForumPosts)
+		let start = Pagination.start(req.query[Int.self, at: "start"])
+		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: Settings.shared.maximumForumPosts)
 		// Start building a query.
 		// Note: categoryAccessFilter() joins the post's forum and category, but other filters (below) may require the join as well.
 		var query = ForumPost.query(on: req.db).filter(\.$author.$id !~ cacheUser.getBlocks())
@@ -1745,7 +1745,7 @@ extension ForumController {
 		let cacheUser = try req.auth.require(UserCacheData.self)
 		var readerPivot = try await forum.$readers.$pivots.query(on: req.db).filter(\.$user.$id == cacheUser.userID)
 			.first()
-		let limit = (req.query[Int.self, at: "limit"] ?? 50).clamped(to: 1...Settings.shared.maximumForumPosts)
+		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: Settings.shared.maximumForumPosts)
 		let query = forum.$posts.query(on: req.db)
 			.filter(\.$author.$id !~ cacheUser.getBlocks())
 			.filter(\.$author.$id !~ cacheUser.getMutes())
@@ -1755,7 +1755,7 @@ extension ForumController {
 		// Determine the start offset into the posts array.
 		var start = 0
 		if let startParam = req.query[Int.self, at: "start"] {
-			start = max(startParam, 0)
+			start = Pagination.start(startParam)
 		}
 		else if let startPostIDParam = req.query[Int.self, at: "startPost"] {
 			start = try await forum.$posts.query(on: req.db).filter(\.$id < startPostIDParam)

--- a/Sources/swiftarr/Controllers/ForumController.swift
+++ b/Sources/swiftarr/Controllers/ForumController.swift
@@ -163,8 +163,7 @@ struct ForumController: APIRouteCollection {
 	/// - Returns: `CategoryData` containing category forums.
 	func categoryForumsHandler(_ req: Request) async throws -> CategoryData {
 		let cacheUser: UserCacheData = try req.auth.require(UserCacheData.self)
-		let start = Pagination.start(req.query[Int.self, at: "start"])
-		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: Settings.shared.maximumForums)
+		let pagination = Pagination(on: req, maxPageSize: Settings.shared.maximumForums)
 		let category = try await Category.findFromParameter(categoryIDParam, on: req)
 		try guardUserCanAccessCategory(cacheUser, category: category)
 		// remove blocks from results, unless it's an admin category
@@ -233,7 +232,7 @@ struct ForumController: APIRouteCollection {
 				countQuery.filter(\.$createdAt > afterDate)
 			}
 		}
-		let forumsQuery = countQuery.copy().range(start..<(start + limit))
+		let forumsQuery = countQuery.copy().range(pagination.range)
 		let forums = try await forumsQuery.all()
 		// We store the number of threads in a category in the database via Category.forumCount.
 		// But this is global and doesn't account for users blocks. For the purposes of Pagination
@@ -243,7 +242,7 @@ struct ForumController: APIRouteCollection {
 		return try CategoryData(
 			category,
 			restricted: category.accessLevelToCreate > cacheUser.accessLevel,
-			paginator: Paginator(total: forumCount, start: start, limit: limit),
+			paginator: Paginator(total: forumCount, start: pagination.start, limit: pagination.limit),
 			forumThreads: forumList
 		)
 	}
@@ -289,10 +288,12 @@ struct ForumController: APIRouteCollection {
 			var limit: Int?
 			var sort: String?
 			var order: String?
+
+			var pagination: Pagination {
+				return Pagination(start: start, limit: limit, maxPageSize: Settings.shared.maximumForums)
+			}
 			
 			mutating func afterDecode() throws {
-				start = Pagination.start(start)
-				limit = Pagination.limit(limit, maximum: Settings.shared.maximumForums)
 				// postgres "_" and "%" are wildcards, so escape for literals
 				search = search?.replacingOccurrences(of: "_", with: "\\_").replacingOccurrences(of: "%", with: "\\%")
 						.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -308,6 +309,7 @@ struct ForumController: APIRouteCollection {
 		}
 		let cacheUser = try req.auth.require(UserCacheData.self)
 		var urlQuery = try req.query.decode(QueryStruct.self)
+		let pagination = urlQuery.pagination
 		// Vapor/URLEncodedForm/URLEncodedFormDecoder.swift doesn't seem to want to decode 'flag' URL query params into structs.
 		// Because of that, we have to do this to set the values. See https://github.com/vapor/vapor/issues/3163
 		urlQuery.creatorself = req.query[Bool.self, at: "creatorself"]
@@ -375,10 +377,8 @@ struct ForumController: APIRouteCollection {
 		}
 		// get forums and total forum count, turn into [ForumListData] and then insert into ForumSearchData
 		let forumCount = try await countQuery.count()
-		let start = urlQuery.start ?? 0
-		let limit = urlQuery.limit ?? 50
 		let orderDirection = req.orderDirection();
-		let forumQuery = countQuery.copy().range(start..<(start + limit)).join(child: \.$scheduleEvent, method: .left)
+		let forumQuery = countQuery.copy().range(pagination.range).join(child: \.$scheduleEvent, method: .left)
 		switch req.query[String.self, at: "sort"] {
 			case "create": _ = forumQuery.sort(\.$createdAt, orderDirection ?? .descending)
 			case "title": _ = forumQuery.sort(.custom("lower(\"forum\".\"title\")"), orderDirection ?? .ascending)
@@ -386,7 +386,10 @@ struct ForumController: APIRouteCollection {
 		}
 		let forums = try await forumQuery.all()
 		let forumList = try await buildForumListData(forums, on: req, user: cacheUser)
-		return ForumSearchData( paginator: Paginator(total: forumCount, start: start, limit: limit), forumThreads: forumList)
+		return ForumSearchData(
+			paginator: Paginator(total: forumCount, start: pagination.start, limit: pagination.limit),
+			forumThreads: forumList
+		)
 	}
 
 	/// `GET /api/v3/forum/owner`
@@ -403,8 +406,7 @@ struct ForumController: APIRouteCollection {
 	/// - Returns: A `ForumSearchData` containing all forums created by the user.
 	func ownerHandler(_ req: Request) async throws -> ForumSearchData {
 		let cacheUser = try req.auth.require(UserCacheData.self)
-		let start = Pagination.start(req.query[Int.self, at: "start"])
-		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: Settings.shared.maximumForums)
+		let pagination = Pagination(on: req, maxPageSize: Settings.shared.maximumForums)
 		let countQuery = Forum.query(on: req.db).filter(\.$creator.$id == cacheUser.userID)
 			.categoryAccessFilter(for: cacheUser)
 		if let cat = req.query[UUID.self, at: "cat"] {
@@ -412,7 +414,7 @@ struct ForumController: APIRouteCollection {
 		}
 		let forumCount = try await countQuery.count()
 		let orderDirection = req.orderDirection();
-		let forumQuery = countQuery.copy().range(start..<(start + limit)).join(child: \.$scheduleEvent, method: .left)
+		let forumQuery = countQuery.copy().range(pagination.range).join(child: \.$scheduleEvent, method: .left)
 		switch req.query[String.self, at: "sort"] {
 		case "create": _ = forumQuery.sort(\.$createdAt, orderDirection ?? .descending)
 		case "update": _ = forumQuery.sort(\.$lastPostTime, orderDirection ?? .descending)
@@ -420,7 +422,10 @@ struct ForumController: APIRouteCollection {
 		}
 		async let forums = try forumQuery.all()
 		let forumList = try await buildForumListData(forums, on: req, user: cacheUser)
-		return ForumSearchData(paginator: Paginator(total: forumCount, start: start, limit: limit), forumThreads: forumList)
+		return ForumSearchData(
+			paginator: Paginator(total: forumCount, start: pagination.start, limit: pagination.limit),
+			forumThreads: forumList
+		)
 	}
 
 	/// `GET /api/v3/forum/favorites`
@@ -437,8 +442,7 @@ struct ForumController: APIRouteCollection {
 	/// - Returns: A `ForumSearchData` containing the user's favorited forums.
 	func favoritesHandler(_ req: Request) async throws -> ForumSearchData {
 		let cacheUser = try req.auth.require(UserCacheData.self)
-		let start = Pagination.start(req.query[Int.self, at: "start"])
-		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: Settings.shared.maximumForums)
+		let pagination = Pagination(on: req, maxPageSize: Settings.shared.maximumForums)
 		let countQuery = Forum.query(on: req.db).filter(\.$creator.$id !~ cacheUser.getBlocks())
 			.categoryAccessFilter(for: cacheUser)
 			.join(ForumReaders.self, on: \Forum.$id == \ForumReaders.$forum.$id)
@@ -449,7 +453,7 @@ struct ForumController: APIRouteCollection {
 		}
 		let forumCount = try await countQuery.count()
 		let orderDirection = req.orderDirection()
-		let forumQuery = countQuery.copy().range(start..<(start + limit)).join(child: \.$scheduleEvent, method: .left)
+		let forumQuery = countQuery.copy().range(pagination.range).join(child: \.$scheduleEvent, method: .left)
 		switch req.query[String.self, at: "sort"] {
 		case "create": _ = forumQuery.sort(\.$createdAt, orderDirection ?? .descending)
 		case "title": _ = forumQuery.sort(.custom("lower(\"forum\".\"title\")"), orderDirection ?? .ascending)
@@ -457,7 +461,10 @@ struct ForumController: APIRouteCollection {
 		}
 		async let forums = try forumQuery.all()
 		let forumList = try await buildForumListData(forums, on: req, user: cacheUser, forceIsFavorite: true)
-		return ForumSearchData(paginator: Paginator(total: forumCount, start: start, limit: limit), forumThreads: forumList)
+		return ForumSearchData(
+			paginator: Paginator(total: forumCount, start: pagination.start, limit: pagination.limit),
+			forumThreads: forumList
+		)
 	}
 
 	/// `GET /api/v3/forum/mutes`
@@ -474,8 +481,7 @@ struct ForumController: APIRouteCollection {
 	/// - Returns: A `ForumSearchData` containing the user's muted forums.
 	func mutesHandler(_ req: Request) async throws -> ForumSearchData {
 		let cacheUser = try req.auth.require(UserCacheData.self)
-		let start = Pagination.start(req.query[Int.self, at: "start"])
-		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: Settings.shared.maximumForums)
+		let pagination = Pagination(on: req, maxPageSize: Settings.shared.maximumForums)
 		let countQuery = Forum.query(on: req.db).filter(\.$creator.$id !~ cacheUser.getBlocks())
 			.categoryAccessFilter(for: cacheUser)
 			.join(ForumReaders.self, on: \Forum.$id == \ForumReaders.$forum.$id)
@@ -486,7 +492,7 @@ struct ForumController: APIRouteCollection {
 		}
 		let forumCount = try await countQuery.count()
 		let orderDirection = req.orderDirection()
-		let forumQuery = countQuery.copy().range(start..<(start + limit)).join(child: \.$scheduleEvent, method: .left)
+		let forumQuery = countQuery.copy().range(pagination.range).join(child: \.$scheduleEvent, method: .left)
 		switch req.query[String.self, at: "sort"] {
 		case "create": _ = forumQuery.sort(\.$createdAt, orderDirection ?? .descending)
 		case "title": _ = forumQuery.sort(.custom("lower(\"forum\".\"title\")"), orderDirection ?? .ascending)
@@ -494,7 +500,10 @@ struct ForumController: APIRouteCollection {
 		}
 		async let forums = try forumQuery.all()
 		let forumList = try await buildForumListData(forums, on: req, user: cacheUser, forceIsMuted: true)
-		return ForumSearchData(paginator: Paginator(total: forumCount, start: start, limit: limit), forumThreads: forumList)
+		return ForumSearchData(
+			paginator: Paginator(total: forumCount, start: pagination.start, limit: pagination.limit),
+			forumThreads: forumList
+		)
 	}
 
 	/// `GET /api/v3/forum/unread`
@@ -511,8 +520,7 @@ struct ForumController: APIRouteCollection {
 	/// - Returns: A `ForumSearchData` containing the user's muted forums.
 	func unreadHandler(_ req: Request) async throws -> ForumSearchData {
 		let cacheUser = try req.auth.require(UserCacheData.self)
-		let start = Pagination.start(req.query[Int.self, at: "start"])
-		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: Settings.shared.maximumForums)
+		let pagination = Pagination(on: req, maxPageSize: Settings.shared.maximumForums)
 		// https://github.com/jocosocial/swiftarr/issues/217
 		// Lots of swearing, source code reading, and AI hallucinations went into the crafting of this
 		// join. Unfortunately we can't do:
@@ -541,7 +549,7 @@ struct ForumController: APIRouteCollection {
 		}
 		let forumCount = try await countQuery.count()
 		let orderDirection = req.orderDirection()
-		let forumQuery = countQuery.copy().range(start..<(start + limit)).join(child: \.$scheduleEvent, method: .left)
+		let forumQuery = countQuery.copy().range(pagination.range).join(child: \.$scheduleEvent, method: .left)
 		switch req.query[String.self, at: "sort"] {
 		case "create": _ = forumQuery.sort(\.$createdAt, orderDirection ?? .descending)
 		case "title": _ = forumQuery.sort(.custom("lower(\"forum\".\"title\")"), orderDirection ?? .ascending)
@@ -549,7 +557,10 @@ struct ForumController: APIRouteCollection {
 		}
 		let forums = try await forumQuery.all()
 		let forumList = try await buildForumListData(forums, on: req, user: cacheUser)
-		return ForumSearchData(paginator: Paginator(total: forumCount, start: start, limit: limit), forumThreads: forumList)
+		return ForumSearchData(
+			paginator: Paginator(total: forumCount, start: pagination.start, limit: pagination.limit),
+			forumThreads: forumList
+		)
 	}
 
 	/// `GET /api/v3/forum/recent`
@@ -563,19 +574,21 @@ struct ForumController: APIRouteCollection {
 	/// - Returns: A `ForumSearchData` containing the user's favorited forums.
 	func recentsHandler(_ req: Request) async throws -> ForumSearchData {
 		let cacheUser = try req.auth.require(UserCacheData.self)
-		let start = Pagination.start(req.query[Int.self, at: "start"])
-		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: Settings.shared.maximumForums)
+		let pagination = Pagination(on: req, maxPageSize: Settings.shared.maximumForums)
 		let countQuery = Forum.query(on: req.db).filter(\.$creator.$id !~ cacheUser.getBlocks())
 				.categoryAccessFilter(for: cacheUser)
 				.join(ForumReaders.self, on: \Forum.$id == \ForumReaders.$forum.$id)
 				.filter(ForumReaders.self, \.$user.$id == cacheUser.userID)
 		let forumCount = try await countQuery.count()
-		let rangeQuery = countQuery.copy().range(start..<(start + limit))
+		let rangeQuery = countQuery.copy().range(pagination.range)
 				.sort(ForumReaders.self, \.$updatedAt, .descending)
 				.join(child: \.$scheduleEvent, method: .left)
 		let forums = try await rangeQuery.all()
 		let forumList = try await buildForumListData(forums, on: req, user: cacheUser, forceIsFavorite: false)
-		return ForumSearchData(paginator: Paginator(total: forumCount, start: start, limit: limit), forumThreads: forumList)
+		return ForumSearchData(
+			paginator: Paginator(total: forumCount, start: pagination.start, limit: pagination.limit),
+			forumThreads: forumList
+		)
 	}
 
 	// MARK: Returns Posts
@@ -748,8 +761,7 @@ struct ForumController: APIRouteCollection {
 	func postSearchHandler(_ req: Request) async throws -> PostSearchData {
 		let cacheUser = try req.auth.require(UserCacheData.self)
 		var postFilterMentions: String? = nil
-		let start = Pagination.start(req.query[Int.self, at: "start"])
-		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: Settings.shared.maximumForumPosts)
+		let pagination = Pagination(on: req, maxPageSize: Settings.shared.maximumForumPosts)
 		// Start building a query.
 		// Note: categoryAccessFilter() joins the post's forum and category, but other filters (below) may require the join as well.
 		var query = ForumPost.query(on: req.db).filter(\.$author.$id !~ cacheUser.getBlocks())
@@ -801,7 +813,7 @@ struct ForumController: APIRouteCollection {
 				.replacingOccurrences(of: "%", with: "\\%")
 				.trimmingCharacters(in: .whitespacesAndNewlines)
 			query.fullTextFilter(\.$text, searchStr)
-			if !searchStr.contains(" ") && start == 0 {
+			if !searchStr.contains(" ") && pagination.start == 0 {
 				try await markNotificationViewed(user: cacheUser, type: .alertwordPost(searchStr, 0), on: req)
 			}
 		}
@@ -847,7 +859,7 @@ struct ForumController: APIRouteCollection {
 		let countQuery = query.copy()
 		let rangeQuery = query.copy()
 		let totalPostsFound = try await countQuery.count()
-		let posts = try await rangeQuery.range(start..<(start + limit)).all()
+		let posts = try await rangeQuery.range(pagination.range).all()
 		// The filter() for mentions will include usernames that are prefixes for other usernames and other false positives.
 		// This filters those out after the query.
 		var postFilteredPosts = posts
@@ -859,7 +871,7 @@ struct ForumController: APIRouteCollection {
 		}
 		let postData = try await buildPostData(postFilteredPosts, userID: cacheUser.userID, on: req, mutewords: cacheUser.mutewords)
 		return PostSearchData(queryString: req.url.query ?? "", posts: postData,
-				paginator: Paginator(total: totalPostsFound, start: start, limit: limit))
+				paginator: Paginator(total: totalPostsFound, start: pagination.start, limit: pagination.limit))
 	}
 
 	// MARK: POST and DELETE actions
@@ -1745,7 +1757,7 @@ extension ForumController {
 		let cacheUser = try req.auth.require(UserCacheData.self)
 		var readerPivot = try await forum.$readers.$pivots.query(on: req.db).filter(\.$user.$id == cacheUser.userID)
 			.first()
-		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: Settings.shared.maximumForumPosts)
+		let requestedPagination = Pagination(on: req, maxPageSize: Settings.shared.maximumForumPosts)
 		let query = forum.$posts.query(on: req.db)
 			.filter(\.$author.$id !~ cacheUser.getBlocks())
 			.filter(\.$author.$id !~ cacheUser.getMutes())
@@ -1753,24 +1765,26 @@ extension ForumController {
 		let postCount = try await query.count()
 
 		// Determine the start offset into the posts array.
-		var start = 0
-		if let startParam = req.query[Int.self, at: "start"] {
-			start = Pagination.start(startParam)
-		}
-		else if let startPostIDParam = req.query[Int.self, at: "startPost"] {
+		var start = requestedPagination.start
+		if req.query[Int.self, at: "start"] == nil, let startPostIDParam = req.query[Int.self, at: "startPost"] {
 			start = try await forum.$posts.query(on: req.db).filter(\.$id < startPostIDParam)
 				.filter(\.$author.$id !~ cacheUser.getBlocks()).filter(\.$author.$id !~ cacheUser.getMutes()).count()
 		}
-		else if let directStartPostID = startPostID {
+		else if req.query[Int.self, at: "start"] == nil, let directStartPostID = startPostID {
 			start = try await forum.$posts.query(on: req.db).filter(\.$id < directStartPostID)
 				.filter(\.$author.$id !~ cacheUser.getBlocks()).filter(\.$author.$id !~ cacheUser.getMutes()).count()
 		}
-		else if let lastReadPost = readerPivot?.lastPostReadID {
+		else if req.query[Int.self, at: "start"] == nil, let lastReadPost = readerPivot?.lastPostReadID {
 			start = try await forum.$posts.query(on: req.db).filter(\.$id < lastReadPost)
 				.filter(\.$author.$id !~ cacheUser.getBlocks()).filter(\.$author.$id !~ cacheUser.getMutes()).count()
-			start = max((start / limit) * limit, 0)
+			start = max((start / requestedPagination.limit) * requestedPagination.limit, 0)
 		}
-		let posts = try await query.range(start...start + max(limit - 1, 0)).all()
+		let pagination = Pagination(
+			start: start,
+			limit: requestedPagination.limit,
+			maxPageSize: Settings.shared.maximumForumPosts
+		)
+		let posts = try await query.range(pagination.range).all()
 		if let lastPostID = posts.last?.id {
 			if readerPivot == nil {
 				readerPivot = try ForumReaders(cacheUser.userID, forum)
@@ -1787,7 +1801,7 @@ extension ForumController {
 			mutewords: cacheUser.mutewords
 		)
 		let creatorHeader = try req.userCache.getHeader(forum.$creator.id)
-		let pager = Paginator(total: postCount, start: start, limit: limit)
+		let pager = Paginator(total: postCount, start: pagination.start, limit: pagination.limit)
 		// For event forums
 		var event: Event? = nil
 		if forum.category.isEventCategory {

--- a/Sources/swiftarr/Controllers/KaraokeController.swift
+++ b/Sources/swiftarr/Controllers/KaraokeController.swift
@@ -51,8 +51,11 @@ struct KaraokeController: APIRouteCollection {
 			var limit: Int?
 		}
 		let filters = try req.query.decode(SongQueryOptions.self)
-		let start = Pagination.start(filters.start)
-		let limit = Pagination.limit(filters.limit, maximum: Settings.shared.maximumTwarrts)
+		let pagination = Pagination(
+			start: filters.start,
+			limit: filters.limit,
+			maxPageSize: Settings.shared.maximumTwarrts
+		)
 		let songQuery = KaraokeSong.query(on: req.db).sort(\.$artist, .ascending).sort(\.$title, .ascending)
 		var filteringLetters = false
 		if let search = filters.search {
@@ -112,7 +115,7 @@ struct KaraokeController: APIRouteCollection {
 		}
 
 		let totalFoundSongs = try await songQuery.count()
-		let songs = try await songQuery.range(start..<(start + limit)).with(\.$sungBy).all()
+		let songs = try await songQuery.range(pagination.range).with(\.$sungBy).all()
 		let songData = try songs.map { song -> KaraokeSongData in
 			// Fluent doesn't seem to have an optional joined() variant; if we do a left join to join KaraokeFavorite,
 			// there can be songs that aren't favorited in the results. But joined() always returns a model, or throws if it can't.
@@ -121,7 +124,12 @@ struct KaraokeController: APIRouteCollection {
 			let isFavorite = filteringFavorites ? true : (try? song.joined(KaraokeFavorite.self)) != nil
 			return try KaraokeSongData(with: song, isFavorite: isFavorite)
 		}
-		return KaraokeSongResponseData(totalSongs: totalFoundSongs, start: start, limit: limit, songs: songData)
+		return KaraokeSongResponseData(
+			totalSongs: totalFoundSongs,
+			start: pagination.start,
+			limit: pagination.limit,
+			songs: songData
+		)
 	}
 
 	/// `GET /api/v3/karaoke/:song_id`
@@ -154,8 +162,11 @@ struct KaraokeController: APIRouteCollection {
 			var limit: Int?
 		}
 		let filters = try req.query.decode(QueryOptions.self)
-		let start = Pagination.start(filters.start)
-		let limit = Pagination.limit(filters.limit, maximum: Settings.shared.maximumTwarrts)
+		let pagination = Pagination(
+			start: filters.start,
+			limit: filters.limit,
+			maxPageSize: Settings.shared.maximumTwarrts
+		)
 		let songQuery = KaraokePlayedSong.query(on: req.db)
 		if let search = filters.search {
 			songQuery.join(KaraokeSong.self, on: \KaraokePlayedSong.$song.$id == \KaraokeSong.$id).group(.or) { (or) in
@@ -165,7 +176,7 @@ struct KaraokeController: APIRouteCollection {
 			}
 		}
 		let songCount = try await songQuery.count()
-		let recentSongs = try await songQuery.sort(\.$createdAt, .descending).range(start..<(start + limit)).with(\.$song).all()
+		let recentSongs = try await songQuery.sort(\.$createdAt, .descending).range(pagination.range).with(\.$song).all()
 		let favoriteSongIDs: Set<UUID>
 		if let user = try? req.auth.require(UserCacheData.self) {
 			let favorites = try await KaraokeFavorite.query(on: req.db).filter(\.$user.$id == user.userID).all()
@@ -176,7 +187,10 @@ struct KaraokeController: APIRouteCollection {
 		let results = recentSongs.map {
 			KaraokePerformedSongsData(songID: $0.$song.id, artist: $0.song.artist, songName: $0.song.title, performers: $0.performers, time: $0.createdAt ?? Date(), isFavorite: favoriteSongIDs.contains($0.$song.id))
 		}
-		return KaraokePerformedSongsResult(songs: results, paginator: Paginator(total: songCount, start: start, limit: limit))
+		return KaraokePerformedSongsResult(
+			songs: results,
+			paginator: Paginator(total: songCount, start: pagination.start, limit: pagination.limit)
+		)
 	}
 
 	/// `POST /api/v3/karaoke/:songID/favorite`

--- a/Sources/swiftarr/Controllers/KaraokeController.swift
+++ b/Sources/swiftarr/Controllers/KaraokeController.swift
@@ -51,8 +51,8 @@ struct KaraokeController: APIRouteCollection {
 			var limit: Int?
 		}
 		let filters = try req.query.decode(SongQueryOptions.self)
-		let start = filters.start ?? 0
-		let limit = (filters.limit ?? 50).clamped(to: 0...Settings.shared.maximumTwarrts)
+		let start = Pagination.start(filters.start)
+		let limit = Pagination.limit(filters.limit, maximum: Settings.shared.maximumTwarrts)
 		let songQuery = KaraokeSong.query(on: req.db).sort(\.$artist, .ascending).sort(\.$title, .ascending)
 		var filteringLetters = false
 		if let search = filters.search {
@@ -154,8 +154,8 @@ struct KaraokeController: APIRouteCollection {
 			var limit: Int?
 		}
 		let filters = try req.query.decode(QueryOptions.self)
-		let start = filters.start ?? 0
-		let limit = (filters.limit ?? 50).clamped(to: 0...Settings.shared.maximumTwarrts)
+		let start = Pagination.start(filters.start)
+		let limit = Pagination.limit(filters.limit, maximum: Settings.shared.maximumTwarrts)
 		let songQuery = KaraokePlayedSong.query(on: req.db)
 		if let search = filters.search {
 			songQuery.join(KaraokeSong.self, on: \KaraokePlayedSong.$song.$id == \KaraokeSong.$id).group(.or) { (or) in

--- a/Sources/swiftarr/Controllers/ModerationController.swift
+++ b/Sources/swiftarr/Controllers/ModerationController.swift
@@ -185,13 +185,15 @@ struct ModerationController: APIRouteCollection {
 	/// - Throws: 403 error if the user is not an admin.
 	/// - Returns: An array of `ModeratorActionLogData` records.
 	func moderatorActionLogHandler(_ req: Request) async throws -> ModeratorActionLogResponseData {
-		let start = Pagination.start(req.query[Int.self, at: "start"])
-		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: 200)
+		let pagination = Pagination(on: req, maxPageSize: 200)
 		let query = ModeratorAction.query(on: req.db)
 		let totalActionCount = try await query.count()
-		let result = try await query.copy().range(start..<(start + limit)).sort(\.$createdAt, .descending).all()
+		let result = try await query.copy().range(pagination.range).sort(\.$createdAt, .descending).all()
 				.map { try ModeratorActionLogData(action: $0, on: req) }
-		let response = ModeratorActionLogResponseData(actions: result, paginator: Paginator(total: totalActionCount, start: start, limit: limit))
+		let response = ModeratorActionLogResponseData(
+			actions: result,
+			paginator: Paginator(total: totalActionCount, start: pagination.start, limit: pagination.limit)
+		)
 		return response
 	}
 

--- a/Sources/swiftarr/Controllers/ModerationController.swift
+++ b/Sources/swiftarr/Controllers/ModerationController.swift
@@ -185,8 +185,8 @@ struct ModerationController: APIRouteCollection {
 	/// - Throws: 403 error if the user is not an admin.
 	/// - Returns: An array of `ModeratorActionLogData` records.
 	func moderatorActionLogHandler(_ req: Request) async throws -> ModeratorActionLogResponseData {
-		let start = (req.query[Int.self, at: "start"] ?? 0)
-		let limit = (req.query[Int.self, at: "limit"] ?? 50).clamped(to: 0...200)
+		let start = Pagination.start(req.query[Int.self, at: "start"])
+		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: 200)
 		let query = ModeratorAction.query(on: req.db)
 		let totalActionCount = try await query.count()
 		let result = try await query.copy().range(start..<(start + limit)).sort(\.$createdAt, .descending).all()

--- a/Sources/swiftarr/Controllers/PerformerController.swift
+++ b/Sources/swiftarr/Controllers/PerformerController.swift
@@ -56,8 +56,8 @@ struct PerformerController: APIRouteCollection {
 	///	* `?start=INT` - Offset from start of results set
 	/// * `?limit=INT` - the maximum number of games to retrieve: 1-200, default is 50.
 	func getOfficialPerformers(_ req: Request) async throws -> PerformerResponseData {
-		let start = req.query[Int.self, at: "start"] ?? 0
-		let limit = (req.query[Int.self, at: "limit"] ?? 50).clamped(to: 0...Settings.shared.maximumTwarrts)
+		let start = Pagination.start(req.query[Int.self, at: "start"])
+		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: Settings.shared.maximumTwarrts)
 		let query = Performer.query(on: req.db).filter(\.$officialPerformer == true).sort(\.$sortOrder)
 		let performerCount = try await query.count()
 		let performers = try await query.copy().range(start..<(start+limit)).all()
@@ -77,8 +77,8 @@ struct PerformerController: APIRouteCollection {
 	///	* `?start=INT` - Offset from start of results set
 	/// * `?limit=INT` - the maximum number of games to retrieve: 1-200, default is 50.
 	func getShadowPerformers(_ req: Request) async throws -> PerformerResponseData {
-		let start = req.query[Int.self, at: "start"] ?? 0
-		let limit = (req.query[Int.self, at: "limit"] ?? 100).clamped(to: 0...Settings.shared.maximumTwarrts)
+		let start = Pagination.start(req.query[Int.self, at: "start"])
+		let limit = Pagination.limit(req.query[Int.self, at: "limit"], default: 100, maximum: Settings.shared.maximumTwarrts)
 		let query = Performer.query(on: req.db).filter(\.$officialPerformer == false).sort(\.$sortOrder)
 				.join(User.self, on: \Performer.$user.$id == \User.$id)
 				.filter(User.self, \.$accessLevel != .banned)

--- a/Sources/swiftarr/Controllers/PerformerController.swift
+++ b/Sources/swiftarr/Controllers/PerformerController.swift
@@ -56,13 +56,15 @@ struct PerformerController: APIRouteCollection {
 	///	* `?start=INT` - Offset from start of results set
 	/// * `?limit=INT` - the maximum number of games to retrieve: 1-200, default is 50.
 	func getOfficialPerformers(_ req: Request) async throws -> PerformerResponseData {
-		let start = Pagination.start(req.query[Int.self, at: "start"])
-		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: Settings.shared.maximumTwarrts)
+		let pagination = Pagination(on: req, maxPageSize: Settings.shared.maximumTwarrts)
 		let query = Performer.query(on: req.db).filter(\.$officialPerformer == true).sort(\.$sortOrder)
 		let performerCount = try await query.count()
-		let performers = try await query.copy().range(start..<(start+limit)).all()
+		let performers = try await query.copy().range(pagination.range).all()
 		let performerDataArray = try performers.map { try PerformerHeaderData($0) }
-		return PerformerResponseData(performers: performerDataArray, paginator: Paginator(total: performerCount, start: start, limit: limit))
+		return PerformerResponseData(
+			performers: performerDataArray,
+			paginator: Paginator(total: performerCount, start: pagination.start, limit: pagination.limit)
+		)
 	}
 	
 	/// `GET /api/v3/performer/shadow`
@@ -77,15 +79,21 @@ struct PerformerController: APIRouteCollection {
 	///	* `?start=INT` - Offset from start of results set
 	/// * `?limit=INT` - the maximum number of games to retrieve: 1-200, default is 50.
 	func getShadowPerformers(_ req: Request) async throws -> PerformerResponseData {
-		let start = Pagination.start(req.query[Int.self, at: "start"])
-		let limit = Pagination.limit(req.query[Int.self, at: "limit"], default: 100, maximum: Settings.shared.maximumTwarrts)
+		let pagination = Pagination(
+			on: req,
+			defaultLimit: 100,
+			maxPageSize: Settings.shared.maximumTwarrts
+		)
 		let query = Performer.query(on: req.db).filter(\.$officialPerformer == false).sort(\.$sortOrder)
 				.join(User.self, on: \Performer.$user.$id == \User.$id)
 				.filter(User.self, \.$accessLevel != .banned)
 		let performerCount = try await query.count()
-		let performers = try await query.copy().range(start..<(start+limit)).with(\.$events).all()
+		let performers = try await query.copy().range(pagination.range).with(\.$events).all()
 		let performerDataArray = try performers.map { try PerformerHeaderData($0) }
-		return PerformerResponseData(performers: performerDataArray, paginator: Paginator(total: performerCount, start: start, limit: limit))
+		return PerformerResponseData(
+			performers: performerDataArray,
+			paginator: Paginator(total: performerCount, start: pagination.start, limit: pagination.limit)
+		)
 	}
 		
 	/// `GET /api/v3/performer/self`

--- a/Sources/swiftarr/Controllers/PhotostreamController.swift
+++ b/Sources/swiftarr/Controllers/PhotostreamController.swift
@@ -39,15 +39,21 @@ struct PhotostreamController: APIRouteCollection {
 		guard user.accessLevel != .banned else {
 			throw Abort(.unauthorized, reason: "User is banned, and cannot access this resource.")
 		}
-		var start = 0
-		var limit = 30
+		let pagination: Pagination
 		var photoCount = 0
 		if user.accessLevel.hasAccess(.moderator) {
-			start = Pagination.start(req.query[Int.self, at: "start"])
-			limit = Pagination.limit(
-				req.query[Int.self, at: "limit"],
-				default: 30,
-				maximum: Settings.shared.maximumTwarrts
+			pagination = Pagination(
+				on: req,
+				defaultLimit: 30,
+				maxPageSize: Settings.shared.maximumTwarrts
+			)
+		}
+		else {
+			pagination = Pagination(
+				start: nil,
+				limit: nil,
+				defaultLimit: 30,
+				maxPageSize: Settings.shared.maximumTwarrts
 			)
 		}
 		
@@ -72,7 +78,10 @@ struct PhotostreamController: APIRouteCollection {
 				query = query.filter(\.$boatLocation == boatLocation)
 			} else {
 				// Invalid location name, return empty results
-				return PhotostreamListData(photos: [], paginator: Paginator(total: 0, start: start, limit: limit))
+				return PhotostreamListData(
+					photos: [],
+					paginator: Paginator(total: 0, start: pagination.start, limit: pagination.limit)
+				)
 			}
 		}
 		
@@ -84,8 +93,7 @@ struct PhotostreamController: APIRouteCollection {
 		// Fetch photos with pagination
 		let photos = try await query
 			.sort(\.$id, .descending)
-			.offset(start)
-			.limit(limit)
+			.range(pagination.range)
 			.with(\.$atEvent, withDeleted: true)
 			.all()
 		
@@ -96,7 +104,10 @@ struct PhotostreamController: APIRouteCollection {
 		if photoCount == 0 {
 			photoCount = imageData.count
 		}
-		return PhotostreamListData(photos: imageData, paginator: Paginator(total: photoCount, start: start, limit: limit))
+		return PhotostreamListData(
+			photos: imageData,
+			paginator: Paginator(total: photoCount, start: pagination.start, limit: pagination.limit)
+		)
 	}
 	
 	/// `GET /api/v3/photostream/placenames`

--- a/Sources/swiftarr/Controllers/PhotostreamController.swift
+++ b/Sources/swiftarr/Controllers/PhotostreamController.swift
@@ -43,8 +43,12 @@ struct PhotostreamController: APIRouteCollection {
 		var limit = 30
 		var photoCount = 0
 		if user.accessLevel.hasAccess(.moderator) {
-			start = req.query[Int.self, at: "start"] ?? 0
-			limit = req.query[Int.self, at: "limit"] ?? 30
+			start = Pagination.start(req.query[Int.self, at: "start"])
+			limit = Pagination.limit(
+				req.query[Int.self, at: "limit"],
+				default: 30,
+				maximum: Settings.shared.maximumTwarrts
+			)
 		}
 		
 		// Get filter parameters
@@ -263,4 +267,3 @@ struct PhotostreamController: APIRouteCollection {
 	}
 
 }
-

--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -1470,6 +1470,46 @@ extension NoteData {
 	}
 }
 
+/// Normalizes the common `start` and `limit` URL query parameters before they are used to build database ranges.
+struct Pagination {
+	/// The normalized index of the first item to return.
+	let start: Int
+	/// The normalized maximum number of items to return.
+	let limit: Int
+	/// The range to apply to a database query.
+	var range: Range<Int> {
+		return start..<(start + limit)
+	}
+
+	/// Creates pagination values from decoded query parameters.
+	init(
+		start: Int?,
+		limit: Int?,
+		defaultStart: Int = 0,
+		defaultLimit: Int = 50,
+		maxPageSize: Int
+	) {
+		self.start = max(start ?? defaultStart, 0)
+		self.limit = (limit ?? defaultLimit).clamped(to: 1...max(maxPageSize, 1))
+	}
+
+	/// Decodes and normalizes pagination values from a request's URL query.
+	init(
+		on req: Request,
+		defaultStart: Int = 0,
+		defaultLimit: Int = 50,
+		maxPageSize: Int
+	) {
+		self.init(
+			start: req.query[Int.self, at: "start"],
+			limit: req.query[Int.self, at: "limit"],
+			defaultStart: defaultStart,
+			defaultLimit: defaultLimit,
+			maxPageSize: maxPageSize
+		)
+	}
+}
+
 /// Composes into other structs to add pagination.
 ///
 /// Generally this will be added to a top-level struct along with an array of some result type, like this:

--- a/Sources/swiftarr/Controllers/TwitarrController.swift
+++ b/Sources/swiftarr/Controllers/TwitarrController.swift
@@ -67,7 +67,7 @@ public struct TwarrtQueryOptions: Content {
 	}
 
 	func computedLimit() -> Int {
-		return limit ?? 50
+		return Pagination.limit(limit, maximum: Settings.shared.maximumTwarrts)
 	}
 
 	func buildQuery(baseURL: String, anchor: Int, startOffset: Int) -> String? {
@@ -290,8 +290,8 @@ struct TwitarrController: APIRouteCollection {
 		let filters = try req.query.decode(TwarrtQueryOptions.self)
 
 		// Query builder always filters out blocks and mutes, and the range always applies.
-		let start = filters.start ?? 0
-		let limit = (filters.limit ?? 50).clamped(to: 0...Settings.shared.maximumTwarrts)
+		let start = Pagination.start(filters.start)
+		let limit = Pagination.limit(filters.limit, maximum: Settings.shared.maximumTwarrts)
 		var postFilterMentions: String? = nil
 		var applyMutes = true
 		let twarrtQuery = Twarrt.query(on: req.db)

--- a/Sources/swiftarr/Controllers/TwitarrController.swift
+++ b/Sources/swiftarr/Controllers/TwitarrController.swift
@@ -66,8 +66,8 @@ public struct TwarrtQueryOptions: Content {
 		return (after != nil) || (afterdate != nil) || (from == "first") || (replyGroup != nil)
 	}
 
-	func computedLimit() -> Int {
-		return Pagination.limit(limit, maximum: Settings.shared.maximumTwarrts)
+	var pagination: Pagination {
+		return Pagination(start: start, limit: limit, maxPageSize: Settings.shared.maximumTwarrts)
 	}
 
 	func buildQuery(baseURL: String, anchor: Int, startOffset: Int) -> String? {
@@ -290,13 +290,12 @@ struct TwitarrController: APIRouteCollection {
 		let filters = try req.query.decode(TwarrtQueryOptions.self)
 
 		// Query builder always filters out blocks and mutes, and the range always applies.
-		let start = Pagination.start(filters.start)
-		let limit = Pagination.limit(filters.limit, maximum: Settings.shared.maximumTwarrts)
+		let pagination = filters.pagination
 		var postFilterMentions: String? = nil
 		var applyMutes = true
 		let twarrtQuery = Twarrt.query(on: req.db)
 			.filter(\.$author.$id !~ cachedUser.getBlocks())
-			.range(start..<(start + limit))
+			.range(pagination.range)
 
 		// Process query params that set an anchor twarrt and search direction.
 		// SearchDescending refers to the sort order in the database query, which affects start and limit.
@@ -330,7 +329,7 @@ struct TwitarrController: APIRouteCollection {
 		// Process query params that filter for specific content.
 		if let searchStr = filters.search {
 			twarrtQuery.fullTextFilter(\.$text, searchStr)
-			if !searchStr.contains(" ") && start == 0 {
+			if !searchStr.contains(" ") && pagination.start == 0 {
 				try await markNotificationViewed(user: cachedUser, type: .alertwordTwarrt(searchStr, 0), on: req)
 			}
 		}

--- a/Sources/swiftarr/Extensions/Foundation+Extensions.swift
+++ b/Sources/swiftarr/Extensions/Foundation+Extensions.swift
@@ -129,18 +129,6 @@ extension Comparable {
 	}
 }
 
-/// Normalizes the common `start` and `limit` URL query parameters before they
-/// are used to build database ranges.
-enum Pagination {
-	static func start(_ requested: Int?, default defaultValue: Int = 0) -> Int {
-		return max(requested ?? defaultValue, 0)
-	}
-
-	static func limit(_ requested: Int?, default defaultValue: Int = 50, maximum: Int) -> Int {
-		return (requested ?? defaultValue).clamped(to: 1...max(maximum, 1))
-	}
-}
-
 // Another thing Foundation ought to have. String(substring) requires a non-optional substring.
 // let x: String? = substring?.string -- uses chaining to allow an optional substring to be converted into an optional String.
 extension Substring {

--- a/Sources/swiftarr/Extensions/Foundation+Extensions.swift
+++ b/Sources/swiftarr/Extensions/Foundation+Extensions.swift
@@ -129,6 +129,18 @@ extension Comparable {
 	}
 }
 
+/// Normalizes the common `start` and `limit` URL query parameters before they
+/// are used to build database ranges.
+enum Pagination {
+	static func start(_ requested: Int?, default defaultValue: Int = 0) -> Int {
+		return max(requested ?? defaultValue, 0)
+	}
+
+	static func limit(_ requested: Int?, default defaultValue: Int = 50, maximum: Int) -> Int {
+		return (requested ?? defaultValue).clamped(to: 1...max(maximum, 1))
+	}
+}
+
 // Another thing Foundation ought to have. String(substring) requires a non-optional substring.
 // let x: String? = substring?.string -- uses chaining to allow an optional substring to be converted into an optional String.
 extension Substring {

--- a/Sources/swiftarr/Site/SiteForumController.swift
+++ b/Sources/swiftarr/Site/SiteForumController.swift
@@ -354,8 +354,7 @@ struct SiteForumController: SiteControllerUtils {
 		guard let catID = req.parameters.get(categoryIDParam.paramString)?.percentEncodeFilePathEntry() else {
 			throw "Invalid forum category ID"
 		}
-		let start = Pagination.start(req.query[Int.self, at: "start"])
-		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: 200)
+		let pagination = Pagination(on: req, maxPageSize: 200)
 
 		let response = try await apiQuery(req, endpoint: "/forum/categories/\(catID)")
 		let forums = try response.content.decode(CategoryData.self)
@@ -402,7 +401,12 @@ struct SiteForumController: SiteControllerUtils {
 				}
 			}
 		}
-		let ctx = try ForumsPageContext(req, forums: forums, start: start, limit: limit)
+		let ctx = try ForumsPageContext(
+			req,
+			forums: forums,
+			start: pagination.start,
+			limit: pagination.limit
+		)
 		return try await req.view.render("Forums/forums", ctx)
 	}
 

--- a/Sources/swiftarr/Site/SiteForumController.swift
+++ b/Sources/swiftarr/Site/SiteForumController.swift
@@ -354,8 +354,8 @@ struct SiteForumController: SiteControllerUtils {
 		guard let catID = req.parameters.get(categoryIDParam.paramString)?.percentEncodeFilePathEntry() else {
 			throw "Invalid forum category ID"
 		}
-		let start = (req.query[Int.self, at: "start"] ?? 0)
-		let limit = (req.query[Int.self, at: "limit"] ?? 50).clamped(to: 0...200)
+		let start = Pagination.start(req.query[Int.self, at: "start"])
+		let limit = Pagination.limit(req.query[Int.self, at: "limit"], maximum: 200)
 
 		let response = try await apiQuery(req, endpoint: "/forum/categories/\(catID)")
 		let forums = try response.content.decode(CategoryData.self)
@@ -904,7 +904,7 @@ struct SiteForumController: SiteControllerUtils {
 			let responseData = try response.content.decode(PostSearchData.self)
 			var ctx = try PostSearchPageContext(req, posts: responseData, searchType: .textSearch, formData: formData)
 			if let forumID = formData.forum {
-				let forumResponse = try await apiQuery(req, endpoint: "/forum/\(forumID)", query: [URLQueryItem(name: "limit", value: "0")])
+				let forumResponse = try await apiQuery(req, endpoint: "/forum/\(forumID)", query: [URLQueryItem(name: "limit", value: "1")])
 				ctx.forumData = try forumResponse.content.decode(ForumData.self)
 			}
 			if let categoryID = ctx.forumData?.categoryID ?? formData.category {

--- a/Sources/swiftarr/Site/SiteTwittarController.swift
+++ b/Sources/swiftarr/Site/SiteTwittarController.swift
@@ -116,14 +116,14 @@ struct TweetPageContext: Encodable {
 					topMorePostsURL = queryStruct.buildQuery(
 						baseURL: "/tweets",
 						anchor: anchorID,
-						startOffset: 0 - queryStruct.computedLimit()
+						startOffset: 0 - queryStruct.pagination.limit
 					)
 					topMorePostsLabel = "Older"
 				}
 				bottomMorePostsURL = queryStruct.buildQuery(
 					baseURL: "/tweets",
 					anchor: anchorID,
-					startOffset: queryStruct.computedLimit()
+					startOffset: queryStruct.pagination.limit
 				)
 				bottomMorePostsLabel = "Newer"
 			}
@@ -140,7 +140,7 @@ struct TweetPageContext: Encodable {
 					topMorePostsURL = queryStruct.buildQuery(
 						baseURL: "/tweets",
 						anchor: anchorID,
-						startOffset: 0 - queryStruct.computedLimit()
+						startOffset: 0 - queryStruct.pagination.limit
 					)
 					topMorePostsLabel = "Newer"
 				}
@@ -148,7 +148,7 @@ struct TweetPageContext: Encodable {
 					bottomMorePostsURL = queryStruct.buildQuery(
 						baseURL: "/tweets",
 						anchor: anchorID,
-						startOffset: queryStruct.computedLimit()
+						startOffset: queryStruct.pagination.limit
 					)
 					bottomMorePostsLabel = "Older"
 				}

--- a/Tests/AppTests/PaginationTests.swift
+++ b/Tests/AppTests/PaginationTests.swift
@@ -30,6 +30,10 @@ class PaginationTests: XCTestCase {
 		XCTAssertEqual(Pagination.limit(201, maximum: 200), 200)
 	}
 
+	func testLimitStaysNonzeroWhenMaximumIsMisconfigured() {
+		XCTAssertEqual(Pagination.limit(10, maximum: 0), 1)
+	}
+
 	func testLimitPreservesInRangeValues() {
 		XCTAssertEqual(Pagination.limit(25, maximum: 200), 25)
 	}

--- a/Tests/AppTests/PaginationTests.swift
+++ b/Tests/AppTests/PaginationTests.swift
@@ -3,38 +3,45 @@ import XCTVapor
 
 class PaginationTests: XCTestCase {
 
-	func testStartDefaultsToZero() {
-		XCTAssertEqual(Pagination.start(nil), 0)
+	func testDefaults() {
+		let pagination = Pagination(start: nil, limit: nil, maxPageSize: 200)
+		XCTAssertEqual(pagination.start, 0)
+		XCTAssertEqual(pagination.limit, 50)
+		XCTAssertEqual(pagination.range, 0..<50)
 	}
 
 	func testStartClampsNegativeValues() {
-		XCTAssertEqual(Pagination.start(-1), 0)
-		XCTAssertEqual(Pagination.start(nil, default: -5), 0)
+		XCTAssertEqual(Pagination(start: -1, limit: nil, maxPageSize: 200).start, 0)
+		XCTAssertEqual(Pagination(start: nil, limit: nil, defaultStart: -5, maxPageSize: 200).start, 0)
 	}
 
-	func testStartPreservesPositiveValues() {
-		XCTAssertEqual(Pagination.start(12), 12)
+	func testPreservesValuesAndBuildsRange() {
+		let pagination = Pagination(start: 12, limit: 25, maxPageSize: 200)
+		XCTAssertEqual(pagination.start, 12)
+		XCTAssertEqual(pagination.limit, 25)
+		XCTAssertEqual(pagination.range, 12..<37)
 	}
 
-	func testLimitDefaultsToFifty() {
-		XCTAssertEqual(Pagination.limit(nil, maximum: 200), 50)
+	func testLimitClampsToNonzeroBounds() {
+		XCTAssertEqual(Pagination(start: nil, limit: 0, maxPageSize: 200).limit, 1)
+		XCTAssertEqual(Pagination(start: nil, limit: -10, maxPageSize: 200).limit, 1)
+		XCTAssertEqual(Pagination(start: nil, limit: nil, defaultLimit: 0, maxPageSize: 200).limit, 1)
+		XCTAssertEqual(Pagination(start: nil, limit: 201, maxPageSize: 200).limit, 200)
+		XCTAssertEqual(Pagination(start: nil, limit: 10, maxPageSize: 0).limit, 1)
 	}
 
-	func testLimitClampsToNonzeroLowerBound() {
-		XCTAssertEqual(Pagination.limit(0, maximum: 200), 1)
-		XCTAssertEqual(Pagination.limit(-10, maximum: 200), 1)
-		XCTAssertEqual(Pagination.limit(nil, default: 0, maximum: 200), 1)
-	}
-
-	func testLimitClampsToConfiguredMaximum() {
-		XCTAssertEqual(Pagination.limit(201, maximum: 200), 200)
-	}
-
-	func testLimitStaysNonzeroWhenMaximumIsMisconfigured() {
-		XCTAssertEqual(Pagination.limit(10, maximum: 0), 1)
-	}
-
-	func testLimitPreservesInRangeValues() {
-		XCTAssertEqual(Pagination.limit(25, maximum: 200), 25)
+	func testDecodesRequestQuery() {
+		let app = Application(.testing)
+		defer { app.shutdown() }
+		let req = Request(
+			application: app,
+			method: .GET,
+			url: URI(string: "/?start=12&limit=201"),
+			on: app.eventLoopGroup.next()
+		)
+		let pagination = Pagination(on: req, defaultLimit: 30, maxPageSize: 200)
+		XCTAssertEqual(pagination.start, 12)
+		XCTAssertEqual(pagination.limit, 200)
+		XCTAssertEqual(pagination.range, 12..<212)
 	}
 }

--- a/Tests/AppTests/PaginationTests.swift
+++ b/Tests/AppTests/PaginationTests.swift
@@ -1,0 +1,36 @@
+import XCTVapor
+@testable import swiftarr
+
+class PaginationTests: XCTestCase {
+
+	func testStartDefaultsToZero() {
+		XCTAssertEqual(Pagination.start(nil), 0)
+	}
+
+	func testStartClampsNegativeValues() {
+		XCTAssertEqual(Pagination.start(-1), 0)
+		XCTAssertEqual(Pagination.start(nil, default: -5), 0)
+	}
+
+	func testStartPreservesPositiveValues() {
+		XCTAssertEqual(Pagination.start(12), 12)
+	}
+
+	func testLimitDefaultsToFifty() {
+		XCTAssertEqual(Pagination.limit(nil, maximum: 200), 50)
+	}
+
+	func testLimitClampsToNonzeroLowerBound() {
+		XCTAssertEqual(Pagination.limit(0, maximum: 200), 1)
+		XCTAssertEqual(Pagination.limit(-10, maximum: 200), 1)
+		XCTAssertEqual(Pagination.limit(nil, default: 0, maximum: 200), 1)
+	}
+
+	func testLimitClampsToConfiguredMaximum() {
+		XCTAssertEqual(Pagination.limit(201, maximum: 200), 200)
+	}
+
+	func testLimitPreservesInRangeValues() {
+		XCTAssertEqual(Pagination.limit(25, maximum: 200), 25)
+	}
+}


### PR DESCRIPTION
## Summary
- centralize nonnegative `start` and nonzero bounded `limit` normalization
- apply the shared bounds across list endpoints, including the two divide-by-limit paths
- cover defaults, negative and zero values, configured maxima, and a misconfigured zero maximum

Closes #558.

## Validation
- Red: fork Build Branch run 29684744575 failed in `PaginationTests` because `Pagination` did not exist yet
- Green: fork Build Branch run 29685998161 passed the pure-helper test job and production-stack health check

Rollback: revert commits 9025777d and b6254216.