### PR TITLE
Add Photostream filtering by user

### DIFF
--- a/Sources/swiftarr/Controllers/PhotostreamController.swift
+++ b/Sources/swiftarr/Controllers/PhotostreamController.swift
@@ -2,6 +2,14 @@ import Fluent
 import FluentSQL
 import Vapor
 
+struct PhotostreamQueryOptions: Content, Sendable {
+	var start: Int? = nil
+	var limit: Int? = nil
+	var eventID: UUID? = nil
+	var locationName: String? = nil
+	var byUser: UUID? = nil
+}
+
 struct PhotostreamController: APIRouteCollection {
 
 	/// Required. Registers routes to the incoming router.
@@ -32,6 +40,7 @@ struct PhotostreamController: APIRouteCollection {
 	/// * `?limit=INT` - Moderators only. The max # of entries to return. Defaults to 30.
 	/// * `?eventID=UUID` - Filter results to photos tagged with the specified event ID.
 	/// * `?locationName=STRING` - Filter results to photos tagged with the specified location name.
+	/// * `?byUser=UUID` - Filter results to photos uploaded by the specified user.
 	/// 
 	/// - Returns: `PhotostreamListData`, a paginated array of `PhotostreamImageData`
 	func photostreamHandler(_ req: Request) async throws -> PhotostreamListData {
@@ -39,37 +48,43 @@ struct PhotostreamController: APIRouteCollection {
 		guard user.accessLevel != .banned else {
 			throw Abort(.unauthorized, reason: "User is banned, and cannot access this resource.")
 		}
+		let filters = PhotostreamQueryOptions(
+			start: req.query[Int.self, at: "start"],
+			limit: req.query[Int.self, at: "limit"],
+			eventID: req.query[UUID.self, at: "eventID"],
+			locationName: req.query[String.self, at: "locationName"],
+			byUser: req.query[UUID.self, at: "byUser"]
+		)
 		var start = 0
 		var limit = 30
 		var photoCount = 0
 		if user.accessLevel.hasAccess(.moderator) {
-			start = req.query[Int.self, at: "start"] ?? 0
-			limit = req.query[Int.self, at: "limit"] ?? 30
+			start = filters.start ?? 0
+			limit = filters.limit ?? 30
 		}
 		
-		// Get filter parameters
-		let eventID = req.query[UUID.self, at: "eventID"]
-		let locationName = req.query[String.self, at: "locationName"]
-		
-		// Validate that only one filter is provided, not both
-		if eventID != nil && locationName != nil {
-			throw Abort(.badRequest, reason: "Cannot filter by both eventID and locationName at the same time. Please specify only one filter.")
+		let filterCount = [filters.eventID != nil, filters.locationName != nil, filters.byUser != nil].filter { $0 }.count
+		if filterCount > 1 {
+			throw Abort(.badRequest, reason: "Cannot combine eventID, locationName, and byUser filters. Please specify only one filter.")
 		}
 		
 		// Build base query
 		var query = StreamPhoto.query(on: req.db).filter(\.$moderationStatus !~ [.autoQuarantined, .quarantined])
 		
 		// Apply filters
-		if let eventID = eventID {
+		if let eventID = filters.eventID {
 			query = query.filter(\.$atEvent.$id == eventID)
 		}
-		if let locationName = locationName {
+		if let locationName = filters.locationName {
 			if let boatLocation = PhotoStreamBoatLocation(rawValue: locationName) {
 				query = query.filter(\.$boatLocation == boatLocation)
 			} else {
 				// Invalid location name, return empty results
 				return PhotostreamListData(photos: [], paginator: Paginator(total: 0, start: start, limit: limit))
 			}
+		}
+		if let byUser = filters.byUser {
+			query = query.filter(\.$author.$id == byUser)
 		}
 		
 		// Get total count for pagination (mods only)
@@ -263,4 +278,3 @@ struct PhotostreamController: APIRouteCollection {
 	}
 
 }
-

--- a/Sources/swiftarr/Resources/Views/Photostream/photostream.html
+++ b/Sources/swiftarr/Resources/Views/Photostream/photostream.html
@@ -10,6 +10,8 @@
 							<span class="swiftarr-breadcrumb-item active" aria-current="page">#(currentEventTitle)</span>
 						#elseif(currentLocationName != nil):
 							<span class="swiftarr-breadcrumb-item active" aria-current="page">#(currentLocationName)</span>
+						#elseif(currentAuthor != nil):
+							<span class="swiftarr-breadcrumb-item active" aria-current="page">Photos by #userByline(currentAuthor, "short-nolink")</span>
 						#else:
 							<span class="swiftarr-breadcrumb-item active" aria-current="page">All Photos</span>
 						#endif
@@ -22,11 +24,13 @@
 						<b>Filtered by Location: #(currentLocationName)</b>
 					#elseif(currentEventID != nil):
 						<b>Filtered by Event</b>
+					#elseif(currentAuthor != nil):
+						<b>Photos by #userByline(currentAuthor)</b>
 					#else:
 						<b>All Photos</b>
 					#endif
 				</div>
-				#if(currentEventID == nil):
+				#if(currentEventID == nil && currentAuthor == nil):
 					<div class="col col-auto">
 						<div class="dropdown">
 							<button class="btn btn-outline-primary dropdown-toggle btn-sm" type="button" id="locationFilterMenu" data-bs-toggle="dropdown" aria-expanded="false">
@@ -60,6 +64,7 @@
 							#else:
 								<h5>#(photo.title)</h5>
 							#endif
+							<div>Posted by #userByline(photo.author)</div>
 							<div>#staticTime(photo.createdAt)</div>
 							<a class="btn btn-primary" role="button" href="photostream/#(photo.postID)">link</a>
 							<a class="btn btn-primary" role="button" href="photostream/report/#(photo.postID)">Report</a>

--- a/Sources/swiftarr/Resources/Views/User/userProfile.html
+++ b/Sources/swiftarr/Resources/Views/User/userProfile.html
@@ -70,6 +70,7 @@
 			#endif
 			<div class="row mx-1 mt-2 list-group">
 				<a href="/forum/search?creatorid=#(profile.header.userID)&searchType=forums" class="list-group-item list-group-item-action">View Forums by @#(profile.header.username)</a>
+				<a href="/photostream?byUser=#(profile.header.userID)" class="list-group-item list-group-item-action">View Photostream photos by @#(profile.header.username)</a>
 				#if(trunk.userIsMod):
 				<a href="/forumpost/search?creatorid=#(profile.header.userID)" class="list-group-item list-group-item-action">View Forum Posts by @#(profile.header.username)</a>
 				#endif
@@ -169,4 +170,3 @@
 		</div>
     #endexport
 #endextend
-

--- a/Sources/swiftarr/Site/SitePhotostreamController.swift
+++ b/Sources/swiftarr/Site/SitePhotostreamController.swift
@@ -21,26 +21,31 @@ struct SitePhotostreamController: SiteControllerUtils {
 	// user confusion as to which photo you'd be reporting play a part.
 	//
 	// Mods get pagination when seeing this page; the `start` and `limit` query parameters work.
-	// Supports filtering by `eventID` or `locationName` query parameters.
+	// Supports filtering by `eventID`, `locationName`, or `byUser` query parameters.
 	func showPhotostream(_ req: Request) async throws -> View {
-		// Get query parameters for filtering
-		let eventID = req.query[UUID.self, at: "eventID"]
-		let locationName = req.query[String.self, at: "locationName"]
-		let start = req.query[Int.self, at: "start"]
-		let limit = req.query[Int.self, at: "limit"]
+		let filters = PhotostreamQueryOptions(
+			start: req.query[Int.self, at: "start"],
+			limit: req.query[Int.self, at: "limit"],
+			eventID: req.query[UUID.self, at: "eventID"],
+			locationName: req.query[String.self, at: "locationName"],
+			byUser: req.query[UUID.self, at: "byUser"]
+		)
 		
 		// Build query items for API call
 		var queryItems: [URLQueryItem] = []
-		if let eventID = eventID {
+		if let eventID = filters.eventID {
 			queryItems.append(URLQueryItem(name: "eventID", value: eventID.uuidString))
 		}
-		if let locationName = locationName {
+		if let locationName = filters.locationName {
 			queryItems.append(URLQueryItem(name: "locationName", value: locationName))
 		}
-		if let start = start {
+		if let byUser = filters.byUser {
+			queryItems.append(URLQueryItem(name: "byUser", value: byUser.uuidString))
+		}
+		if let start = filters.start {
 			queryItems.append(URLQueryItem(name: "start", value: String(start)))
 		}
-		if let limit = limit {
+		if let limit = filters.limit {
 			queryItems.append(URLQueryItem(name: "limit", value: String(limit)))
 		}
 		
@@ -111,15 +116,17 @@ struct SitePhotostreamController: SiteControllerUtils {
 			var currentEventID: UUID?
 			var currentEventTitle: String?
 			var currentLocationName: String?
+			var currentAuthor: UserHeader?
 
-			init(_ req: Request, photostream: PhotostreamListData, locations: [String], eventID: UUID?, locationName: String?) {
+			init(_ req: Request, photostream: PhotostreamListData, locations: [String], filters: PhotostreamQueryOptions) {
 				trunk = .init(req, title: "Twitarr", tab: .home)
 				self.photos = photostream.photos.map { PhotostreamPhotoContext($0) }
 				self.locations = locations.map { LocationFilterItem($0) }
-				self.currentEventID = eventID
-				self.currentLocationName = locationName
+				self.currentEventID = filters.eventID
+				self.currentLocationName = filters.locationName
+				self.currentAuthor = filters.byUser.flatMap { try? req.userCache.getHeader($0) }
 				// Get event title from first photo if filtering by event
-				if let eventID = eventID, let firstPhoto = photostream.photos.first, let event = firstPhoto.event, event.eventID == eventID {
+				if let eventID = filters.eventID, let firstPhoto = photostream.photos.first, let event = firstPhoto.event, event.eventID == eventID {
 					self.currentEventTitle = event.title
 				} else {
 					self.currentEventTitle = nil
@@ -132,18 +139,21 @@ struct SitePhotostreamController: SiteControllerUtils {
 					var queryItems: [URLQueryItem] = []
 					queryItems.append(URLQueryItem(name: "start", value: String(pageIndex * photostream.paginator.limit)))
 					queryItems.append(URLQueryItem(name: "limit", value: String(photostream.paginator.limit)))
-					if let eventID = eventID {
+					if let eventID = filters.eventID {
 						queryItems.append(URLQueryItem(name: "eventID", value: eventID.uuidString))
 					}
-					if let locationName = locationName {
+					if let locationName = filters.locationName {
 						queryItems.append(URLQueryItem(name: "locationName", value: locationName))
+					}
+					if let byUser = filters.byUser {
+						queryItems.append(URLQueryItem(name: "byUser", value: byUser.uuidString))
 					}
 					components.queryItems = queryItems
 					return components.string ?? "/photostream"
 				}
 			}
 		}
-		let ctx = PhotostreamPageContext(req, photostream: photostream, locations: locationsData.locations, eventID: eventID, locationName: locationName)
+		let ctx = PhotostreamPageContext(req, photostream: photostream, locations: locationsData.locations, filters: filters)
 		return try await req.view.render("Photostream/photostream", ctx)		
 	}
 

--- a/Tests/AppTests/PhotostreamQueryOptionsTests.swift
+++ b/Tests/AppTests/PhotostreamQueryOptionsTests.swift
@@ -1,0 +1,14 @@
+@testable import swiftarr
+import Foundation
+import Testing
+
+struct PhotostreamQueryOptionsTests {
+	@Test("Photostream query options retain the author filter")
+	func byUserFilter() {
+		let userID = UUID()
+
+		let options = PhotostreamQueryOptions(byUser: userID)
+
+		#expect(options.byUser == userID)
+	}
+}

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -223,3 +223,6 @@ associated AddedToChat field value increase.
 
 ## Mar 01, 2026
 * `GET /api/v3/fez/joined` with `onlynew=[true,false]` now include/exclude newly added-to fezzes.
+
+## Jul 19, 2026
+* `GET /api/v3/photostream` now supports a `byUser` UUID query parameter.


### PR DESCRIPTION
## Summary

- add a `byUser` UUID filter to `GET /api/v3/photostream`
- preserve the author filter in the site paginator and link photo bylines to profiles
- add a profile action for viewing Photostream photos by that user
- document the additive API query parameter

Closes #515

## Testing

- test-only Build Branch run `29688306953` failed because `PhotostreamQueryOptions` was not yet defined
- implementation Build Branch run `29688549872` passed 177 tests and the production-stack health check