### PR TITLE
Return created content from photostream uploads

### DIFF
--- a/Sources/swiftarr/Controllers/PhotostreamController.swift
+++ b/Sources/swiftarr/Controllers/PhotostreamController.swift
@@ -113,7 +113,7 @@ struct PhotostreamController: APIRouteCollection {
 	/// `/api/v3/photostream/placenames`.
 	/// 
 	/// - Parameter `PhotostreamUploadData`: In the request body.
-	/// - Returns: 200 OK if upload successful.
+	/// - Returns: 200 OK with the created `PhotostreamImageData` if upload is successful.
 	func photostreamUploadHandler(_ req: Request) async throws -> Response {
 		let user = try req.auth.require(UserCacheData.self)
 		try user.guardCanCreateContent(customErrorString: "user cannot post to photostream")
@@ -147,8 +147,14 @@ struct PhotostreamController: APIRouteCollection {
 		let streamPhoto = StreamPhoto(image: filename, captureTime: newPostData.createdAt, user: user, atEvent: matchingEvent,
 				boatLocation: boatLocation)
 		try await streamPhoto.save(on: req.db)
+		let photoData = try PhotostreamImageData(streamPhoto: streamPhoto, author: user.makeHeader())
+		return try makeUploadResponse(photo: photoData, rateLimit: Settings.shared.photostreamUploadRateLimit)
+	}
+
+	func makeUploadResponse(photo: PhotostreamImageData, rateLimit: TimeInterval) throws -> Response {
 		let response = Response(status: .ok)
-		response.headers.add(name: "Retry-After", value: "\(Settings.shared.photostreamUploadRateLimit)")
+		response.headers.add(name: "Retry-After", value: "\(rateLimit)")
+		try response.content.encode(photo)
 		return response
 	}
 	
@@ -263,4 +269,3 @@ struct PhotostreamController: APIRouteCollection {
 	}
 
 }
-

--- a/Tests/AppTests/PhotostreamControllerTests.swift
+++ b/Tests/AppTests/PhotostreamControllerTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+import XCTVapor
+@testable import swiftarr
+
+final class PhotostreamControllerTests: XCTestCase {
+	func testUploadResponseIncludesCreatedPhotoAndRateLimit() throws {
+		let createdAt = Date(timeIntervalSince1970: 1_725_000_000)
+		let photo = PhotostreamImageData(
+			postID: 42,
+			createdAt: createdAt,
+			author: UserHeader(
+				userID: UUID(uuidString: "A914114F-0B8E-4D86-9FB3-7D8C37F36FB7")!,
+				username: "photographer",
+				displayName: "Photographer",
+				userImage: "avatar.png",
+				preferredPronoun: nil
+			),
+			image: "photostream-42.jpg",
+			event: nil,
+			location: PhotoStreamBoatLocation.onBoat.rawValue
+		)
+
+		let response = try PhotostreamController().makeUploadResponse(
+			photo: photo,
+			rateLimit: 900
+		)
+
+		XCTAssertEqual(response.status, .ok)
+		XCTAssertEqual(response.headers.first(name: "Retry-After"), "900.0")
+		let content = try response.content.decode(PhotostreamImageData.self)
+		XCTAssertEqual(content.postID, 42)
+		XCTAssertEqual(content.createdAt, createdAt)
+		XCTAssertEqual(content.author.username, "photographer")
+		XCTAssertEqual(content.image, "photostream-42.jpg")
+		XCTAssertEqual(content.location, PhotoStreamBoatLocation.onBoat.rawValue)
+	}
+}

--- a/Tests/AppTests/PhotostreamControllerTests.swift
+++ b/Tests/AppTests/PhotostreamControllerTests.swift
@@ -1,5 +1,6 @@
-import XCTest
 import XCTVapor
+import XCTest
+
 @testable import swiftarr
 
 final class PhotostreamControllerTests: XCTestCase {
@@ -20,10 +21,11 @@ final class PhotostreamControllerTests: XCTestCase {
 			location: PhotoStreamBoatLocation.onBoat.rawValue
 		)
 
-		let response = try PhotostreamController().makeUploadResponse(
-			photo: photo,
-			rateLimit: 900
-		)
+		let response = try PhotostreamController()
+			.makeUploadResponse(
+				photo: photo,
+				rateLimit: 900
+			)
 
 		XCTAssertEqual(response.status, .ok)
 		XCTAssertEqual(response.headers.first(name: "Retry-After"), "900.0")

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -223,3 +223,7 @@ associated AddedToChat field value increase.
 
 ## Mar 01, 2026
 * `GET /api/v3/fez/joined` with `onlynew=[true,false]` now include/exclude newly added-to fezzes.
+
+## Jul 19, 2026
+* `POST /api/v3/photostream/upload` now returns the created
+  `PhotostreamImageData` in its successful response body.


### PR DESCRIPTION
## Summary

- return the created PhotostreamImageData from POST /api/v3/photostream/upload
- preserve the existing HTTP 200 status and Retry-After header
- document the successful response contract

## Validation

- red Build Branch workflow 29689183816 failed because the response builder was absent
- green Build Branch workflow 29689529067 passed 177 tests and the production-stack health check

Closes #481