### PR TITLE
Link favorite users outside preregistration

### DIFF
--- a/Sources/swiftarr/Resources/Views/User/userFavorites.html
+++ b/Sources/swiftarr/Resources/Views/User/userFavorites.html
@@ -14,7 +14,11 @@
 						<li class="list-group-item">
 							<div class="row justify-content-between align-items-baseline">
 								<div class="col col-auto">
-									#userByline(favoriteUser, "short-nolink")
+									#if(trunk.preregistrationApplies):
+										#userByline(favoriteUser, "short-nolink")
+									#else:
+										#userByline(favoriteUser, "short")
+									#endif
 								</div>
 								<div class="col col-auto">
 									<button type="button" class="btn btn-sm btn-primary" autocomplete="off" data-action="unfavorite" 


### PR DESCRIPTION
## Summary

- link Favorite Users usernames to their profiles during normal operation
- keep usernames unlinked when preregistration restrictions apply
- leave the existing Unfavorite action unchanged

Fixes https://github.com/jocosocial/swiftarr/issues/563

## Validation

- real development HTTP path: normal profile link and profile GET, preregistration non-link, and Unfavorite in both modes
- `swift format lint --recursive --configuration .swift-format Sources Tests Package.swift` (exit 0 with existing repository warnings)
- `swift build`
- exact GitHub Actions test subset: 178 tests, 0 failures
- `swift test --enable-test-discovery`: 241 tests, 0 failures, using the migrated task-local database and the test class's documented 2024 fixture
- `swift build -c release`
- native release binary in production mode: migrations succeeded and `/api/v3/client/health` returned HTTP 200

Docker was unavailable locally, so the exact `BuildAndDeployStack` container workflow is left to pull request CI.
