### PR TITLE
fix: registration code replay in account recovery, and image loss on moderator edit (#526)

### DIFF
--- a/Sources/swiftarr/Controllers/AuthController.swift
+++ b/Sources/swiftarr/Controllers/AuthController.swift
@@ -127,12 +127,13 @@ struct AuthController: APIRouteCollection {
 
 		// attempt data.recoveryKey match
 		var foundMatch = false
-		if normalizedKey == user.verification {
+		// A spent registration code is disabled by prefixing its stored `verification` with '*'.
+		// Only match an unspent verification, so the marked value ("*code") can't be replayed to
+		// reuse a spent code -- the password/recoveryKey paths below still accept any input.
+		if let verification = user.verification, !verification.hasPrefix("*"), normalizedKey == verification {
 			foundMatch = true
 			// prevent .verification from being used again
-			if let newVerification = user.verification {
-				user.verification = "*" + newVerification
-			}
+			user.verification = "*" + verification
 		}
 		else {
 			// password and recoveryKey require hash verification

--- a/Sources/swiftarr/Controllers/ForumController.swift
+++ b/Sources/swiftarr/Controllers/ForumController.swift
@@ -723,8 +723,13 @@ struct ForumController: APIRouteCollection {
 			case .none: break
 			}
 		}
-		// init return struct
-		var postDetailData = try PostDetailData(post: post, author: req.userCache.getHeader(post.$author.id))
+		// init return struct. Editors (moderators) see the real text/images of quarantined posts so
+		// that editing one preserves its images instead of wiping them; matches ModerationController.
+		var postDetailData = try PostDetailData(
+			post: post,
+			author: req.userCache.getHeader(post.$author.id),
+			overrideQuarantine: cacheUser.accessLevel.canEditOthersContent()
+		)
 		postDetailData.isBookmarked = isFavorite
 		postDetailData.laughs = req.userCache.getHeaders(laughUsers)
 		postDetailData.likes = req.userCache.getHeaders(likeUsers)

--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -1142,7 +1142,9 @@ struct ImageUploadData: Content, Sendable {
 
 extension ImageUploadData {
 	init(_ filename: String? = nil, _ image: Data? = nil) {
-		self.filename = filename
+		// An empty filename comes from unused photo-form slots; treat it as "no image" so it
+		// doesn't get stored as a bogus empty filename on the post.
+		self.filename = filename?.isEmpty == true ? nil : filename
 		self.image = image
 	}
 }

--- a/Tests/AppTests/AuthControllerTests.swift
+++ b/Tests/AppTests/AuthControllerTests.swift
@@ -1,0 +1,92 @@
+import Testing
+import XCTVapor
+
+@testable import swiftarr
+
+// Tests the single-use guarantee on registration codes in account recovery.
+//
+// A spent registration code is disabled by prefixing the stored `verification` with '*'.
+// Recovery must not accept either form of a spent code, while an unspent code still works.
+class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
+
+	private func makeRecoveryUser(_ app: Application, username: String, verification: String?) async throws -> User {
+		let user = User(
+			username: username,
+			password: try Bcrypt.hash("password1"),
+			recoveryKey: try Bcrypt.hash("recovery key"),
+			verification: verification,
+			accessLevel: .verified
+		)
+		try await user.save(on: app.db)
+		return user
+	}
+
+	private func recoveryBody(username: String, key: String) -> UserRecoveryData {
+		UserRecoveryData(username: username, recoveryKey: key, newPassword: "newpassword1")
+	}
+
+	// A spent code is stored as "*code". Submitting that marked value must not recover the
+	// account -- it normalizes to 7 characters, so a length-based guard alone does not catch it.
+	func testRecovery_MarkedSpentCodeIsRejected() async throws {
+		try await withApp { app in
+			let username = "recovery-marked-\(UUID().uuidString.prefix(8))"
+			let user = try await makeRecoveryUser(app, username: username, verification: "*abc123")
+			defer { Task { try? await user.delete(on: app.db) } }
+
+			try await app.test(
+				.POST,
+				"/api/v3/auth/recovery",
+				beforeRequest: { req async throws in
+					try req.content.encode(recoveryBody(username: username, key: "*abc123"))
+				},
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .badRequest, "a spent registration code must not recover the account")
+				}
+			)
+		}
+	}
+
+	// The bare form of a spent code must stay rejected too.
+	func testRecovery_BareSpentCodeIsRejected() async throws {
+		try await withApp { app in
+			let username = "recovery-bare-\(UUID().uuidString.prefix(8))"
+			let user = try await makeRecoveryUser(app, username: username, verification: "*abc123")
+			defer { Task { try? await user.delete(on: app.db) } }
+
+			try await app.test(
+				.POST,
+				"/api/v3/auth/recovery",
+				beforeRequest: { req async throws in
+					try req.content.encode(recoveryBody(username: username, key: "abc123"))
+				},
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .badRequest, "a spent registration code must not recover the account")
+				}
+			)
+		}
+	}
+
+	// Guards the fix against over-correcting: an unspent code must still recover the account.
+	func testRecovery_UnspentCodeStillWorks() async throws {
+		try await withApp { app in
+			let username = "recovery-unspent-\(UUID().uuidString.prefix(8))"
+			let user = try await makeRecoveryUser(app, username: username, verification: "abc123")
+			defer { Task { try? await user.delete(on: app.db) } }
+
+			try await app.test(
+				.POST,
+				"/api/v3/auth/recovery",
+				beforeRequest: { req async throws in
+					try req.content.encode(recoveryBody(username: username, key: "abc123"))
+				},
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .ok, "an unspent registration code must still recover the account")
+				}
+			)
+
+			// The code is spent by that recovery, so it is marked and cannot be replayed.
+			let reloaded = try await User.find(user.requireID(), on: app.db)
+			XCTAssertEqual(reloaded?.verification, "*abc123")
+		}
+	}
+}

--- a/Tests/AppTests/ContentStructValidationTests.swift
+++ b/Tests/AppTests/ContentStructValidationTests.swift
@@ -120,4 +120,16 @@ class ContentStructValidationTests: XCTestCase {
 
 		XCTAssertEqual(json["maxImageSize"] as? Int, Settings.shared.maxImageSize)
 	}
+
+	// MARK: - ImageUploadData
+
+	func testImageUploadData_EmptyFilenameBecomesNil() {
+		// Unused photo-form slots submit filename="" -- it must not be stored as a real image.
+		XCTAssertNil(ImageUploadData("").filename)
+		XCTAssertNil(ImageUploadData(nil).filename)
+	}
+
+	func testImageUploadData_RealFilenamePreserved() {
+		XCTAssertEqual(ImageUploadData("photo.jpg").filename, "photo.jpg")
+	}
 }

--- a/Tests/AppTests/ForumQuarantineVisibilityTests.swift
+++ b/Tests/AppTests/ForumQuarantineVisibilityTests.swift
@@ -1,0 +1,105 @@
+import Testing
+import XCTVapor
+
+@testable import swiftarr
+
+// Tests who sees a quarantined post's real content on `GET /api/v3/forum/post/:postID`.
+//
+// Moderators must receive the real text and images. The edit form is populated from this
+// response, so hiding them from a moderator means saving an edit wipes the post's images (#526).
+class ForumQuarantineVisibilityTests: XCTestCase, SwiftarrBaseTest {
+
+	private let images = ["quarantined-one.jpg", "quarantined-two.jpg"]
+
+	private struct Fixture {
+		let moderatorToken: String
+		let verifiedToken: String
+		let postID: Int
+	}
+
+	private func makeUser(_ app: Application, username: String, accessLevel: UserAccessLevel) async throws -> User {
+		let user = User(
+			username: username,
+			password: try Bcrypt.hash("password1"),
+			recoveryKey: try Bcrypt.hash("recovery key"),
+			accessLevel: accessLevel
+		)
+		try await user.save(on: app.db)
+		return user
+	}
+
+	private func makeToken(_ app: Application, for user: User) async throws -> String {
+		let token = try Token.generate(for: user)
+		try await token.save(on: app.db)
+		return token.token
+	}
+
+	// Builds a quarantined post with images, owned by a plain verified user, plus tokens for a
+	// moderator and a non-moderator. Rebuilds the user cache so token auth can resolve both.
+	private func makeFixture(_ app: Application, suffix: String) async throws -> Fixture {
+		let moderator = try await makeUser(app, username: "mod-\(suffix)", accessLevel: .moderator)
+		let author = try await makeUser(app, username: "author-\(suffix)", accessLevel: .verified)
+
+		let category = Category(title: "Quarantine Fixture \(suffix)", purpose: "test fixture")
+		try await category.save(on: app.db)
+		let forum = try Forum(title: "Quarantine Fixture \(suffix)", category: category, creatorID: author.requireID())
+		try await forum.save(on: app.db)
+
+		let post = try ForumPost(forum: forum, authorID: author.requireID(), text: "hidden text", images: images)
+		post.moderationStatus = .quarantined
+		try await post.save(on: app.db)
+
+		let moderatorToken = try await makeToken(app, for: moderator)
+		let verifiedToken = try await makeToken(app, for: author)
+		// The cache is built from Redis, which is not reachable until the app has booted.
+		try await app.asyncBoot()
+		try await app.initializeUserCache(app)
+
+		return Fixture(moderatorToken: moderatorToken, verifiedToken: verifiedToken, postID: try post.requireID())
+	}
+
+	private func bearer(_ token: String) -> HTTPHeaders {
+		var headers = HTTPHeaders()
+		headers.bearerAuthorization = BearerAuthorization(token: token)
+		return headers
+	}
+
+	// The regression from #526: a moderator loading a quarantined post for editing got no images,
+	// so saving the edit overwrote the post's images with an empty set.
+	func testQuarantinedPost_ModeratorSeesImages() async throws {
+		try await withApp { app in
+			let fixture = try await makeFixture(app, suffix: UUID().uuidString.prefix(8).lowercased())
+
+			try await app.test(
+				.GET,
+				"/api/v3/forum/post/\(fixture.postID)",
+				headers: bearer(fixture.moderatorToken),
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .ok)
+					let detail = try res.content.decode(PostDetailData.self)
+					XCTAssertEqual(detail.images, images, "a moderator must see a quarantined post's images")
+					XCTAssertEqual(detail.text, "hidden text", "a moderator must see a quarantined post's text")
+				}
+			)
+		}
+	}
+
+	// The other half of the contract: quarantine still hides content from everyone else.
+	func testQuarantinedPost_NonModeratorSeesNoImages() async throws {
+		try await withApp { app in
+			let fixture = try await makeFixture(app, suffix: UUID().uuidString.prefix(8).lowercased())
+
+			try await app.test(
+				.GET,
+				"/api/v3/forum/post/\(fixture.postID)",
+				headers: bearer(fixture.verifiedToken),
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .ok)
+					let detail = try res.content.decode(PostDetailData.self)
+					XCTAssertNil(detail.images, "quarantine must still hide images from non-moderators")
+					XCTAssertEqual(detail.text, "This post is under moderator review.")
+				}
+			)
+		}
+	}
+}

--- a/Tests/AppTests/SettingsCalendarTests.swift
+++ b/Tests/AppTests/SettingsCalendarTests.swift
@@ -20,6 +20,12 @@ class SettingsCalendarTests: XCTestCase {
 	func testCalendarForDate_FallsBackToPortTimeZone_WithEmptyChangeSet() {
 		// With the default (empty) timeZoneChanges, calendarForDate returns a calendar
 		// whose timezone is the port timezone — fall-through behavior of tzAtTime.
+		// Settings is process-global, so pin the change set here rather than relying on
+		// no earlier test having loaded one from the database.
+		let savedChanges = Settings.shared.timeZoneChanges
+		defer { Settings.shared.timeZoneChanges = savedChanges }
+		Settings.shared.timeZoneChanges = TimeZoneChangeSet()
+
 		let date = Date()
 		let cal = Settings.shared.calendarForDate(date)
 		XCTAssertEqual(cal.timeZone.identifier, Settings.shared.portTimeZone.identifier)


### PR DESCRIPTION
Two fixes. The first is a security issue, so I want to be upfront about it rather than bury it in a diff.

## Account recovery: a spent registration code could be replayed

The docs on `recoveryHandler` promise that a registration code "can only be used to recover once," specifically to cover the case where "a malicious user has obtained another's registration code." That guarantee did not hold.

A spent code is disabled by prefixing the stored `verification` with `*`. The single-use guard only runs when the submitted key normalizes to 6 characters, and normalization is just lowercasing and stripping spaces, so it does not remove the prefix. Submitting the marked 7-character value skipped the guard and then satisfied the verification equality check directly, resetting the password and returning a token. It re-marks on each use, so it repeats.

The match is now gated on an unspent verification. The password and recoveryKey paths are unchanged and still accept any input, so recovery using a password containing any character is unaffected.

On how much this matters: it needs the target's username plus their original registration code, so it is targeted rather than mass exploitable, and no cruise is currently running. I would not call it urgent. I am raising it because it defeats a protection that is already documented and already has code written for it, and because the fix is one line.

If you would rather review the security change on its own, say the word and I will split it out.

## #526: moderator edits deleted images on quarantined forum posts

`PostDetailData` nulls a quarantined post's images, and only moderators can edit quarantined content, so a mod's edit form loaded with no images and saving overwrote `post.images` with an empty set. `postHandler` now passes `overrideQuarantine` for users who can edit others' content, matching the pattern `ModerationController` already uses.

Also normalizes an empty `ImageUploadData` filename to nil. Unused photo-form slots submit `serverPhotoN=""`, which was being stored as a real empty filename and leaked bogus entries into a post's image list.

## Testing

Seven tests added, all driving real endpoints against Postgres and Redis.

`AuthControllerTests` on `POST /api/v3/auth/recovery`:

- the marked form of a spent code is rejected
- the bare form stays rejected
- an unspent code still recovers the account and is marked afterward

`ForumQuarantineVisibilityTests` on `GET /api/v3/forum/post/:postID`:

- a moderator receives a quarantined post's real text and images
- a non-moderator still gets the placeholder and no images

Both regressions are pinned by a test that fails against the unfixed code. The recovery case returns 200 and recovers the account; the moderator case returns nil images and the placeholder text. In each pair the other cases pass before and after, so the coverage isolates the defect rather than masking it.

Full suite: 253 tests, 2 failures. Both failures are pre-existing and reproduce identically on an unmodified master (`testTimeZoneChange` and `testNowDate` in `SettingsTests`, both expecting 2024 route data).

One extra commit makes `SettingsCalendarTests` order-independent. `Settings` is process-global, and that test only passed while nothing had loaded a change set from the database first. Adding any DB-backed test that sorts before it breaks it, so it now pins the change set explicitly using the same save-and-restore idiom the `cruiseStartDate` test in that file already uses.

## Running the DB-backed tests

The CI filter skips these because a pristine Postgres cannot satisfy them. The reason is that `Application.testable()` calls `readTimeZoneChanges` before `withApp` gets to `autoMigrate`, so the first query hits a table that does not exist yet. Migrating once out of band is enough:

```
swift run swiftarr migrate --env testing --yes
```

After that the DB-backed tests run normally. Two other things that cost me time and are worth writing down for anyone adding endpoint tests: `withApp` does not boot the app, so Redis is unreachable and `initializeUserCache` traps until you call `try await app.asyncBoot()`. And token auth resolves through `usersByToken` in that cache, so it has to be built before the request.

Happy to wire the migrate step into the CI job as a follow-up so the filter can widen.
