### PR TITLE
fix: return moderator post edits to moderation view (#526)

### DIFF
--- a/Sources/swiftarr/Controllers/ForumController.swift
+++ b/Sources/swiftarr/Controllers/ForumController.swift
@@ -1470,16 +1470,8 @@ struct ForumController: APIRouteCollection {
 			try await forumEdit.save(on: req.db)
 			try await post.save(on: req.db)
 		}
-		// Return the updated post. Editors (moderators) see the real text/images of a quarantined
-		// post, so the response shows what was just saved rather than the quarantine placeholder;
-		// matches `postHandler` and `ModerationController`. Only moderators reach this line for a
-		// quarantined post — `guardCanModifyContent` requires `canEditOthersContent()`.
-		let postDataArray = try await buildPostData(
-			[post],
-			userID: cacheUser.userID,
-			on: req,
-			overrideQuarantine: cacheUser.accessLevel.canEditOthersContent()
-		)
+		// return updated post as PostData
+		let postDataArray = try await buildPostData([post], userID: cacheUser.userID, on: req)
 		return postDataArray[0]
 	}
 
@@ -1842,8 +1834,7 @@ extension ForumController {
 		mutewords: [String]? = nil,
 		assumeBookmarked: Bool? = nil,
 		assumeLikeType: LikeType? = nil,
-		matchHashtag: String? = nil,
-		overrideQuarantine: Bool = false
+		matchHashtag: String? = nil
 	) async throws -> [PostData] {
 		// remove muteword posts
 		var filteredPosts = posts
@@ -1880,8 +1871,7 @@ extension ForumController {
 				author: author,
 				bookmarked: bookmarked,
 				userLike: userLike,
-				likeCount: likeCount,
-				overrideQuarantine: overrideQuarantine
+				likeCount: likeCount
 			)
 		}
 		return postDataArray

--- a/Sources/swiftarr/Controllers/ForumController.swift
+++ b/Sources/swiftarr/Controllers/ForumController.swift
@@ -1470,8 +1470,16 @@ struct ForumController: APIRouteCollection {
 			try await forumEdit.save(on: req.db)
 			try await post.save(on: req.db)
 		}
-		// return updated post as PostData
-		let postDataArray = try await buildPostData([post], userID: cacheUser.userID, on: req)
+		// Return the updated post. Editors (moderators) see the real text/images of a quarantined
+		// post, so the response shows what was just saved rather than the quarantine placeholder;
+		// matches `postHandler` and `ModerationController`. Only moderators reach this line for a
+		// quarantined post — `guardCanModifyContent` requires `canEditOthersContent()`.
+		let postDataArray = try await buildPostData(
+			[post],
+			userID: cacheUser.userID,
+			on: req,
+			overrideQuarantine: cacheUser.accessLevel.canEditOthersContent()
+		)
 		return postDataArray[0]
 	}
 
@@ -1834,7 +1842,8 @@ extension ForumController {
 		mutewords: [String]? = nil,
 		assumeBookmarked: Bool? = nil,
 		assumeLikeType: LikeType? = nil,
-		matchHashtag: String? = nil
+		matchHashtag: String? = nil,
+		overrideQuarantine: Bool = false
 	) async throws -> [PostData] {
 		// remove muteword posts
 		var filteredPosts = posts
@@ -1871,7 +1880,8 @@ extension ForumController {
 				author: author,
 				bookmarked: bookmarked,
 				userLike: userLike,
-				likeCount: likeCount
+				likeCount: likeCount,
+				overrideQuarantine: overrideQuarantine
 			)
 		}
 		return postDataArray

--- a/Sources/swiftarr/Resources/Views/moderation/forumPostView.html
+++ b/Sources/swiftarr/Resources/Views/moderation/forumPostView.html
@@ -9,7 +9,7 @@
 			<div class="row mb-3">
 				<div class="col" data-reportabletype="forumpost" data-reportableid="#(modData.forumPost.postID)">
 					#if(!modData.isDeleted):
-						<a class="btn btn-outline-primary btn-sm" href="/forumpost/edit/#(modData.forumPost.postID)">Edit</a>
+						<a class="btn btn-outline-primary btn-sm" href="/forumpost/edit/#(modData.forumPost.postID)?intent=modEdit">Edit</a>
 						<button type="button" class="btn btn-outline-primary btn-sm" data-bs-toggle="modal" data-bs-target="\#deleteModal">Delete</button>
 						<span class="dropdown">
 							<button class="btn btn-primary btn-sm dropdown-toggle" type="button" id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false">

--- a/Sources/swiftarr/Site/SiteController.swift
+++ b/Sources/swiftarr/Site/SiteController.swift
@@ -210,10 +210,27 @@ struct MessagePostContext: Encodable {
 		case themeEdit(DailyThemeData)
 	}
 
+	/// Why the user opened an edit form. Set from the `intent` query parameter on the edit page's URL,
+	/// which the moderation views append to their Edit links. It is deliberately not inferred from the
+	/// user's access level: a moderator editing one of their own posts from the forum is an ordinary
+	/// edit and should return to the forum, not to the moderation view.
+	enum EditIntent: String {
+		/// The user reached the edit form the ordinary way, from the content itself.
+		case normal
+		/// The user reached the edit form from a moderation view, and should be returned there.
+		case modEdit
+
+		/// Reads the intent from a request's `intent` query parameter. An absent or unrecognized
+		/// value is `.normal`, so a hand-edited URL cannot do anything but the default.
+		init(_ req: Request) {
+			self = req.query[String.self, at: "intent"].flatMap(EditIntent.init(rawValue:)) ?? .normal
+		}
+	}
+
 	init(
 		forType: InitType,
 		userRoles: Set<UserRoleType>? = nil,
-		userIsModerator: Bool = false
+		editIntent: EditIntent = .normal
 	) {
 		allowedImageTypes = Settings.shared.validImageInputTypes.joined(separator: ", ")
 		// Determine max images based on user role (shutternauts get 8, others get setting value)
@@ -276,10 +293,9 @@ struct MessagePostContext: Encodable {
 				photoFilenames.append("")
 			}
 			formAction = "/forumpost/edit/\(withForumPost.postID)"
-			if userIsModerator {
-				postSuccessURL = "/moderate/forumpost/\(withForumPost.postID)"
-			} else {
-				postSuccessURL = "/forum/\(withForumPost.forumID)"
+			switch editIntent {
+			case .modEdit: postSuccessURL = "/moderate/forumpost/\(withForumPost.postID)"
+			case .normal: postSuccessURL = "/forum/\(withForumPost.forumID)"
 			}
 			isEdit = true
 		// For creating a new Seamail thread

--- a/Sources/swiftarr/Site/SiteController.swift
+++ b/Sources/swiftarr/Site/SiteController.swift
@@ -210,7 +210,11 @@ struct MessagePostContext: Encodable {
 		case themeEdit(DailyThemeData)
 	}
 
-	init(forType: InitType, userRoles: Set<UserRoleType>? = nil) {
+	init(
+		forType: InitType,
+		userRoles: Set<UserRoleType>? = nil,
+		userIsModerator: Bool = false
+	) {
 		allowedImageTypes = Settings.shared.validImageInputTypes.joined(separator: ", ")
 		// Determine max images based on user role (shutternauts get 8, others get setting value)
 		let maxImages: Int
@@ -272,7 +276,11 @@ struct MessagePostContext: Encodable {
 				photoFilenames.append("")
 			}
 			formAction = "/forumpost/edit/\(withForumPost.postID)"
-			postSuccessURL = "/forum/\(withForumPost.forumID)"
+			if userIsModerator {
+				postSuccessURL = "/moderate/forumpost/\(withForumPost.postID)"
+			} else {
+				postSuccessURL = "/forum/\(withForumPost.forumID)"
+			}
 			isEdit = true
 		// For creating a new Seamail thread
 		case .seamail:

--- a/Sources/swiftarr/Site/SiteForumController.swift
+++ b/Sources/swiftarr/Site/SiteForumController.swift
@@ -726,8 +726,12 @@ struct SiteForumController: SiteControllerUtils {
 
 			init(_ req: Request, post: PostDetailData) throws {
 				trunk = .init(req, title: "Edit Forum Post", tab: .forums)
-				let userRoles = req.auth.get(UserCacheData.self)?.userRoles
-				self.post = .init(forType: .forumPostEdit(post), userRoles: userRoles)
+				let user = req.auth.get(UserCacheData.self)
+				self.post = .init(
+					forType: .forumPostEdit(post),
+					userRoles: user?.userRoles,
+					userIsModerator: user?.accessLevel.canEditOthersContent() == true
+				)
 			}
 		}
 		var ctx = try ForumPostEditPageContext(req, post: post)

--- a/Sources/swiftarr/Site/SiteForumController.swift
+++ b/Sources/swiftarr/Site/SiteForumController.swift
@@ -726,11 +726,10 @@ struct SiteForumController: SiteControllerUtils {
 
 			init(_ req: Request, post: PostDetailData) throws {
 				trunk = .init(req, title: "Edit Forum Post", tab: .forums)
-				let user = req.auth.get(UserCacheData.self)
 				self.post = .init(
 					forType: .forumPostEdit(post),
-					userRoles: user?.userRoles,
-					userIsModerator: user?.accessLevel.canEditOthersContent() == true
+					userRoles: req.auth.get(UserCacheData.self)?.userRoles,
+					editIntent: .init(req)
 				)
 			}
 		}

--- a/Tests/AppTests/ForumQuarantineVisibilityTests.swift
+++ b/Tests/AppTests/ForumQuarantineVisibilityTests.swift
@@ -84,58 +84,6 @@ class ForumQuarantineVisibilityTests: XCTestCase, SwiftarrBaseTest {
 		}
 	}
 
-	// The same regression on the write path. `POST /api/v3/forum/post/:postID/update` builds its
-	// response through `buildPostData`, which does not pass `overrideQuarantine`, so a moderator
-	// who saves an edit gets back `images: nil` and the placeholder text — the API reporting that
-	// the edit wiped the post it just stored. A client that re-seeds its edit form from this
-	// response then writes that emptiness back on the next save, which is #526 exactly.
-	func testQuarantinedPost_ModeratorEditResponseShowsWhatWasSaved() async throws {
-		try await withApp { app in
-			let fixture = try await makeFixture(app, suffix: UUID().uuidString.prefix(8).lowercased())
-			let edit = PostContentData(text: "edited by a moderator", images: images.map { ImageUploadData($0) })
-
-			try await app.test(
-				.POST,
-				"/api/v3/forum/post/\(fixture.postID)/update",
-				headers: bearer(fixture.moderatorToken),
-				beforeRequest: { req async throws in
-					try req.content.encode(edit)
-				},
-				afterResponse: { res async throws in
-					XCTAssertEqual(res.status, .ok)
-					let updated = try res.content.decode(PostData.self)
-					XCTAssertEqual(updated.images, images, "the edit response must show the images the moderator just saved")
-					XCTAssertEqual(
-						updated.text,
-						"edited by a moderator",
-						"the edit response must show the text the moderator just saved"
-					)
-				}
-			)
-		}
-	}
-
-	// The bound on the above: quarantine is not loosened for anyone who cannot already edit
-	// others' content, so there is no path by which a non-moderator reaches the override.
-	func testQuarantinedPost_NonModeratorCannotEdit() async throws {
-		try await withApp { app in
-			let fixture = try await makeFixture(app, suffix: UUID().uuidString.prefix(8).lowercased())
-			let edit = PostContentData(text: "edited by the author", images: images.map { ImageUploadData($0) })
-
-			try await app.test(
-				.POST,
-				"/api/v3/forum/post/\(fixture.postID)/update",
-				headers: bearer(fixture.verifiedToken),
-				beforeRequest: { req async throws in
-					try req.content.encode(edit)
-				},
-				afterResponse: { res async throws in
-					XCTAssertEqual(res.status, .forbidden, "only moderators may edit a quarantined post")
-				}
-			)
-		}
-	}
-
 	// The other half of the contract: quarantine still hides content from everyone else.
 	func testQuarantinedPost_NonModeratorSeesNoImages() async throws {
 		try await withApp { app in
@@ -153,5 +101,39 @@ class ForumQuarantineVisibilityTests: XCTestCase, SwiftarrBaseTest {
 				}
 			)
 		}
+	}
+
+	func testForumPostEditSuccessURLReturnsModeratorsToModeration() {
+		let post = PostDetailData(
+			postID: 42,
+			forumID: UUID(),
+			createdAt: Date(),
+			author: UserHeader(
+				userID: UUID(),
+				username: "author",
+				displayName: nil,
+				userImage: nil,
+				preferredPronoun: nil
+			),
+			text: "post text",
+			images: nil,
+			isBookmarked: false,
+			userLike: nil,
+			laughs: [],
+			likes: [],
+			loves: []
+		)
+
+		let moderatorContext = MessagePostContext(
+			forType: .forumPostEdit(post),
+			userIsModerator: true
+		)
+		let userContext = MessagePostContext(
+			forType: .forumPostEdit(post),
+			userIsModerator: false
+		)
+
+		XCTAssertEqual(moderatorContext.postSuccessURL, "/moderate/forumpost/42")
+		XCTAssertEqual(userContext.postSuccessURL, "/forum/\(post.forumID)")
 	}
 }

--- a/Tests/AppTests/ForumQuarantineVisibilityTests.swift
+++ b/Tests/AppTests/ForumQuarantineVisibilityTests.swift
@@ -103,8 +103,8 @@ class ForumQuarantineVisibilityTests: XCTestCase, SwiftarrBaseTest {
 		}
 	}
 
-	func testForumPostEditSuccessURLReturnsModeratorsToModeration() {
-		let post = PostDetailData(
+	private func editFixturePost() -> PostDetailData {
+		PostDetailData(
 			postID: 42,
 			forumID: UUID(),
 			createdAt: Date(),
@@ -123,17 +123,52 @@ class ForumQuarantineVisibilityTests: XCTestCase, SwiftarrBaseTest {
 			likes: [],
 			loves: []
 		)
+	}
 
-		let moderatorContext = MessagePostContext(
-			forType: .forumPostEdit(post),
-			userIsModerator: true
-		)
-		let userContext = MessagePostContext(
-			forType: .forumPostEdit(post),
-			userIsModerator: false
-		)
+	// A moderator who opened the edit form from the moderation view is returned to it; every other
+	// edit goes back to the forum.
+	func testForumPostEditSuccessURLFollowsEditIntent() {
+		let post = editFixturePost()
 
-		XCTAssertEqual(moderatorContext.postSuccessURL, "/moderate/forumpost/42")
-		XCTAssertEqual(userContext.postSuccessURL, "/forum/\(post.forumID)")
+		let fromModeration = MessagePostContext(forType: .forumPostEdit(post), editIntent: .modEdit)
+		let fromForum = MessagePostContext(forType: .forumPostEdit(post), editIntent: .normal)
+
+		XCTAssertEqual(fromModeration.postSuccessURL, "/moderate/forumpost/42")
+		XCTAssertEqual(fromForum.postSuccessURL, "/forum/\(post.forumID)")
+	}
+
+	// The default matters as much as the modEdit case: omitting `editIntent` must behave like an
+	// ordinary edit, because every caller other than the moderation-view link omits it.
+	func testForumPostEditSuccessURLDefaultsToTheForum() {
+		let post = editFixturePost()
+
+		XCTAssertEqual(
+			MessagePostContext(forType: .forumPostEdit(post)).postSuccessURL,
+			"/forum/\(post.forumID)"
+		)
+	}
+
+	// The intent is read from the URL, never inferred from who is asking. A moderator editing one of
+	// their own posts from the forum sends no `intent`, so they get `.normal` and return to the forum
+	// — the case that made an access-level check the wrong signal.
+	func testEditIntentComesFromTheQueryParameter() async throws {
+		try await withApp { app in
+			func intent(for url: String) -> MessagePostContext.EditIntent {
+				MessagePostContext.EditIntent(
+					Request(
+						application: app,
+						method: .GET,
+						url: URI(string: url),
+						on: app.eventLoopGroup.next()
+					)
+				)
+			}
+
+			XCTAssertEqual(intent(for: "/forumpost/edit/42?intent=modEdit"), .modEdit)
+			XCTAssertEqual(intent(for: "/forumpost/edit/42"), .normal, "no intent means an ordinary edit")
+			XCTAssertEqual(intent(for: "/forumpost/edit/42?intent="), .normal)
+			XCTAssertEqual(intent(for: "/forumpost/edit/42?intent=modedit"), .normal, "the value is exact")
+			XCTAssertEqual(intent(for: "/forumpost/edit/42?intent=javascript:alert(1)"), .normal)
+		}
 	}
 }

--- a/Tests/AppTests/ForumQuarantineVisibilityTests.swift
+++ b/Tests/AppTests/ForumQuarantineVisibilityTests.swift
@@ -84,6 +84,58 @@ class ForumQuarantineVisibilityTests: XCTestCase, SwiftarrBaseTest {
 		}
 	}
 
+	// The same regression on the write path. `POST /api/v3/forum/post/:postID/update` builds its
+	// response through `buildPostData`, which does not pass `overrideQuarantine`, so a moderator
+	// who saves an edit gets back `images: nil` and the placeholder text — the API reporting that
+	// the edit wiped the post it just stored. A client that re-seeds its edit form from this
+	// response then writes that emptiness back on the next save, which is #526 exactly.
+	func testQuarantinedPost_ModeratorEditResponseShowsWhatWasSaved() async throws {
+		try await withApp { app in
+			let fixture = try await makeFixture(app, suffix: UUID().uuidString.prefix(8).lowercased())
+			let edit = PostContentData(text: "edited by a moderator", images: images.map { ImageUploadData($0) })
+
+			try await app.test(
+				.POST,
+				"/api/v3/forum/post/\(fixture.postID)/update",
+				headers: bearer(fixture.moderatorToken),
+				beforeRequest: { req async throws in
+					try req.content.encode(edit)
+				},
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .ok)
+					let updated = try res.content.decode(PostData.self)
+					XCTAssertEqual(updated.images, images, "the edit response must show the images the moderator just saved")
+					XCTAssertEqual(
+						updated.text,
+						"edited by a moderator",
+						"the edit response must show the text the moderator just saved"
+					)
+				}
+			)
+		}
+	}
+
+	// The bound on the above: quarantine is not loosened for anyone who cannot already edit
+	// others' content, so there is no path by which a non-moderator reaches the override.
+	func testQuarantinedPost_NonModeratorCannotEdit() async throws {
+		try await withApp { app in
+			let fixture = try await makeFixture(app, suffix: UUID().uuidString.prefix(8).lowercased())
+			let edit = PostContentData(text: "edited by the author", images: images.map { ImageUploadData($0) })
+
+			try await app.test(
+				.POST,
+				"/api/v3/forum/post/\(fixture.postID)/update",
+				headers: bearer(fixture.verifiedToken),
+				beforeRequest: { req async throws in
+					try req.content.encode(edit)
+				},
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .forbidden, "only moderators may edit a quarantined post")
+				}
+			)
+		}
+	}
+
 	// The other half of the contract: quarantine still hides content from everyone else.
 	func testQuarantinedPost_NonModeratorSeesNoImages() async throws {
 		try await withApp { app in


### PR DESCRIPTION
## What changed

A moderator who opens a forum post's Edit form **from the moderation view** is returned to `/moderate/forumpost/:post_id` after saving, instead of to the forum. Every other edit still returns to `/forum/:forum_id`.

The signal is an explicit `intent=modEdit` query parameter on the moderation view's Edit link, not the editor's access level. That distinction is the point: a moderator editing one of their own posts from the forum has moderator rights but did not arrive from moderation, and must go back to the forum they were reading.

- `moderation/forumPostView.html` links to `/forumpost/edit/:post_id?intent=modEdit`.
- `MessagePostContext.EditIntent` reads that parameter. Absent or unrecognized values are `.normal`, so no other caller changes behavior.
- The existing `ForumController` response and quarantine behavior are unchanged.

The form already uses `location.assign(successURL)`, so this requests a fresh moderation page rather than reusing a cached back-navigation response. The destination shows the current post, its edit history, and the moderation-state controls.

A non-moderator who hand-types the parameter sends only themselves to a page `SiteRequireModeratorMiddleware` turns them away from.

## Tests

- Success-URL cases for `.modEdit`, `.normal`, and the omitted default.
- A request-level test that the intent comes from the URL, including that no `intent` means an ordinary edit. Hard-coding the parse to `.modEdit` fails it on four assertions.
- `swift test --enable-test-discovery --skip SettingsTests` (the CI command): **246 passed, 0 failed**, rebased onto current `master`.
