### PR TITLE
fix: an event-tagged photostream upload reports itself as untagged (#562)

### DIFF
--- a/Sources/swiftarr/Models/StreamPhoto.swift
+++ b/Sources/swiftarr/Models/StreamPhoto.swift
@@ -50,6 +50,12 @@ final class StreamPhoto: Model, @unchecked Sendable {
 		self.moderationStatus = .normal
 		if let event = atEvent {
 			self.$atEvent.id = event.id
+			// Keep the relation loaded, not just referenced. `@OptionalParent`'s getter is
+			// `self.value ?? nil`, so an id-only relation reads back as "no event" instead of
+			// trapping — and anything that builds a response off this instance before a
+			// re-fetch (`photostreamUploadHandler` does) silently reports the photo as
+			// untagged.
+			self.$atEvent.value = event
 		}
 		self.boatLocation = boatLocation
 	}

--- a/Tests/AppTests/PhotostreamControllerTests.swift
+++ b/Tests/AppTests/PhotostreamControllerTests.swift
@@ -3,7 +3,79 @@ import XCTest
 
 @testable import swiftarr
 
-final class PhotostreamControllerTests: XCTestCase {
+final class PhotostreamControllerTests: XCTestCase, SwiftarrBaseTest {
+
+	// `photostreamUploadHandler` builds its response straight off the `StreamPhoto` it just
+	// created, and `StreamPhoto.init` records an `atEvent` by id only. `@OptionalParent`'s
+	// getter is `self.value ?? nil`, so an unloaded relation reads as "no event" rather than
+	// trapping — and `PhotostreamImageData.init` then falls through to the boat-location
+	// branch. An event-tagged upload comes back tagged `onBoat` with no event attached, even
+	// though the row it just wrote has the right `at_event`. Only the immediate response is
+	// wrong; a later fetch that eager-loads the relation is correct, which is why this
+	// survived review.
+	func testEventTaggedPhoto_ResponseCarriesTheEvent() async throws {
+		try await withApp { app in
+			let suffix = UUID().uuidString.prefix(8).lowercased()
+			let user = User(
+				username: "photographer-\(suffix)",
+				password: try Bcrypt.hash("password1"),
+				recoveryKey: try Bcrypt.hash("recovery key"),
+				accessLevel: .verified
+			)
+			try await user.save(on: app.db)
+
+			let event = Event(
+				startTime: Date(timeIntervalSince1970: 1_725_000_000),
+				endTime: Date(timeIntervalSince1970: 1_725_003_600),
+				title: "Tagged Event \(suffix)",
+				description: "fixture",
+				location: "Deck 5",
+				eventType: .general,
+				uid: "photostream-fixture-\(suffix)"
+			)
+			try await event.save(on: app.db)
+
+			// Re-read the saved row with `roles` eager-loaded: `User.init` leaves optional columns
+			// uninitialized and `UserCacheData.init` reads every field plus `user.roles`, either
+			// of which traps when unfetched.
+			let userID = try user.requireID()
+			guard let storedUser = try await User.find(userID, on: app.db) else {
+				return XCTFail("the fixture user was not saved")
+			}
+			try await storedUser.$roles.load(on: app.db)
+			let cacheUser = UserCacheData(userID: try storedUser.requireID(), user: storedUser, blocks: nil, mutewords: nil)
+			// Exactly what the handler does: designated init, then save, then build the response.
+			let streamPhoto = StreamPhoto(
+				image: "photostream-\(suffix).jpg",
+				captureTime: Date(timeIntervalSince1970: 1_725_001_000),
+				user: cacheUser,
+				atEvent: event,
+				boatLocation: nil
+			)
+			try await streamPhoto.save(on: app.db)
+
+			XCTAssertEqual(
+				streamPhoto.$atEvent.id,
+				try event.requireID(),
+				"the row itself is tagged correctly — the stored data is not the problem"
+			)
+
+			let photoData = try PhotostreamImageData(
+				streamPhoto: streamPhoto,
+				author: UserHeader(
+					userID: try user.requireID(),
+					username: user.username,
+					displayName: nil,
+					userImage: nil,
+					preferredPronoun: nil
+				)
+			)
+
+			XCTAssertEqual(photoData.event?.title, "Tagged Event \(suffix)", "the upload response must carry the event the photo was tagged with")
+			XCTAssertNil(photoData.location, "a photo tagged with an event has no boat location")
+		}
+	}
+
 	func testUploadResponseIncludesCreatedPhotoAndRateLimit() throws {
 		let createdAt = Date(timeIntervalSince1970: 1_725_000_000)
 		let photo = PhotostreamImageData(


### PR DESCRIPTION
This is a regression I introduced in #562, found today. Sorry about that.

## The behaviour

Upload a photostream photo tagged with an event and the response comes back saying the photo is tagged **`On Boat`, with no event attached**. The database row is correct — `at_event` holds the right id — and any later fetch that eager-loads the relation shows the event. Only the immediate upload response is wrong.

`#562` made the upload return the created content, and it returns it built off the in-memory `StreamPhoto`:

```swift
let streamPhoto = StreamPhoto(image: filename, ..., atEvent: matchingEvent, boatLocation: boatLocation)
try await streamPhoto.save(on: req.db)
let photoData = try PhotostreamImageData(streamPhoto: streamPhoto, author: user.makeHeader())
```

`StreamPhoto.init` records the event by id only:

```swift
if let event = atEvent {
    self.$atEvent.id = event.id
}
```

FluentKit's `OptionalParentProperty.wrappedValue` is `self.value ?? nil` — it does **not** trap on an unloaded relation, it reads back as `nil`. So `PhotostreamImageData.init` misses the `if let event = streamPhoto.atEvent` branch, finds no `boatLocation` either (the handler leaves it nil whenever an event matched), and falls through to `location = .onBoat`.

Silent wrong data rather than a crash, which is why it survived review.

## The fix

In the initializer, not the controller:

```swift
if let event = atEvent {
    self.$atEvent.id = event.id
    self.$atEvent.value = event
}
```

An init that accepts an `Event` and keeps only its id has a postcondition that doesn't match its input, and every caller inherits that. Setting the relation value costs nothing and needs no extra query — the alternative, `try await streamPhoto.$atEvent.load(on: req.db)` in the handler, is a round trip for data we were already handed.

## Why the existing test didn't catch it

The test I added in #562 asserted `makeUploadResponse` against a hand-built `PhotostreamImageData`. It exercised the half that worked and never the construction. That's the actual lesson here — the test covered the code I wrote rather than the behaviour I claimed.

The new test drives the real sequence: designated init → save → build the response. On unmodified `master`:

```
XCTAssertEqual failed: ("nil") is not equal to ("Optional("Tagged Event 818a48c0")")
  - the upload response must carry the event the photo was tagged with
XCTAssertNil failed: "On Boat"
  - a photo tagged with an event has no boat location
```

Green after the two-line change.

## Verification

Local Postgres 17 + Redis (`swiftarr migrate --env testing` first — a fresh test DB can't boot the app, `readTimeZoneChanges` runs during configure and needs the table).

`swift test --skip SettingsTests` → **243 tests, 0 failures.**

## One thing to flag

`PhotostreamControllerTests` is not in the `Test` job's filter, so **neither the old test nor this new one runs in CI**. Same for `AuthControllerTests` and `ForumQuarantineVisibilityTests` from #565. I've opened a separate PR for that so this fix is actually protected going forward; happy for you to take these in either order, they don't conflict.

## Credit where it's due, and a correction

A review bot flagged this line on an unrelated branch of mine. Its diagnosis was that reading the unloaded relation would **trap**, crashing the request after the photo was already persisted. That part is wrong — `OptionalParentProperty` returns `nil` rather than calling `fatalError`, which I checked in `.build/checkouts/fluent-kit` before writing any of this. But it was looking at the right line, and the real behaviour underneath is a bug worth fixing.
