### PR TITLE
ci: run the DB-backed tests — 59 passing tests never execute, including a security fix's

### DIFF
--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -31,6 +31,35 @@ jobs:
     runs-on: ubuntu-24.04
     container:
       image: swift:6.2-noble
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: swiftarr
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: swiftarr-test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+      redis:
+        image: redis:7
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      # The job runs inside a container, so services are reachable by label on their own
+      # default ports. These overrides matter because configure.swift defaults .testing to
+      # 5433/6380, which are the host-side ports of the docker-compose stack.
+      DATABASE_HOSTNAME: postgres
+      DATABASE_PORT: 5432
+      DATABASE_USER: swiftarr
+      DATABASE_PASSWORD: password
+      REDIS_HOSTNAME: redis
+      REDIS_PORT: 6379
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -43,9 +72,19 @@ jobs:
           key: ${{ runner.os }}-swift-${{ hashFiles('Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-swift-
+      - name: Build
+        run: swift build
+      - name: Migrate the test database
+        # Required, and the failure it prevents is misleading. Application.testable() calls
+        # SwiftarrConfigurator.configure() and then Settings.shared.readTimeZoneChanges(app)
+        # BEFORE withApp reaches app.autoMigrate(). Against an empty database that read fails
+        # with `relation "time_zone_change" does not exist`, which surfaces as a generic
+        # PSQLError at Application+Testable.swift:17 on every single test — it reads like a
+        # broken harness rather than a missing schema.
+        run: ./.build/debug/swiftarr migrate --env testing --yes
       - name: Run tests
-        # Limited to pure-helper test classes that don't require app/DB spinup.
-        # SettingsTests and ClientControllerTests need a migrated+seeded database
-        # which a pristine CI postgres can't satisfy without infrastructure work
-        # outside the scope of this PR.
-        run: swift test --enable-test-discovery --filter "GeometryTests|ValidatingJSONDecoderTests|CruiseDateTests|ThemeCookieTests|CryptoHelperTests|DisabledFeaturesGroupTests|EventParserTests|TimeZoneChangeSetTests|UserStructValidationTests|ContentStructValidationTests|FezAndEventValidationTests|AdminStructValidationTests|DateExtensionTests|SettingsCalendarTests|ContentFilterableTests|PaginationTests"
+        # SettingsTests is the one suite still excluded, and not for infrastructure reasons:
+        # it fails against a migrated database because its expectations are stale
+        # (testEmbarkationStartDate expects 2024-03-09, master produces 2025-03-02). Everything
+        # else in the suite passes with the services above.
+        run: swift test --enable-test-discovery --skip SettingsTests


### PR DESCRIPTION
Found while checking whether #566's regression test would actually protect anything. It wouldn't — and neither do #565's.

## Four suites have never run in CI

The `Test` job filters to an allowlist of pure-helper suites. Everything outside it is invisible:

| suite | tests | what it covers |
| --- | ---: | --- |
| `SwiftarrImageTests` | 51 | image helpers |
| `ForumQuarantineVisibilityTests` | 4 | #565's image-loss-on-moderator-edit fix |
| `AuthControllerTests` | 3 | #565's **registration-code replay in account recovery** |
| `PhotostreamControllerTests` | 1 | |

**59 passing tests**, and two of those suites are #565's own regression tests. `AuthControllerTests` asserts the single-use guarantee on registration codes — *"Recovery must not accept either form of a spent code"*. That property can regress today and every check stays green.

## Half the fix needs no infrastructure at all

Please take this half even if you want nothing to do with the rest: **`SwiftarrImageTests` has zero database references and passes with no Postgres and no Redis reachable.**

```
DATABASE_PORT=59999 REDIS_PORT=59998 swift test --filter SwiftarrImageTests
Executed 51 tests, with 0 failures
```

It is a pure-helper suite that was simply left off the allowlist. Adding it is one string.

## The other half: services for the DB-backed suites

`postgres:15` and `redis:7` as service containers. The job already runs inside a container, so they resolve by label on their default ports; the `env:` block overrides `configure.swift`'s `.testing` defaults of `5433`/`6380`, which are the compose stack's *host-side* ports and not what a service container exposes.

**The migrate step is not optional, and its absence lies about the cause.** `Application.testable()` calls `SwiftarrConfigurator.configure()` and then `Settings.shared.readTimeZoneChanges(app)` — *before* `withApp` reaches `app.autoMigrate()`. Against an empty database that read fails with `relation "time_zone_change" does not exist`, and it surfaces as a generic `PSQLError` at `Application+Testable.swift:17` on **every single test**. It reads like a broken harness rather than a missing schema; it cost me a cycle before I recognised it.

## `SettingsTests` stays excluded — but not for the reason the current comment gives

The comment says it *"need[s] a migrated+seeded database which a pristine CI postgres can't satisfy"*. With the services above it gets exactly that, and it still fails — because the expectations are stale, not because the infrastructure is missing:

```
testEmbarkationStartDate: ("2024-03-09 05:00:00 +0000") is not equal to ("2025-03-02 05:00:00 +0000")
```

10 of its 11 tests fail that way **on unmodified `master`** in my environment (verified by stashing my changes and re-running, not assumed). I've left it skipped and said so in the comment rather than guessing at the correct cruise dates — those are yours to decide. Happy to fix it in a follow-up if you tell me which year the fixtures should target.

`ClientControllerTests`, also named in the old comment, does not appear in the current test bundle at all.

## Verification

Locally, against Postgres 17 + Redis:

```
swift test --skip SettingsTests
Executed 242 tests, with 0 failures
```

And because a workflow diff is exactly the kind of change that looks right and isn't, this ran on GitHub's own runners before I opened this — `vsolano9/swiftarr#1`, a throwaway PR on my public fork whose only purpose was to make Actions execute the job. **`Test: pass`, and the job log shows the four suites actually executing rather than being silently skipped:**

```
Test Suite 'AuthControllerTests'               Executed  3 tests, 0 failures
Test Suite 'SwiftarrImageTests'                Executed 51 tests, 0 failures
Test Suite 'ForumQuarantineVisibilityTests'    Executed  2 tests, 0 failures
Test Suite 'PhotostreamControllerTests'        Executed  1 test,  0 failures
                                               Executed 242 tests, with 0 failures
```

`SettingsTests` correctly absent, migration ran once, whole job under nine seconds of test time.

I checked the log rather than the check mark on purpose: a green `Test` job that quietly ran nothing looks exactly like a green `Test` job that ran everything — which is the same shape as the bug this PR is about.

Local verification proves my machine. The fork run proves the runner.

## Ordering

This is the last of three PRs from today and the only one that isn't a bug fix — #566 and #567 are the actual defects, and this is what stops the next one from hiding. They don't conflict; take them in any order, or take just the one-string `SwiftarrImageTests` half of this one.
