### PR TITLE
Quartermaster Phase 1: schema foundation

### DIFF
--- a/Sources/swiftarr/Enumerations/AppFeatures.swift
+++ b/Sources/swiftarr/Enumerations/AppFeatures.swift
@@ -52,6 +52,7 @@ public enum SwiftarrFeature: String, Content, CaseIterable, Sendable {
 	case registration // User account creation. This is independent of .users above.
 	case hunts  // Puzzle hunts, quizzes, etc.
 	case eventFeedback  	// Form for Shadow Event hosts to give feedback on how their event went
+	case quartermaster  // Searchable "have / need" item board
 
 	case all
 

--- a/Sources/swiftarr/Enumerations/QuartermasterCategory.swift
+++ b/Sources/swiftarr/Enumerations/QuartermasterCategory.swift
@@ -1,0 +1,29 @@
+import Vapor
+
+/// The category of a `QuartermasterItem` — whether the user has the item to offer, or needs it.
+enum QuartermasterCategory: String, CaseIterable, Codable, Sendable {
+	/// The user has this item and is offering it to others.
+	case have
+	/// The user needs this item and is looking for someone who has it.
+	case need
+
+	/// `.label` returns a consumer-friendly display name.
+	var label: String {
+		switch self {
+		case .have: return "Have"
+		case .need: return "Need"
+		}
+	}
+
+	/// For use by the URL-parameter layer. Lowercases the input and maps it to a case,
+	/// throwing a 400 on unknown values.
+	///
+	/// URL parameters that take a category string should use this function.
+	static func fromAPIString(_ str: String) throws -> Self {
+		let lcString = str.lowercased()
+		if let result = QuartermasterCategory(rawValue: lcString) {
+			return result
+		}
+		throw Abort(.badRequest, reason: "Unknown category parameter value.")
+	}
+}

--- a/Sources/swiftarr/Enumerations/ReportType.swift
+++ b/Sources/swiftarr/Enumerations/ReportType.swift
@@ -23,6 +23,8 @@ enum ReportType: String, Codable {
 	case streamPhoto
 	/// a `PersonalEvent`
 	case personalEvent
+	/// a `QuartermasterItem`
+	case quartermasterItem
 }
 
 /// Moderation status of a piece of reportable content.

--- a/Sources/swiftarr/Extensions/SQLDatabase+FullTextSearch.swift
+++ b/Sources/swiftarr/Extensions/SQLDatabase+FullTextSearch.swift
@@ -1,0 +1,46 @@
+import FluentSQL
+
+/// Shared helpers for the `Create*SearchIndexes` migrations (see `SearchIndexCreation.swift`,
+/// `SeamailSearchIndexCreation.swift`, `QuartermasterSearchIndexCreation.swift`), which each add a
+/// stored generated `fulltext_search` tsvector column plus a GIN index to one or more tables.
+/// Centralized here so the full-text index strategy only needs to change in one place.
+extension SQLDatabase {
+
+	/// Adds a `fulltext_search` tsvector column to `tableName`, generated from `tsvectorExpression`
+	/// (a raw SQL expression, e.g. `"to_tsvector('english', text)"`), and creates a GIN index over it.
+	func addFullTextSearchColumn(tableName: String, tsvectorExpression: String) async throws {
+		try await self.raw(
+			"""
+			  ALTER TABLE \(unsafeRaw: tableName)
+			  ADD COLUMN IF NOT EXISTS fulltext_search tsvector
+			    GENERATED ALWAYS AS (\(unsafeRaw: tsvectorExpression)) STORED;
+			"""
+		)
+		.run()
+
+		try await createSearchIndex(tableName: tableName)
+	}
+
+	func createSearchIndex(tableName: String) async throws {
+		try await self.raw(
+			"""
+			  CREATE INDEX IF NOT EXISTS idx_\(unsafeRaw: tableName)_search
+			  ON \(ident: tableName)
+			  USING GIN
+			  (fulltext_search)
+			"""
+		)
+		.run()
+	}
+
+	func dropSearchIndexAndColumn(tableName: String) async throws {
+		try await self
+			.drop(index: "idx_\(tableName)_search")
+			.run()
+
+		try await self
+			.alter(table: tableName)
+			.dropColumn("fulltext_search")
+			.run()
+	}
+}

--- a/Sources/swiftarr/Migrations/Schema Creation/QuartermasterSearchIndexCreation.swift
+++ b/Sources/swiftarr/Migrations/Schema Creation/QuartermasterSearchIndexCreation.swift
@@ -1,0 +1,54 @@
+import FluentSQL
+
+struct CreateQuartermasterSearchIndexes: AsyncMigration {
+	func prepare(on database: Database) async throws {
+		let sqlDatabase = (database as! SQLDatabase)
+		try await createQuartermasterItemSearch(on: sqlDatabase)
+	}
+
+	func revert(on database: Database) async throws {
+		let sqlDatabase = (database as! SQLDatabase)
+		try await dropSearchIndexAndColumn(on: sqlDatabase, tableName: "quartermaster_item")
+	}
+
+	func createQuartermasterItemSearch(on database: SQLDatabase) async throws {
+		try await database.raw(
+			"""
+			  ALTER TABLE quartermaster_item
+			  ADD COLUMN IF NOT EXISTS fulltext_search tsvector
+			    GENERATED ALWAYS AS (
+			      to_tsvector('english',
+			        coalesce(item_name, '') || ' ' ||
+			        coalesce(item_description, '') || ' ' ||
+			        coalesce(location, ''))
+			    ) STORED;
+			"""
+		)
+		.run()
+
+		try await createSearchIndex(on: database, tableName: "quartermaster_item")
+	}
+
+	func createSearchIndex(on database: SQLDatabase, tableName: String) async throws {
+		try await database.raw(
+			"""
+			  CREATE INDEX IF NOT EXISTS idx_\(unsafeRaw: tableName)_search
+			  ON \(ident: tableName)
+			  USING GIN
+			  (fulltext_search)
+			"""
+		)
+		.run()
+	}
+
+	func dropSearchIndexAndColumn(on database: SQLDatabase, tableName: String) async throws {
+		try await database
+			.drop(index: "idx_\(tableName)_search")
+			.run()
+
+		try await database
+			.alter(table: tableName)
+			.dropColumn("fulltext_search")
+			.run()
+	}
+}

--- a/Sources/swiftarr/Migrations/Schema Creation/QuartermasterSearchIndexCreation.swift
+++ b/Sources/swiftarr/Migrations/Schema Creation/QuartermasterSearchIndexCreation.swift
@@ -3,52 +3,19 @@ import FluentSQL
 struct CreateQuartermasterSearchIndexes: AsyncMigration {
 	func prepare(on database: Database) async throws {
 		let sqlDatabase = (database as! SQLDatabase)
-		try await createQuartermasterItemSearch(on: sqlDatabase)
+		try await sqlDatabase.addFullTextSearchColumn(
+			tableName: "quartermaster_item",
+			tsvectorExpression: """
+				to_tsvector('english',
+				  coalesce(item_name, '') || ' ' ||
+				  coalesce(item_description, '') || ' ' ||
+				  coalesce(location, ''))
+				"""
+		)
 	}
 
 	func revert(on database: Database) async throws {
 		let sqlDatabase = (database as! SQLDatabase)
-		try await dropSearchIndexAndColumn(on: sqlDatabase, tableName: "quartermaster_item")
-	}
-
-	func createQuartermasterItemSearch(on database: SQLDatabase) async throws {
-		try await database.raw(
-			"""
-			  ALTER TABLE quartermaster_item
-			  ADD COLUMN IF NOT EXISTS fulltext_search tsvector
-			    GENERATED ALWAYS AS (
-			      to_tsvector('english',
-			        coalesce(item_name, '') || ' ' ||
-			        coalesce(item_description, '') || ' ' ||
-			        coalesce(location, ''))
-			    ) STORED;
-			"""
-		)
-		.run()
-
-		try await createSearchIndex(on: database, tableName: "quartermaster_item")
-	}
-
-	func createSearchIndex(on database: SQLDatabase, tableName: String) async throws {
-		try await database.raw(
-			"""
-			  CREATE INDEX IF NOT EXISTS idx_\(unsafeRaw: tableName)_search
-			  ON \(ident: tableName)
-			  USING GIN
-			  (fulltext_search)
-			"""
-		)
-		.run()
-	}
-
-	func dropSearchIndexAndColumn(on database: SQLDatabase, tableName: String) async throws {
-		try await database
-			.drop(index: "idx_\(tableName)_search")
-			.run()
-
-		try await database
-			.alter(table: tableName)
-			.dropColumn("fulltext_search")
-			.run()
+		try await sqlDatabase.dropSearchIndexAndColumn(tableName: "quartermaster_item")
 	}
 }

--- a/Sources/swiftarr/Migrations/Schema Creation/SeamailSearchIndexCreation.swift
+++ b/Sources/swiftarr/Migrations/Schema Creation/SeamailSearchIndexCreation.swift
@@ -4,63 +4,17 @@ struct CreateSeamailSearchIndexes: AsyncMigration {
 	func prepare(on database: Database) async throws {
 		let sqlDatabase = (database as! SQLDatabase)
 
-		try await createFezPostsSearch(on: sqlDatabase)
-		try await createFriendlyFezSearch(on: sqlDatabase)
+		try await sqlDatabase.addFullTextSearchColumn(tableName: "fezposts", tsvectorExpression: "to_tsvector('english', text)")
+		try await sqlDatabase.addFullTextSearchColumn(
+			tableName: "friendlyfez",
+			tsvectorExpression: "to_tsvector('english', coalesce(title, '') || ' ' || coalesce(info, ''))"
+		)
 	}
 
 	func revert(on database: Database) async throws {
 		let sqlDatabase = (database as! SQLDatabase)
 
-		try await dropSearchIndexAndColumn(on: sqlDatabase, tableName: "fezposts")
-		try await dropSearchIndexAndColumn(on: sqlDatabase, tableName: "friendlyfez")
-	}
-
-	func createFezPostsSearch(on database: SQLDatabase) async throws {
-		try await database.raw(
-			"""
-			  ALTER TABLE fezposts
-			  ADD COLUMN IF NOT EXISTS fulltext_search tsvector
-			    GENERATED ALWAYS AS (to_tsvector('english', text)) STORED;
-			"""
-		)
-		.run()
-
-		try await createSearchIndex(on: database, tableName: "fezposts")
-	}
-
-	func createFriendlyFezSearch(on database: SQLDatabase) async throws {
-		try await database.raw(
-			"""
-			  ALTER TABLE friendlyfez
-			  ADD COLUMN IF NOT EXISTS fulltext_search tsvector
-			    GENERATED ALWAYS AS (to_tsvector('english', coalesce(title, '') || ' ' || coalesce(info, ''))) STORED;
-			"""
-		)
-		.run()
-
-		try await createSearchIndex(on: database, tableName: "friendlyfez")
-	}
-
-	func createSearchIndex(on database: SQLDatabase, tableName: String) async throws {
-		try await database.raw(
-			"""
-			  CREATE INDEX IF NOT EXISTS idx_\(unsafeRaw: tableName)_search
-			  ON \(ident: tableName)
-			  USING GIN
-			  (fulltext_search)
-			"""
-		)
-		.run()
-	}
-
-	func dropSearchIndexAndColumn(on database: SQLDatabase, tableName: String) async throws {
-		try await database
-			.drop(index: "idx_\(tableName)_search")
-			.run()
-
-		try await database
-			.alter(table: tableName)
-			.dropColumn("fulltext_search")
-			.run()
+		try await sqlDatabase.dropSearchIndexAndColumn(tableName: "fezposts")
+		try await sqlDatabase.dropSearchIndexAndColumn(tableName: "friendlyfez")
 	}
 }

--- a/Sources/swiftarr/Migrations/Schema Creation/SearchIndexCreation.swift
+++ b/Sources/swiftarr/Migrations/Schema Creation/SearchIndexCreation.swift
@@ -5,125 +5,30 @@ struct CreateSearchIndexes: AsyncMigration {
 		let sqlDatabase = (database as! SQLDatabase)
 		try await sqlDatabase.raw("CREATE EXTENSION IF NOT EXISTS pg_trgm").run()
 
-		try await createTwarrtSearch(on: sqlDatabase)
-		try await createForumSearch(on: sqlDatabase)
-		try await createForumPostSearch(on: sqlDatabase)
-		try await createEventSearch(on: sqlDatabase)
-		try await createBoardgameSearch(on: sqlDatabase)
-		try await createKaraokeSongSearch(on: sqlDatabase)
+		try await sqlDatabase.addFullTextSearchColumn(tableName: "twarrt", tsvectorExpression: "to_tsvector('english', text)")
+		try await sqlDatabase.addFullTextSearchColumn(tableName: "forum", tsvectorExpression: "to_tsvector('english', title)")
+		try await sqlDatabase.addFullTextSearchColumn(tableName: "forumpost", tsvectorExpression: "to_tsvector('english', text)")
+		try await sqlDatabase.addFullTextSearchColumn(
+			tableName: "event",
+			tsvectorExpression: "to_tsvector('english', coalesce(title, '') || ' ' || coalesce(info, ''))"
+		)
+		try await sqlDatabase.addFullTextSearchColumn(tableName: "boardgame", tsvectorExpression: "to_tsvector('english', \"gameName\")")
+		try await sqlDatabase.addFullTextSearchColumn(
+			tableName: "karaoke_song",
+			tsvectorExpression: "to_tsvector('english', coalesce(artist, '') || ' ' || coalesce(title, ''))"
+		)
 	}
 
 	func revert(on database: Database) async throws {
 		let sqlDatabase = (database as! SQLDatabase)
 
-		try await dropSearchIndexAndColumn(on: sqlDatabase, tableName: "twarrt")
-		try await dropSearchIndexAndColumn(on: sqlDatabase, tableName: "forum")
-		try await dropSearchIndexAndColumn(on: sqlDatabase, tableName: "forumpost")
-		try await dropSearchIndexAndColumn(on: sqlDatabase, tableName: "event")
-		try await dropSearchIndexAndColumn(on: sqlDatabase, tableName: "boardgame")
-		try await dropSearchIndexAndColumn(on: sqlDatabase, tableName: "karaoke_song")
+		try await sqlDatabase.dropSearchIndexAndColumn(tableName: "twarrt")
+		try await sqlDatabase.dropSearchIndexAndColumn(tableName: "forum")
+		try await sqlDatabase.dropSearchIndexAndColumn(tableName: "forumpost")
+		try await sqlDatabase.dropSearchIndexAndColumn(tableName: "event")
+		try await sqlDatabase.dropSearchIndexAndColumn(tableName: "boardgame")
+		try await sqlDatabase.dropSearchIndexAndColumn(tableName: "karaoke_song")
 
 		try await sqlDatabase.raw("DROP EXTENSION IF EXISTS pg_trgm").run()
-	}
-
-	func createTwarrtSearch(on database: SQLDatabase) async throws {
-		try await database.raw(
-			"""
-			  ALTER TABLE twarrt
-			  ADD COLUMN IF NOT EXISTS fulltext_search tsvector
-			    GENERATED ALWAYS AS (to_tsvector('english', text)) STORED;
-			"""
-		)
-		.run()
-
-		try await createSearchIndex(on: database, tableName: "twarrt")
-	}
-
-	func createForumSearch(on database: SQLDatabase) async throws {
-		try await database.raw(
-			"""
-			  ALTER TABLE forum
-			  ADD COLUMN IF NOT EXISTS fulltext_search tsvector
-			    GENERATED ALWAYS AS (to_tsvector('english', title)) STORED;
-			"""
-		)
-		.run()
-
-		try await createSearchIndex(on: database, tableName: "forum")
-	}
-
-	func createForumPostSearch(on database: SQLDatabase) async throws {
-		try await database.raw(
-			"""
-			  ALTER TABLE forumpost
-			  ADD COLUMN IF NOT EXISTS fulltext_search tsvector
-			    GENERATED ALWAYS AS (to_tsvector('english', text)) STORED;
-			"""
-		)
-		.run()
-
-		try await createSearchIndex(on: database, tableName: "forumpost")
-	}
-
-	func createEventSearch(on database: SQLDatabase) async throws {
-		try await database.raw(
-			"""
-			  ALTER TABLE event
-			  ADD COLUMN IF NOT EXISTS fulltext_search tsvector
-			    GENERATED ALWAYS AS (to_tsvector('english', coalesce(title, '') || ' ' || coalesce(info, ''))) STORED;
-			"""
-		)
-		.run()
-
-		try await createSearchIndex(on: database, tableName: "event")
-	}
-
-	func createBoardgameSearch(on database: SQLDatabase) async throws {
-		try await database.raw(
-			"""
-			  ALTER TABLE boardgame
-			  ADD COLUMN IF NOT EXISTS fulltext_search tsvector
-			    GENERATED ALWAYS AS (to_tsvector('english', "gameName")) STORED;
-			"""
-		)
-		.run()
-
-		try await createSearchIndex(on: database, tableName: "boardgame")
-	}
-
-	func createKaraokeSongSearch(on database: SQLDatabase) async throws {
-		try await database.raw(
-			"""
-			  ALTER TABLE karaoke_song
-			  ADD COLUMN IF NOT EXISTS fulltext_search tsvector
-			    GENERATED ALWAYS AS (to_tsvector('english', coalesce(artist, '') || ' ' || coalesce(title, ''))) STORED;
-			"""
-		)
-		.run()
-
-		try await createSearchIndex(on: database, tableName: "karaoke_song")
-	}
-
-	func createSearchIndex(on database: SQLDatabase, tableName: String) async throws {
-		try await database.raw(
-			"""
-			  CREATE INDEX IF NOT EXISTS idx_\(unsafeRaw: tableName)_search
-			  ON \(ident: tableName)
-			  USING GIN
-			  (fulltext_search)
-			"""
-		)
-		.run()
-	}
-
-	func dropSearchIndexAndColumn(on database: SQLDatabase, tableName: String) async throws {
-		try await database
-			.drop(index: "idx_\(tableName)_search")
-			.run()
-
-		try await database
-			.alter(table: tableName)
-			.dropColumn("fulltext_search")
-			.run()
 	}
 }

--- a/Sources/swiftarr/Models/QuartermasterItem.swift
+++ b/Sources/swiftarr/Models/QuartermasterItem.swift
@@ -1,0 +1,146 @@
+import Fluent
+import Foundation
+import Vapor
+
+/// 	A QuartermasterItem is a single entry on the Quartermaster "have / need" board.
+///
+/// 	Any logged-in user can post an item they have to offer or an item they are looking for. Each entry
+/// 	may optionally specify a free-text location and/or a contact user (another registered Twitarr user).
+/// 	At least one of {location, contact user} must be present (validated in the controller).
+///
+/// 	Items are searchable, filterable by category (have/need) and by owner, and are individually
+/// 	reportable to the mod queue. Moderators may quarantine or delete entries exactly as they do
+/// 	for forum posts. Edits to text fields are snapshotted in `QuartermasterItemEdit` for accountability.
+///
+/// 	- See Also: [QuartermasterData](QuartermasterData) the DTO for returning item data.
+/// 	- See Also: [QuartermasterContentData](QuartermasterContentData) the DTO for creating or editing items.
+/// 	- See Also: [CreateQuartermasterItemSchema](CreateQuartermasterItemSchema) the Migration creating the table.
+final class QuartermasterItem: Model, Searchable, @unchecked Sendable {
+	static let schema = "quartermaster_item"
+
+	// MARK: Properties
+
+	/// Unique ID for this item.
+	@ID(key: .id) var id: UUID?
+
+	/// Whether the owner has this item to offer, or needs it.
+	@Field(key: "category") var category: QuartermasterCategory
+
+	/// A short name or title for the item. Required; 2–100 characters (validated in controller).
+	@Field(key: "item_name") var itemName: String
+
+	/// An optional longer description of the item. ≤2048 characters when present.
+	@OptionalField(key: "item_description") var itemDescription: String?
+
+	/// An optional free-text location where the item can be picked up / exchanged.
+	/// When present: 3–100 characters (validated in the controller DTO).
+	@OptionalField(key: "location") var location: String?
+
+	/// Moderators can set several statuses on items that modify editability and visibility.
+	@Enum(key: "mod_status") var moderationStatus: ContentModerationStatus
+
+	// MARK: Relationships
+
+	/// The user who created this item listing.
+	@Parent(key: "owner") var owner: User
+
+	/// An optional contact user — the person to approach about this item. Defaults to the owner
+	/// in clients, but may be overridden to any real Twitarr user. When this user is deleted,
+	/// the field is nulled out rather than cascading deletion to the item.
+	@OptionalParent(key: "contact_user") var contactUser: User?
+
+	/// The child `QuartermasterItemEdit` accountability records for this item.
+	@Children(for: \.$item) var edits: [QuartermasterItemEdit]
+
+	// MARK: Record-keeping
+
+	/// Timestamp of the model's creation, set automatically.
+	@Timestamp(key: "created_at", on: .create) var createdAt: Date?
+
+	/// Timestamp of the model's last update, set automatically.
+	@Timestamp(key: "updated_at", on: .update) var updatedAt: Date?
+
+	/// Timestamp of the model's soft-deletion, set automatically.
+	/// Soft-delete allows moderators to view deleted entries.
+	@Timestamp(key: "deleted_at", on: .delete) var deletedAt: Date?
+
+	// MARK: Initialization
+
+	// Used by Fluent.
+	init() {}
+
+	/// Initializes a new QuartermasterItem.
+	///
+	/// - Parameters:
+	///   - ownerID: The UUID of the user creating the listing.
+	///   - category: Whether the owner has or needs the item.
+	///   - itemName: A short name for the item (2–100 chars).
+	///   - itemDescription: An optional longer description (≤2048 chars).
+	///   - location: An optional free-text pickup/exchange location.
+	///   - contactUserID: An optional UUID of the contact user; nil means no contact user is set.
+	init(
+		ownerID: UUID,
+		category: QuartermasterCategory,
+		itemName: String,
+		itemDescription: String? = nil,
+		location: String? = nil,
+		contactUserID: UUID? = nil
+	) {
+		self.$owner.id = ownerID
+		self.category = category
+		self.itemName = itemName
+		self.itemDescription = itemDescription
+		self.location = location
+		self.$contactUser.id = contactUserID
+		self.moderationStatus = .normal
+	}
+}
+
+// MARK: - Reportable
+
+/// Items can be reported to the moderator queue by any user.
+/// No auto-quarantine threshold — mods must manually quarantine (same policy as FriendlyFez).
+extension QuartermasterItem: Reportable {
+	/// The report type for `QuartermasterItem` reports.
+	var reportType: ReportType { .quartermasterItem }
+
+	/// Standardizes how to get the author ID of a Reportable object.
+	var authorUUID: UUID { $owner.id }
+
+	/// No auto-quarantine for Quartermaster items.
+	var autoQuarantineThreshold: Int { Int.max }
+}
+
+// MARK: - ContentFilterable
+
+/// Items participate in mute-word and alert-word processing.
+extension QuartermasterItem: ContentFilterable {
+	func contentTextStrings() -> [String] {
+		[itemName, itemDescription ?? "", location ?? ""]
+	}
+}
+
+// MARK: - Migration
+
+struct CreateQuartermasterItemSchema: AsyncMigration {
+	func prepare(on database: Database) async throws {
+		let modStatusEnum = try await database.enum("moderation_status").read()
+		try await database.schema("quartermaster_item")
+			.id()
+			.field("category", .string, .required)
+			.field("item_name", .string, .required)
+			.field("item_description", .string)
+			.field("location", .string)
+			.field("mod_status", modStatusEnum, .required)
+			.field("owner", .uuid, .required, .references("user", "id", onDelete: .cascade))
+			.field("contact_user", .uuid, .references("user", "id", onDelete: .setNull))
+			.field("created_at", .datetime)
+			.field("updated_at", .datetime)
+			.field("deleted_at", .datetime)
+			.create()
+	}
+
+	func revert(on database: Database) async throws {
+		try await database.schema("quartermaster_item").delete()
+	}
+}

--- a/Sources/swiftarr/Models/QuartermasterItemEdit.swift
+++ b/Sources/swiftarr/Models/QuartermasterItemEdit.swift
@@ -28,6 +28,9 @@ final class QuartermasterItemEdit: Model, @unchecked Sendable {
 	/// The previous location string (empty string when nil at edit time).
 	@Field(key: "location") var location: String
 
+	/// The previous contact user UUID (nil when no contact user was set at edit time).
+	@OptionalField(key: "contact_user") var contactUser: UUID?
+
 	/// Timestamp of the model's creation, set automatically.
 	@Timestamp(key: "created_at", on: .create) var createdAt: Date?
 
@@ -57,6 +60,7 @@ final class QuartermasterItemEdit: Model, @unchecked Sendable {
 		self.itemName = item.itemName
 		self.itemDescription = item.itemDescription ?? ""
 		self.location = item.location ?? ""
+		self.contactUser = item.$contactUser.id
 	}
 }
 
@@ -67,6 +71,7 @@ struct CreateQuartermasterItemEditSchema: AsyncMigration {
 			.field("item_name", .string, .required)
 			.field("item_description", .string, .required)
 			.field("location", .string, .required)
+			.field("contact_user", .uuid, .references("user", "id", onDelete: .setNull))
 			.field("created_at", .datetime)
 			.field("item", .uuid, .required, .references("quartermaster_item", "id"))
 			.field("editor", .uuid, .required, .references("user", "id"))

--- a/Sources/swiftarr/Models/QuartermasterItemEdit.swift
+++ b/Sources/swiftarr/Models/QuartermasterItemEdit.swift
@@ -1,0 +1,79 @@
+import Fluent
+import Vapor
+
+/// 	When the TEXT FIELDS of a `QuartermasterItem` are edited, a `QuartermasterItemEdit` is created
+/// 	to save the previous values of those text fields.
+///
+/// 	Edits that only change the category — without touching item_name, item_description, or location —
+/// 	do not create a QuartermasterItemEdit. This is done for accountability purposes; the data collected
+/// 	is intended to be viewable only by moderators.
+///
+/// 	- See Also: [QuartermasterModerationData](QuartermasterModerationData) the DTO returning data
+/// 	  moderators need to review items. Specifically, [QuartermasterEditLogData](QuartermasterEditLogData)
+/// 	  delivers values from the `QuartermasterItemEdit`.
+/// 	- See Also: [CreateQuartermasterItemEditSchema](CreateQuartermasterItemEditSchema) the Migration
+/// 	  for creating the QuartermasterItemEdit table.
+final class QuartermasterItemEdit: Model, @unchecked Sendable {
+	static let schema = "quartermaster_item_edit"
+
+	/// The edit's ID.
+	@ID(key: .id) var id: UUID?
+
+	/// The previous item name.
+	@Field(key: "item_name") var itemName: String
+
+	/// The previous item description (empty string when nil at edit time).
+	@Field(key: "item_description") var itemDescription: String
+
+	/// The previous location string (empty string when nil at edit time).
+	@Field(key: "location") var location: String
+
+	/// Timestamp of the model's creation, set automatically.
+	@Timestamp(key: "created_at", on: .create) var createdAt: Date?
+
+	// MARK: Relations
+
+	/// The parent `QuartermasterItem` that was edited.
+	@Parent(key: "item") var item: QuartermasterItem
+
+	/// The `User` that performed the edit.
+	@Parent(key: "editor") var editor: User
+
+	// MARK: Initialization
+
+	// Used by Fluent.
+	init() {}
+
+	/// Initializes a new QuartermasterItemEdit with the CURRENT text fields of the item.
+	/// Call this **before** applying the edit so that the prior state is captured.
+	///
+	/// - Parameters:
+	///   - item: The QuartermasterItem about to be edited.
+	///   - editorID: The UUID of the User making the change.
+	init(item: QuartermasterItem, editorID: UUID) throws {
+		self.$item.id = try item.requireID()
+		self.$item.value = item
+		self.$editor.id = editorID
+		self.itemName = item.itemName
+		self.itemDescription = item.itemDescription ?? ""
+		self.location = item.location ?? ""
+	}
+}
+
+struct CreateQuartermasterItemEditSchema: AsyncMigration {
+	func prepare(on database: Database) async throws {
+		try await database.schema("quartermaster_item_edit")
+			.id()
+			.field("item_name", .string, .required)
+			.field("item_description", .string, .required)
+			.field("location", .string, .required)
+			.field("created_at", .datetime)
+			.field("item", .uuid, .required, .references("quartermaster_item", "id"))
+			.field("editor", .uuid, .required, .references("user", "id"))
+			.create()
+	}
+
+	func revert(on database: Database) async throws {
+		try await database.schema("quartermaster_item_edit").delete()
+	}
+}

--- a/Sources/swiftarr/Site/SiteModController.swift
+++ b/Sources/swiftarr/Site/SiteModController.swift
@@ -963,6 +963,7 @@ func generateContentGroups(from reports: [ReportModerationData]) -> [ReportConte
 		case .mkSongSnippet: contentURL = "/moderate/microkaraoke/song/\(report.reportedID)"  // Individual snippets aren't actually reportable yet.
 		case .streamPhoto: contentURL = "/moderate/photostream/\(report.reportedID)"
 		case .personalEvent: contentURL = "/moderate/personalevent/\(report.reportedID)"
+		case .quartermasterItem: contentURL = "/moderate/quartermaster/\(report.reportedID)"
 		}
 		var newGroup = ReportContentGroup(
 			reportType: report.type,

--- a/Sources/swiftarr/configure.swift
+++ b/Sources/swiftarr/configure.swift
@@ -605,6 +605,8 @@ struct SwiftarrConfigurator {
 		app.migrations.add(CreateFezParticipantSchema(), to: .psql)
 		app.migrations.add(CreateFezPostSchema(), to: .psql)
 		app.migrations.add(CreateFriendlyFezEditSchema(), to: .psql)
+		app.migrations.add(CreateQuartermasterItemSchema(), to: .psql)
+		app.migrations.add(CreateQuartermasterItemEditSchema(), to: .psql)
 		app.migrations.add(CreateDailyThemeSchema(), to: .psql)
 		app.migrations.add(CreateBoardgameSchema(), to: .psql)
 		app.migrations.add(CreateBoardgameFavoriteSchema(), to: .psql)
@@ -678,7 +680,8 @@ struct SwiftarrConfigurator {
 		app.migrations.add(AddFoodDrinkCategory(), to: .psql)
 		app.migrations.add(CreateMicroKaraokeUser(), to: .psql)
 		app.migrations.add(RemoveCovidCategory(), to: .psql)
-		
+		app.migrations.add(CreateQuartermasterSearchIndexes(), to: .psql)
+
 		// DON'T add schema-modification migrations down here. Appending migrations that modify a table's schema at the end will
 		// break migrations that use Fluent to populate that table with data, as Fluent only models the current db schema.
 		// When resetting the db (or a new install), all the migrations run in the listed order, and the schema needs to match Fluent before

--- a/Tests/AppTests/QuartermasterSchemaTests.swift
+++ b/Tests/AppTests/QuartermasterSchemaTests.swift
@@ -12,18 +12,23 @@ class QuartermasterSchemaTests: XCTestCase, SwiftarrBaseTest {
 
 	/// Verifies that the new migrations apply cleanly: if the app boots and autoMigrate()
 	/// succeeds inside withApp, the quartermaster_item table exists.
+	///
+	/// The test DB is shared across the whole test run (not reset per-test), so this can't assert
+	/// the table is empty -- it only asserts the table is queryable, which is proof enough that the
+	/// migration created it (a query against a missing table throws before returning).
 	func testSchema_TablesExistAfterMigration() async throws {
 		try await withApp { app in
 			let count = try await QuartermasterItem.query(on: app.db).count()
-			XCTAssertEqual(count, 0, "Expected empty quartermaster_item table after migration")
+			XCTAssertGreaterThanOrEqual(count, 0, "Expected quartermaster_item table to exist and be queryable after migration")
 		}
 	}
 
-	/// Verifies the edit table also exists.
+	/// Verifies the edit table also exists. See `testSchema_TablesExistAfterMigration` for why this
+	/// doesn't assert emptiness.
 	func testSchema_EditTableExistsAfterMigration() async throws {
 		try await withApp { app in
 			let count = try await QuartermasterItemEdit.query(on: app.db).count()
-			XCTAssertEqual(count, 0, "Expected empty quartermaster_item_edit table after migration")
+			XCTAssertGreaterThanOrEqual(count, 0, "Expected quartermaster_item_edit table to exist and be queryable after migration")
 		}
 	}
 

--- a/Tests/AppTests/QuartermasterSchemaTests.swift
+++ b/Tests/AppTests/QuartermasterSchemaTests.swift
@@ -1,0 +1,84 @@
+import XCTVapor
+@testable import swiftarr
+
+// Tests for the Quartermaster Phase 1 schema foundation.
+//
+// The DB-touching tests (table existence) rely on SwiftarrBaseTest which runs autoMigrate()
+// against the test Postgres instance (port 5433). The pure-Swift tests (enum round-trips,
+// feature flag) don't need a live DB and are plain XCTestCase functions.
+class QuartermasterSchemaTests: XCTestCase, SwiftarrBaseTest {
+
+	// MARK: - Schema / boot
+
+	/// Verifies that the new migrations apply cleanly: if the app boots and autoMigrate()
+	/// succeeds inside withApp, the quartermaster_item table exists.
+	func testSchema_TablesExistAfterMigration() async throws {
+		try await withApp { app in
+			let count = try await QuartermasterItem.query(on: app.db).count()
+			XCTAssertEqual(count, 0, "Expected empty quartermaster_item table after migration")
+		}
+	}
+
+	/// Verifies the edit table also exists.
+	func testSchema_EditTableExistsAfterMigration() async throws {
+		try await withApp { app in
+			let count = try await QuartermasterItemEdit.query(on: app.db).count()
+			XCTAssertEqual(count, 0, "Expected empty quartermaster_item_edit table after migration")
+		}
+	}
+
+	// MARK: - Feature flag
+
+	func testFeatureFlag_RawValueDecodes() {
+		XCTAssertEqual(SwiftarrFeature(rawValue: "quartermaster"), .quartermaster)
+	}
+
+	func testFeatureFlag_PresentInAllCases() {
+		XCTAssertTrue(SwiftarrFeature.allCases.contains(.quartermaster),
+			"quartermaster must appear in CaseIterable so admin UI can enable/disable it")
+	}
+
+	// MARK: - ReportType round-trip
+
+	func testReportType_QuartermasterItemRoundTrips() throws {
+		let encoder = JSONEncoder()
+		let decoder = JSONDecoder()
+		let data = try encoder.encode(ReportType.quartermasterItem)
+		let decoded = try decoder.decode(ReportType.self, from: data)
+		XCTAssertEqual(decoded, .quartermasterItem)
+	}
+
+	func testReportType_QuartermasterItemRawValue() {
+		XCTAssertEqual(ReportType.quartermasterItem.rawValue, "quartermasterItem")
+	}
+
+	// MARK: - QuartermasterCategory
+
+	func testCategory_HaveFromAPIString() throws {
+		XCTAssertEqual(try QuartermasterCategory.fromAPIString("have"), .have)
+	}
+
+	func testCategory_NeedFromAPIString() throws {
+		XCTAssertEqual(try QuartermasterCategory.fromAPIString("need"), .need)
+	}
+
+	func testCategory_CaseInsensitive() throws {
+		XCTAssertEqual(try QuartermasterCategory.fromAPIString("HAVE"), .have)
+		XCTAssertEqual(try QuartermasterCategory.fromAPIString("Need"), .need)
+	}
+
+	func testCategory_UnknownThrows() {
+		XCTAssertThrowsError(try QuartermasterCategory.fromAPIString("want")) { error in
+			guard let abortError = error as? Abort else {
+				XCTFail("Expected Abort error, got \(type(of: error))")
+				return
+			}
+			XCTAssertEqual(abortError.status, .badRequest)
+		}
+	}
+
+	func testCategory_Labels() {
+		XCTAssertEqual(QuartermasterCategory.have.label, "Have")
+		XCTAssertEqual(QuartermasterCategory.need.label, "Need")
+	}
+}


### PR DESCRIPTION
Lays down the database schema for Quartermaster, the have/need item board (issue #512): the `quartermaster_items` table, its category enum, and a `QuartermasterItemEdit` model that captures edit history including the contact user, mirroring how other content types track edits.

Includes a couple of follow-up fixes found while testing the migrations: `QuartermasterSchemaTests` no longer assumes it's running against an empty shared test DB, and the full-text search index migration helpers were deduplicated.

No API or UI surface yet — this PR is schema and migrations only. First of a 4-part stack (schema → API → moderation → UI); please merge in order.