### PR TITLE
Quartermaster Phase 3: moderation integration

### DIFF
--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -48,4 +48,4 @@ jobs:
         # SettingsTests and ClientControllerTests need a migrated+seeded database
         # which a pristine CI postgres can't satisfy without infrastructure work
         # outside the scope of this PR.
-        run: swift test --enable-test-discovery --filter "GeometryTests|ValidatingJSONDecoderTests|CruiseDateTests|ThemeCookieTests|CryptoHelperTests|DisabledFeaturesGroupTests|EventParserTests|TimeZoneChangeSetTests|UserStructValidationTests|ContentStructValidationTests|FezAndEventValidationTests|AdminStructValidationTests|DateExtensionTests|SettingsCalendarTests|ContentFilterableTests|PaginationTests"
+        run: swift test --enable-test-discovery --filter "GeometryTests|ValidatingJSONDecoderTests|CruiseDateTests|ThemeCookieTests|CryptoHelperTests|DisabledFeaturesGroupTests|EventParserTests|TimeZoneChangeSetTests|UserStructValidationTests|ContentStructValidationTests|FezAndEventValidationTests|AdminStructValidationTests|DateExtensionTests|SettingsCalendarTests|ContentFilterableTests|PaginationTests|QuartermasterValidationTests"

--- a/Sources/swiftarr/Controllers/EventController.swift
+++ b/Sources/swiftarr/Controllers/EventController.swift
@@ -90,19 +90,14 @@ struct EventController: APIRouteCollection {
 			query.with(\.$performers)
 		}
 		if var search = options.search {
-			// postgres "_" and "%" are wildcards, so escape for literals
-			search = search.replacingOccurrences(of: "_", with: "\\_")
-			search = search.replacingOccurrences(of: "%", with: "\\%")
-			search = search.trimmingCharacters(in: .whitespacesAndNewlines)
+			search = search.escapedForSQLWildcards()
 			query.group(.or) { (or) in
 				or.fullTextFilter(\.$title, search)
 				or.fullTextFilter(\.$info, search)
 			}
 		}
 		if var location = options.location {
-			// postgres "_" and "%" are wildcards, so escape for literals
-			location = location.replacingOccurrences(of: "_", with: "\\_").replacingOccurrences(of: "%", with: "\\%")
-					.trimmingCharacters(in: .whitespacesAndNewlines)
+			location = location.escapedForSQLWildcards()
 			query.filter(\.$location ~~ location)
 		}
 		if let eventType = options.type {

--- a/Sources/swiftarr/Controllers/FezController.swift
+++ b/Sources/swiftarr/Controllers/FezController.swift
@@ -140,9 +140,7 @@ struct FezController: APIRouteCollection {
 			fezQuery.filter(\.$startTime >= dayStart).filter(\.$startTime < dayEnd)
 		}
 		if var searchStr = urlQuery.search {
-			searchStr = searchStr.replacingOccurrences(of: "_", with: "\\_")
-				.replacingOccurrences(of: "%", with: "\\%")
-				.trimmingCharacters(in: .whitespacesAndNewlines)
+			searchStr = searchStr.escapedForSQLWildcards()
 			fezQuery.group(.or) { group in
 				group.fullTextFilter(FriendlyFez.self, \.$title, searchStr)
 					.fullTextFilter(FriendlyFez.self, \.$info, searchStr)
@@ -246,9 +244,7 @@ struct FezController: APIRouteCollection {
 		}
 
 		if var searchStr = urlQuery.search {
-			searchStr = searchStr.replacingOccurrences(of: "_", with: "\\_")
-				.replacingOccurrences(of: "%", with: "\\%")
-				.trimmingCharacters(in: .whitespacesAndNewlines)
+			searchStr = searchStr.escapedForSQLWildcards()
 			query.group(.or) { group in
 				group.fullTextFilter(FriendlyFez.self, \.$title, searchStr)
 					.fullTextFilter(FriendlyFez.self, \.$info, searchStr)
@@ -1087,9 +1083,7 @@ extension FezController {
 			}
 		}
 		if var searchStr = urlQuery.search {
-			searchStr = searchStr.replacingOccurrences(of: "_", with: "\\_")
-				.replacingOccurrences(of: "%", with: "\\%")
-				.trimmingCharacters(in: .whitespacesAndNewlines)
+			searchStr = searchStr.escapedForSQLWildcards()
 			query.join(FezPost.self, on: \FezPost.$fez.$id == \FriendlyFez.$id, method: .left)
 			query.group(.or) { group in
 				group.fullTextFilter(FezPost.self, \.$text, searchStr)

--- a/Sources/swiftarr/Controllers/ForumController.swift
+++ b/Sources/swiftarr/Controllers/ForumController.swift
@@ -294,14 +294,11 @@ struct ForumController: APIRouteCollection {
 			}
 			
 			mutating func afterDecode() throws {
-				// postgres "_" and "%" are wildcards, so escape for literals
-				search = search?.replacingOccurrences(of: "_", with: "\\_").replacingOccurrences(of: "%", with: "\\%")
-						.trimmingCharacters(in: .whitespacesAndNewlines)
+				search = search?.escapedForSQLWildcards()
 				if let search = search, search.isEmpty {
 					throw Abort(.badRequest, reason: "Search string, while optional, must not be empty if it exists.")
 				}
-				searchposts = searchposts?.replacingOccurrences(of: "_", with: "\\_").replacingOccurrences(of: "%", with: "\\%")
-						.trimmingCharacters(in: .whitespacesAndNewlines)
+				searchposts = searchposts?.escapedForSQLWildcards()
 				if let searchposts = searchposts, searchposts.isEmpty {
 					throw Abort(.badRequest, reason: "Search string, while optional, must not be empty if it exists.")
 				}
@@ -814,19 +811,14 @@ struct ForumController: APIRouteCollection {
 		}
 
 		if var searchStr = req.query[String.self, at: "search"] {
-			searchStr = searchStr.replacingOccurrences(of: "_", with: "\\_")
-				.replacingOccurrences(of: "%", with: "\\%")
-				.trimmingCharacters(in: .whitespacesAndNewlines)
+			searchStr = searchStr.escapedForSQLWildcards()
 			query.fullTextFilter(\.$text, searchStr)
 			if !searchStr.contains(" ") && pagination.start == 0 {
 				try await markNotificationViewed(user: cacheUser, type: .alertwordPost(searchStr, 0), on: req)
 			}
 		}
 		if var hashtag = req.query[String.self, at: "hashtag"] {
-			// postgres "_" and "%" are wildcards, so escape for literals
-			hashtag = hashtag.replacingOccurrences(of: "_", with: "\\_")
-				.replacingOccurrences(of: "%", with: "\\%")
-				.trimmingCharacters(in: .whitespacesAndNewlines)
+			hashtag = hashtag.escapedForSQLWildcards()
 			if !hashtag.hasPrefix("#") {
 				hashtag = "#\(hashtag)"
 			}

--- a/Sources/swiftarr/Controllers/ModerationController.swift
+++ b/Sources/swiftarr/Controllers/ModerationController.swift
@@ -62,6 +62,15 @@ struct ModerationController: APIRouteCollection {
 			use: fezPostSetModerationStateHandler
 		)
 
+		moderatorAuthGroup.get("quartermaster", quartermasterIDParam, use: quartermasterModerationHandler)
+		moderatorAuthGroup.post(
+			"quartermaster",
+			quartermasterIDParam,
+			"setstate",
+			modStateParam,
+			use: quartermasterSetModerationStateHandler
+		)
+
 		moderatorAuthGroup.get("profile", userIDParam, use: profileModerationHandler)
 		moderatorAuthGroup.post(
 			"profile",
@@ -554,6 +563,72 @@ struct ModerationController: APIRouteCollection {
 			on: req
 		)
 		try await lfgPost.save(on: req.db)
+		return .ok
+	}
+
+	/// `GET /api/v3/mod/quartermaster/ID`
+	///
+	/// Moderator only. Returns info admins and moderators need to review a Quartermaster item. Works if the item has been
+	/// deleted. Shows the item's quarantine and reviewed states.
+	///
+	/// The `QuartermasterModerationData` contains:
+	/// * The current item contents, even if deleted or quarantined (never masked, unlike the public API)
+	/// * Previous edits of the item
+	/// * Reports against the item
+	/// * The item's current deletion and moderation status.
+	///
+	/// - Parameter quartermasterID: in URL path.
+	/// - Throws: A 5xx response should be reported as a likely bug, please and thank you.
+	/// - Returns: `QuartermasterModerationData` containing a bunch of data pertinient to moderating the item.
+	func quartermasterModerationHandler(_ req: Request) async throws -> QuartermasterModerationData {
+		guard let itemIDString = req.parameters.get(quartermasterIDParam.paramString), let itemID = UUID(itemIDString) else {
+			throw Abort(.badRequest, reason: "Request parameter \(quartermasterIDParam.paramString) is missing.")
+		}
+		guard let item = try await QuartermasterItem.query(on: req.db).filter(\.$id == itemID).withDeleted().first() else {
+			throw Abort(.notFound, reason: "no value found for identifier '\(itemID)'")
+		}
+		let reports = try await Report.query(on: req.db)
+			.filter(\.$reportType == .quartermasterItem)
+			.filter(\.$reportedID == itemIDString)
+			.sort(\.$createdAt, .descending).all()
+		let edits = try await item.$edits.query(on: req.db).sort(\.$createdAt, .ascending).all()
+		let editData: [QuartermasterEditLogData] = try edits.map { try QuartermasterEditLogData($0, on: req) }
+		let reportData = try reports.map { try ReportModerationData.init(req: req, report: $0) }
+		let ownerHeader = try req.userCache.getHeader(item.$owner.id)
+		let contactHeader = item.$contactUser.id.flatMap { req.userCache.getHeaders([$0]).first }
+		let itemData = try QuartermasterData(item: item, owner: ownerHeader, contactUser: contactHeader, overrideQuarantine: true)
+		let modData = QuartermasterModerationData(
+			item: itemData,
+			isDeleted: item.deletedAt != nil,
+			moderationStatus: item.moderationStatus,
+			edits: editData,
+			reports: reportData
+		)
+		return modData
+	}
+
+	/// `POST /api/v3/mod/quartermaster/ID/setstate/STRING`
+	///
+	/// Moderator only. Sets the moderation state enum on the Quartermaster item identified by ID to the `ContentModerationStatus`
+	/// in STRING. Logs the action to the moderator log unless the user owns the item.
+	///
+	/// - Parameter quartermasterID: in URL path.
+	/// - Parameter moderationState: in URL path. Value must match a `ContentModerationStatus` rawValue.
+	/// - Throws: A 5xx response should be reported as a likely bug, please and thank you.
+	/// - Returns: `HTTPStatus` .ok if the requested moderation status was set.
+	func quartermasterSetModerationStateHandler(_ req: Request) async throws -> HTTPStatus {
+		let user = try req.auth.require(UserCacheData.self)
+		guard let modState = req.parameters.get(modStateParam.paramString) else {
+			throw Abort(.badRequest, reason: "Request parameter `Moderation_State` is missing.")
+		}
+		let item = try await QuartermasterItem.findFromParameter(quartermasterIDParam, on: req)
+		try item.moderationStatus.setFromParameterString(modState)
+		await item.logIfModeratorAction(
+			ModeratorActionType.setFromModerationStatus(item.moderationStatus),
+			user: user,
+			on: req
+		)
+		try await item.save(on: req.db)
 		return .ok
 	}
 

--- a/Sources/swiftarr/Controllers/QuartermasterController.swift
+++ b/Sources/swiftarr/Controllers/QuartermasterController.swift
@@ -103,9 +103,20 @@ struct QuartermasterController: APIRouteCollection {
 		let total = try await query.copy().count()
 		let items = try await query.sort(\.$updatedAt, .descending).range(pagination.range).all()
 
+		// Batch-fetch owner + contact user headers in one call instead of one getHeader() call per item.
+		var headerIDs = Set(items.map { $0.$owner.id })
+		headerIDs.formUnion(items.compactMap { $0.$contactUser.id })
+		let headers = Dictionary(uniqueKeysWithValues: req.userCache.getHeaders(headerIDs).map { ($0.userID, $0) })
+		func requireHeader(_ userID: UUID) throws -> UserHeader {
+			guard let header = headers[userID] else {
+				throw Abort(.internalServerError, reason: "No user found with userID \(userID).")
+			}
+			return header
+		}
+
 		let itemDataArray: [QuartermasterData] = try items.map { item in
-			let ownerHeader = try req.userCache.getHeader(item.$owner.id)
-			let contactHeader = try item.$contactUser.id.map { try req.userCache.getHeader($0) }
+			let ownerHeader = try requireHeader(item.$owner.id)
+			let contactHeader = try item.$contactUser.id.map(requireHeader)
 			return try QuartermasterData(item: item, owner: ownerHeader, contactUser: contactHeader)
 		}
 		return QuartermasterListData(

--- a/Sources/swiftarr/Controllers/QuartermasterController.swift
+++ b/Sources/swiftarr/Controllers/QuartermasterController.swift
@@ -90,11 +90,13 @@ struct QuartermasterController: APIRouteCollection {
 			query.filter(\.$category == cat)
 		}
 		if var searchStr = urlQuery.search {
-			searchStr = searchStr.replacingOccurrences(of: "_", with: "\\_")
-				.replacingOccurrences(of: "%", with: "\\%")
-				.trimmingCharacters(in: .whitespacesAndNewlines)
+			searchStr = searchStr.escapedForSQLWildcards()
 			if !searchStr.isEmpty {
-				query.fullTextFilter(\.$itemName, searchStr)
+				query.group(.or) { or in
+					or.fullTextFilter(\.$itemName, searchStr)
+					or.fullTextFilter(\.$itemDescription, searchStr)
+					or.fullTextFilter(\.$location, searchStr)
+				}
 			}
 		}
 

--- a/Sources/swiftarr/Controllers/QuartermasterController.swift
+++ b/Sources/swiftarr/Controllers/QuartermasterController.swift
@@ -1,0 +1,290 @@
+import Fluent
+import Vapor
+
+/// Provides API endpoints for the Quartermaster "have / need" item board.
+///
+/// Quartermaster is a standalone searchable database of items that cruise guests are offering
+/// or looking for, modeled on the Fez/LFG subsystem. All endpoints require a logged-in user
+/// (cruise-internal contact info). Creating and editing items requires the standard content guard
+/// (blocks banned/quarantined users).
+///
+/// All routes are gated by the `.quartermaster` feature flag and accept Bearer token auth only.
+///
+/// Routes registered by this controller:
+///
+///     GET  /api/v3/quartermaster                    list items (filters: category, search, mine)
+///     GET  /api/v3/quartermaster/:quartermaster_id  get a single item
+///     POST /api/v3/quartermaster/create             batch-create one or more items
+///     POST /api/v3/quartermaster/:id/update         update a single item
+///     POST /api/v3/quartermaster/:id/delete         soft-delete an item
+///  DELETE  /api/v3/quartermaster/:id               soft-delete an item (REST alias)
+///     POST /api/v3/quartermaster/:id/report         report an item to the mod queue
+struct QuartermasterController: APIRouteCollection {
+
+	// MARK: - Route Registration
+
+	/// Required. Registers routes to the incoming router.
+	func registerRoutes(_ app: Application) throws {
+		let base = app.grouped("api", "v3", "quartermaster")
+		let tokenAuth = base.tokenRoutes(feature: .quartermaster)
+		tokenAuth.get("", use: listHandler)
+		tokenAuth.get(quartermasterIDParam, use: getHandler)
+		tokenAuth.post("create", use: createHandler)
+		tokenAuth.post(quartermasterIDParam, "update", use: updateHandler)
+		tokenAuth.post(quartermasterIDParam, "delete", use: deleteHandler)
+		tokenAuth.delete(quartermasterIDParam, use: deleteHandler)
+		tokenAuth.post(quartermasterIDParam, "report", use: reportHandler)
+	}
+
+	// MARK: - URL Query Struct
+
+	/// URL query parameters accepted by `listHandler`.
+	struct QuartermasterURLQueryStruct: Content {
+		/// Filter to items in this category. Case-insensitive; `"have"` or `"need"`.
+		var category: String?
+		/// Full-text search string. Matches item name, description, and location via a tsvector index.
+		var search: String?
+		/// If `true`, return only items owned by the authenticated user.
+		var mine: Bool?
+		var start: Int?
+		var limit: Int?
+
+		/// Parses the optional `category` string into a `QuartermasterCategory`.
+		/// Returns `nil` when the parameter was not supplied; throws 400 on unknown values.
+		func getCategory() throws -> QuartermasterCategory? {
+			return try category.map { try QuartermasterCategory.fromAPIString($0) }
+		}
+
+		var pagination: Pagination {
+			Pagination(start: start, limit: limit, maxPageSize: Settings.shared.maximumTwarrts)
+		}
+	}
+
+	// MARK: - Handlers
+
+	/// `GET /api/v3/quartermaster`
+	///
+	/// Returns a paginated list of Quartermaster items, sorted by most-recently-modified first.
+	/// Items owned by blocked users are excluded from results.
+	///
+	/// **Query Parameters:**
+	/// - `category=have|need` — filter to one category
+	/// - `search=<string>` — full-text search across name, description, and location
+	/// - `mine=true` — return only the authenticated user's own items
+	/// - `start=<n>` / `limit=<n>` — pagination (max size: `Settings.shared.maximumTwarrts`)
+	///
+	/// - Throws: 400 if `category` is not a recognized value; 401 if unauthenticated.
+	/// - Returns: `QuartermasterListData`
+	func listHandler(_ req: Request) async throws -> QuartermasterListData {
+		let urlQuery = try req.query.decode(QuartermasterURLQueryStruct.self)
+		let pagination = urlQuery.pagination
+		let cacheUser = try req.auth.require(UserCacheData.self)
+
+		let query = QuartermasterItem.query(on: req.db)
+			.filter(\.$owner.$id !~ cacheUser.getBlocks())
+
+		if urlQuery.mine == true {
+			query.filter(\.$owner.$id == cacheUser.userID)
+		}
+		if let cat = try urlQuery.getCategory() {
+			query.filter(\.$category == cat)
+		}
+		if var searchStr = urlQuery.search {
+			searchStr = searchStr.replacingOccurrences(of: "_", with: "\\_")
+				.replacingOccurrences(of: "%", with: "\\%")
+				.trimmingCharacters(in: .whitespacesAndNewlines)
+			if !searchStr.isEmpty {
+				query.fullTextFilter(\.$itemName, searchStr)
+			}
+		}
+
+		let total = try await query.copy().count()
+		let items = try await query.sort(\.$updatedAt, .descending).range(pagination.range).all()
+
+		let itemDataArray: [QuartermasterData] = try items.map { item in
+			let ownerHeader = try req.userCache.getHeader(item.$owner.id)
+			let contactHeader = try item.$contactUser.id.map { try req.userCache.getHeader($0) }
+			return try QuartermasterData(item: item, owner: ownerHeader, contactUser: contactHeader)
+		}
+		return QuartermasterListData(
+			paginator: Paginator(total: total, start: pagination.start, limit: pagination.limit),
+			items: itemDataArray
+		)
+	}
+
+	/// `GET /api/v3/quartermaster/:quartermaster_id`
+	///
+	/// Returns the details for a single Quartermaster item.
+	///
+	/// - Throws: 400 if item not found or owner is blocked; 401 if unauthenticated.
+	/// - Returns: `QuartermasterData`
+	func getHandler(_ req: Request) async throws -> QuartermasterData {
+		let cacheUser = try req.auth.require(UserCacheData.self)
+		let item = try await findItem(on: req)
+		guard !cacheUser.getBlocks().contains(item.$owner.id) else {
+			throw Abort(.badRequest, reason: "Item not found.")
+		}
+		let ownerHeader = try req.userCache.getHeader(item.$owner.id)
+		let contactHeader = try item.$contactUser.id.map { try req.userCache.getHeader($0) }
+		return try QuartermasterData(item: item, owner: ownerHeader, contactUser: contactHeader)
+	}
+
+	/// `POST /api/v3/quartermaster/create`
+	///
+	/// Creates one or more `QuartermasterItem`s in a single batch. All items share the same
+	/// `category`, `location`, and `contactUsername`; each item has its own `itemName` and
+	/// optional `itemDescription`. All items are saved inside a single transaction so the batch
+	/// is all-or-nothing.
+	///
+	/// At least one of `location` or `contactUsername` must be supplied.
+	///
+	/// - Throws: 400 on validation failure or unknown `contactUsername`; 401 if unauthenticated;
+	///   403 if the user cannot create content (banned/quarantined).
+	/// - Returns: `[QuartermasterData]` with HTTP 201 Created.
+	func createHandler(_ req: Request) async throws -> Response {
+		let data = try ValidatingJSONDecoder().decode(QuartermasterCreateData.self, fromBodyOf: req)
+		let cacheUser = try req.auth.require(UserCacheData.self)
+		try cacheUser.guardCanCreateContent()
+
+		// Resolve the optional shared contact user once, before entering the transaction.
+		let contactUserID: UUID?
+		if let username = data.contactUsername, !username.isEmpty {
+			guard let contactUser = req.userCache.getUser(username: username) else {
+				throw Abort(.badRequest, reason: "User '@\(username)' not found.")
+			}
+			contactUserID = contactUser.userID
+		}
+		else {
+			contactUserID = nil
+		}
+
+		let ownerHeader = cacheUser.makeHeader()
+		let contactHeader = try contactUserID.map { try req.userCache.getHeader($0) }
+
+		let savedItems: [QuartermasterData] = try await req.db.transaction { db in
+			var results: [QuartermasterData] = []
+			for entry in data.items {
+				let item = QuartermasterItem(
+					ownerID: cacheUser.userID,
+					category: data.category,
+					itemName: entry.itemName,
+					itemDescription: entry.itemDescription,
+					location: data.location,
+					contactUserID: contactUserID
+				)
+				try await item.save(on: db)
+				results.append(try QuartermasterData(item: item, owner: ownerHeader, contactUser: contactHeader))
+			}
+			return results
+		}
+
+		let response = Response(status: .created)
+		try response.content.encode(savedItems)
+		return response
+	}
+
+	/// `POST /api/v3/quartermaster/:quartermaster_id/update`
+	///
+	/// Updates a single Quartermaster item. The owner may update any field; a moderator may also
+	/// update items belonging to other users.
+	///
+	/// When any text field (`itemName`, `itemDescription`, or `location`) changes, a
+	/// `QuartermasterItemEdit` is created first to snapshot the prior state for mod accountability.
+	/// Category-only changes do **not** create an edit record.
+	///
+	/// - Throws: 400 on validation failure, unknown `contactUsername`, or item not found;
+	///   401 if unauthenticated; 403 if the caller cannot modify this item.
+	/// - Returns: `QuartermasterData`
+	func updateHandler(_ req: Request) async throws -> QuartermasterData {
+		let data = try ValidatingJSONDecoder().decode(QuartermasterContentData.self, fromBodyOf: req)
+		let cacheUser = try req.auth.require(UserCacheData.self)
+		let item = try await findItem(on: req)
+		try cacheUser.guardCanModifyContent(item)
+
+		// Resolve the new contact user if specified.
+		let newContactUserID: UUID?
+		if let username = data.contactUsername, !username.isEmpty {
+			guard let contactUser = req.userCache.getUser(username: username) else {
+				throw Abort(.badRequest, reason: "User '@\(username)' not found.")
+			}
+			newContactUserID = contactUser.userID
+		}
+		else {
+			newContactUserID = nil
+		}
+
+		// Snapshot the current text fields before applying changes, only when text actually changed.
+		let contentChanged = data.itemName != item.itemName
+			|| data.itemDescription != item.itemDescription
+			|| data.location != item.location
+			|| newContactUserID != item.$contactUser.id
+		if contentChanged {
+			let edit = try QuartermasterItemEdit(item: item, editorID: cacheUser.userID)
+			try await item.logIfModeratorAction(.edit, moderatorID: cacheUser.userID, on: req)
+			try await edit.save(on: req.db)
+		}
+
+		// Apply new values.
+		item.category = data.category
+		item.itemName = data.itemName
+		item.itemDescription = data.itemDescription
+		item.location = data.location
+		item.$contactUser.id = newContactUserID
+		try await item.save(on: req.db)
+
+		let ownerHeader = try req.userCache.getHeader(item.$owner.id)
+		let contactHeader = try newContactUserID.map { try req.userCache.getHeader($0) }
+		return try QuartermasterData(item: item, owner: ownerHeader, contactUser: contactHeader)
+	}
+
+	/// `POST /api/v3/quartermaster/:quartermaster_id/delete`
+	/// `DELETE /api/v3/quartermaster/:quartermaster_id`
+	///
+	/// Soft-deletes a Quartermaster item. The item's owner may delete their own item; a moderator
+	/// may delete any item. The soft-delete timestamp is recorded so moderators can still view
+	/// deleted items during review.
+	///
+	/// - Throws: 400 if item not found; 401 if unauthenticated;
+	///   403 if the caller is neither the owner nor a moderator.
+	/// - Returns: HTTP 204 No Content.
+	func deleteHandler(_ req: Request) async throws -> HTTPStatus {
+		let cacheUser = try req.auth.require(UserCacheData.self)
+		let item = try await findItem(on: req)
+		guard cacheUser.userID == item.$owner.id || cacheUser.accessLevel.canEditOthersContent() else {
+			throw Abort(.forbidden, reason: "User does not have permission to delete this item.")
+		}
+		try cacheUser.guardCanModifyContent(item)
+		try await item.logIfModeratorAction(.delete, moderatorID: cacheUser.userID, on: req)
+		try await item.delete(on: req.db)
+		return .noContent
+	}
+
+	// MARK: - Private Helpers
+
+	/// Looks up the `QuartermasterItem` identified by `quartermasterIDParam`, converting a
+	/// not-found result to a 400 Bad Request per the Swiftarr API convention (404 is reserved
+	/// for endpoints that do not exist).
+	private func findItem(on req: Request) async throws -> QuartermasterItem {
+		do {
+			return try await QuartermasterItem.findFromParameter(quartermasterIDParam, on: req)
+		}
+		catch let abort as Abort where abort.status == .notFound {
+			throw Abort(.badRequest, reason: abort.reason)
+		}
+	}
+
+	/// `POST /api/v3/quartermaster/:quartermaster_id/report`
+	///
+	/// Files a report against a Quartermaster item, feeding it into the moderation queue.
+	/// Duplicate reports from the same user are silently ignored. No auto-quarantine occurs —
+	/// moderators must manually quarantine items.
+	///
+	/// - Throws: 400 if item not found; 401 if unauthenticated.
+	/// - Returns: HTTP 201 Created.
+	func reportHandler(_ req: Request) async throws -> HTTPStatus {
+		let submitter = try req.auth.require(UserCacheData.self)
+		let data = try req.content.decode(ReportData.self)
+		let item = try await findItem(on: req)
+		return try await item.fileReport(submitter: submitter, submitterMessage: data.message, on: req)
+	}
+}

--- a/Sources/swiftarr/Controllers/QuartermasterController.swift
+++ b/Sources/swiftarr/Controllers/QuartermasterController.swift
@@ -160,16 +160,7 @@ struct QuartermasterController: APIRouteCollection {
 		try cacheUser.guardCanCreateContent()
 
 		// Resolve the optional shared contact user once, before entering the transaction.
-		let contactUserID: UUID?
-		if let username = data.contactUsername, !username.isEmpty {
-			guard let contactUser = req.userCache.getUser(username: username) else {
-				throw Abort(.badRequest, reason: "User '@\(username)' not found.")
-			}
-			contactUserID = contactUser.userID
-		}
-		else {
-			contactUserID = nil
-		}
+		let contactUserID = try resolveContactUser(username: data.contactUsername, on: req)
 
 		let ownerHeader = cacheUser.makeHeader()
 		let contactHeader = try contactUserID.map { try req.userCache.getHeader($0) }
@@ -215,16 +206,7 @@ struct QuartermasterController: APIRouteCollection {
 		try cacheUser.guardCanModifyContent(item)
 
 		// Resolve the new contact user if specified.
-		let newContactUserID: UUID?
-		if let username = data.contactUsername, !username.isEmpty {
-			guard let contactUser = req.userCache.getUser(username: username) else {
-				throw Abort(.badRequest, reason: "User '@\(username)' not found.")
-			}
-			newContactUserID = contactUser.userID
-		}
-		else {
-			newContactUserID = nil
-		}
+		let newContactUserID = try resolveContactUser(username: data.contactUsername, on: req)
 
 		// Snapshot the current text fields before applying changes, only when text actually changed.
 		let contentChanged = data.itemName != item.itemName
@@ -284,6 +266,18 @@ struct QuartermasterController: APIRouteCollection {
 		catch let abort as Abort where abort.status == .notFound {
 			throw Abort(.badRequest, reason: abort.reason)
 		}
+	}
+
+	/// Resolves an optional `contactUsername` to a user ID, treating a nil or empty username as "no contact user".
+	/// Used by both `createHandler(_:)` and `updateHandler(_:)`.
+	private func resolveContactUser(username: String?, on req: Request) throws -> UUID? {
+		guard let username, !username.isEmpty else {
+			return nil
+		}
+		guard let contactUser = req.userCache.getUser(username: username) else {
+			throw Abort(.badRequest, reason: "User '@\(username)' not found.")
+		}
+		return contactUser.userID
 	}
 
 	/// `POST /api/v3/quartermaster/:quartermaster_id/report`

--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -785,15 +785,11 @@ extension QuartermasterCreateData: RCFValidatable {
 		let tester = try decoder.validator(keyedBy: CodingKeys.self)
 		tester.validate(!items.isEmpty, forKey: .items, or: "must include at least one item")
 		tester.validate(items.count <= 50, forKey: .items, or: "cannot create more than 50 items at once")
-		if let loc = location {
-			tester.validate(loc.count >= 3, forKey: .location, or: "location field has a 3 character minimum")
-			tester.validate(loc.count <= 100, forKey: .location, or: "location field has a 100 character limit")
-		}
-		let noLocation = location == nil || location?.isEmpty == true
-		let noContact = contactUsername == nil || contactUsername?.isEmpty == true
-		if noLocation && noContact {
-			throw Abort(.badRequest, reason: "An item must have a location, a contact user, or both.")
-		}
+		quartermasterLocationValidations(location: location)
+			.forEach {
+				tester.addValidationError(forKey: .location, errorString: $0)
+			}
+		try validateQuartermasterHasLocationOrContact(location: location, contactUsername: contactUsername)
 		for (index, entry) in items.enumerated() {
 			guard entry.itemName.count >= 2 else {
 				throw Abort(.badRequest, reason: "Item \(index + 1): itemName has a 2 character minimum")
@@ -842,15 +838,34 @@ extension QuartermasterContentData: RCFValidatable {
 				or: "itemDescription length of \(desc.count) is over the 2048 character limit"
 			)
 		}
-		if let loc = location {
-			tester.validate(loc.count >= 3, forKey: .location, or: "location field has a 3 character minimum")
-			tester.validate(loc.count <= 100, forKey: .location, or: "location field has a 100 character limit")
-		}
-		let noLocation = location == nil || location?.isEmpty == true
-		let noContact = contactUsername == nil || contactUsername?.isEmpty == true
-		if noLocation && noContact {
-			throw Abort(.badRequest, reason: "An item must have a location, a contact user, or both.")
-		}
+		quartermasterLocationValidations(location: location)
+			.forEach {
+				tester.addValidationError(forKey: .location, errorString: $0)
+			}
+		try validateQuartermasterHasLocationOrContact(location: location, contactUsername: contactUsername)
+	}
+}
+
+// MARK: - Quartermaster Validation
+
+/// `QuartermasterCreateData` and `QuartermasterContentData` both carry an optional `location` field with the same
+/// bounds; this fn exists to ensure they validate it the same way. Returns a list of validation failure
+/// strings--if it returns an empty array the location is valid (or absent, which is allowed).
+private func quartermasterLocationValidations(location: String?) -> [String] {
+	guard let loc = location else { return [] }
+	var errorStrings: [String] = []
+	if loc.count < 3 { errorStrings.append("location field has a 3 character minimum") }
+	if loc.count > 100 { errorStrings.append("location field has a 100 character limit") }
+	return errorStrings
+}
+
+/// `QuartermasterCreateData` and `QuartermasterContentData` both require at least one of `location` or
+/// `contactUsername` to be present; this fn exists to ensure they enforce that the same way.
+private func validateQuartermasterHasLocationOrContact(location: String?, contactUsername: String?) throws {
+	let noLocation = location == nil || location?.isEmpty == true
+	let noContact = contactUsername == nil || contactUsername?.isEmpty == true
+	if noLocation && noContact {
+		throw Abort(.badRequest, reason: "An item must have a location, a contact user, or both.")
 	}
 }
 

--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -900,10 +900,10 @@ public struct QuartermasterData: Content, ResponseEncodable {
 }
 
 extension QuartermasterData {
-	init(item: QuartermasterItem, owner: UserHeader, contactUser: UserHeader?) throws {
+	init(item: QuartermasterItem, owner: UserHeader, contactUser: UserHeader?, overrideQuarantine: Bool = false) throws {
 		self.itemID = try item.requireID()
 		self.category = item.category
-		let showContent = item.moderationStatus.showsContent()
+		let showContent = overrideQuarantine || item.moderationStatus.showsContent()
 		self.itemName = showContent ? item.itemName : "Item name is under moderator review"
 		self.itemDescription = showContent ? item.itemDescription : "Item description is under moderator review"
 		self.location = showContent ? item.location : "Item location is under moderator review"

--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -750,6 +750,169 @@ extension FezData {
 	}
 }
 
+// MARK: - Quartermaster
+
+/// A single item in a batch-create request. Provides the name and optional description for one
+/// `QuartermasterItem`; category, location, and contact user are shared across the whole batch
+/// and specified in the enclosing `QuartermasterCreateData`.
+public struct QuartermasterItemEntry: Content {
+	/// A short name or title for the item. Required; 2–100 characters.
+	var itemName: String
+	/// An optional longer description of the item. ≤2048 characters when present.
+	var itemDescription: String?
+}
+
+/// Used to batch-create one or more `QuartermasterItem`s.
+///
+/// Required by: `POST /api/v3/quartermaster/create`
+///
+/// See: `QuartermasterController.createHandler(_:)`
+public struct QuartermasterCreateData: Content {
+	/// Whether the items are on offer (`have`) or wanted (`need`). Applies to all items in the batch.
+	var category: QuartermasterCategory
+	/// Optional free-text location where items can be picked up / exchanged. 3–100 characters when present.
+	/// At least one of `location` or `contactUsername` must be supplied.
+	var location: String?
+	/// Optional contact username (a registered Twitarr user). At least one of `location` or `contactUsername`
+	/// must be supplied.
+	var contactUsername: String?
+	/// One or more items to create. 1–50 items per call. Each item has its own name and optional description.
+	var items: [QuartermasterItemEntry]
+}
+
+extension QuartermasterCreateData: RCFValidatable {
+	func runValidations(using decoder: ValidatingDecoder) throws {
+		let tester = try decoder.validator(keyedBy: CodingKeys.self)
+		tester.validate(!items.isEmpty, forKey: .items, or: "must include at least one item")
+		tester.validate(items.count <= 50, forKey: .items, or: "cannot create more than 50 items at once")
+		if let loc = location {
+			tester.validate(loc.count >= 3, forKey: .location, or: "location field has a 3 character minimum")
+			tester.validate(loc.count <= 100, forKey: .location, or: "location field has a 100 character limit")
+		}
+		let noLocation = location == nil || location?.isEmpty == true
+		let noContact = contactUsername == nil || contactUsername?.isEmpty == true
+		if noLocation && noContact {
+			throw Abort(.badRequest, reason: "An item must have a location, a contact user, or both.")
+		}
+		for (index, entry) in items.enumerated() {
+			guard entry.itemName.count >= 2 else {
+				throw Abort(.badRequest, reason: "Item \(index + 1): itemName has a 2 character minimum")
+			}
+			guard entry.itemName.count <= 100 else {
+				throw Abort(.badRequest, reason: "Item \(index + 1): itemName has a 100 character limit")
+			}
+			if let desc = entry.itemDescription {
+				guard desc.count <= 2048 else {
+					throw Abort(.badRequest, reason: "Item \(index + 1): itemDescription is over the 2048 character limit")
+				}
+			}
+		}
+	}
+}
+
+/// Used to update a single `QuartermasterItem`.
+///
+/// Required by: `POST /api/v3/quartermaster/ID/update`
+///
+/// See: `QuartermasterController.updateHandler(_:)`
+public struct QuartermasterContentData: Content {
+	/// The updated category.
+	var category: QuartermasterCategory
+	/// The updated item name. 2–100 characters.
+	var itemName: String
+	/// The updated description. ≤2048 characters when present.
+	var itemDescription: String?
+	/// The updated location. 3–100 characters when present. At least one of `location` or
+	/// `contactUsername` must be supplied.
+	var location: String?
+	/// The updated contact username. Must be a registered Twitarr user when non-nil. At least one
+	/// of `location` or `contactUsername` must be supplied.
+	var contactUsername: String?
+}
+
+extension QuartermasterContentData: RCFValidatable {
+	func runValidations(using decoder: ValidatingDecoder) throws {
+		let tester = try decoder.validator(keyedBy: CodingKeys.self)
+		tester.validate(itemName.count >= 2, forKey: .itemName, or: "itemName field has a 2 character minimum")
+		tester.validate(itemName.count <= 100, forKey: .itemName, or: "itemName field has a 100 character limit")
+		if let desc = itemDescription {
+			tester.validate(
+				desc.count <= 2048,
+				forKey: .itemDescription,
+				or: "itemDescription length of \(desc.count) is over the 2048 character limit"
+			)
+		}
+		if let loc = location {
+			tester.validate(loc.count >= 3, forKey: .location, or: "location field has a 3 character minimum")
+			tester.validate(loc.count <= 100, forKey: .location, or: "location field has a 100 character limit")
+		}
+		let noLocation = location == nil || location?.isEmpty == true
+		let noContact = contactUsername == nil || contactUsername?.isEmpty == true
+		if noLocation && noContact {
+			throw Abort(.badRequest, reason: "An item must have a location, a contact user, or both.")
+		}
+	}
+}
+
+/// Used to return a `QuartermasterItem`'s data.
+///
+/// Returned by:
+/// * `GET /api/v3/quartermaster`
+/// * `GET /api/v3/quartermaster/ID`
+/// * `POST /api/v3/quartermaster/create`
+/// * `POST /api/v3/quartermaster/ID/update`
+///
+/// See: `QuartermasterController`
+public struct QuartermasterData: Content, ResponseEncodable {
+	/// The item's ID.
+	var itemID: UUID
+	/// Whether the owner has or needs the item.
+	var category: QuartermasterCategory
+	/// A short name/title for the item. Masked to a review notice when the item is quarantined.
+	var itemName: String
+	/// An optional longer description. Masked when quarantined.
+	var itemDescription: String?
+	/// An optional free-text pickup/exchange location. Masked when quarantined.
+	var location: String?
+	/// The item's creator.
+	var owner: UserHeader
+	/// An optional contact user. May be the same as `owner` or a different user.
+	var contactUser: UserHeader?
+	/// The item's current moderation status.
+	var moderationStatus: ContentModerationStatus
+	/// The time of the item's most recent modification.
+	var lastModificationTime: Date
+}
+
+extension QuartermasterData {
+	init(item: QuartermasterItem, owner: UserHeader, contactUser: UserHeader?) throws {
+		self.itemID = try item.requireID()
+		self.category = item.category
+		let showContent = item.moderationStatus.showsContent()
+		self.itemName = showContent ? item.itemName : "Item name is under moderator review"
+		self.itemDescription = showContent ? item.itemDescription : "Item description is under moderator review"
+		self.location = showContent ? item.location : "Item location is under moderator review"
+		self.owner = owner
+		self.contactUser = contactUser
+		self.moderationStatus = item.moderationStatus
+		self.lastModificationTime = item.updatedAt ?? Date()
+	}
+}
+
+/// Used to return a paginated list of `QuartermasterItem`s.
+///
+/// Returned by: `GET /api/v3/quartermaster`
+///
+/// See: `QuartermasterController.listHandler(_:)`
+public struct QuartermasterListData: Content {
+	/// Pagination into the result set.
+	var paginator: Paginator
+	/// The items in the result set.
+	var items: [QuartermasterData]
+}
+
+// MARK: -
+
 /// Used to return a `FezPost`'s data.
 ///
 /// Returned by:

--- a/Sources/swiftarr/Controllers/Structs/ModeratorControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ModeratorControllerStructs.swift
@@ -394,3 +394,65 @@ extension UserModerationData {
 		self.reports = reports
 	}
 }
+
+/// Used to return `QuartermasterItemEdit` data for moderators. The only primary data an edit stores is the item
+/// name, description, and location text fields, plus the contact user at the time of the edit.
+///
+///	Included in:
+///	* `QuartermasterModerationData`
+///
+/// Returned by:
+/// * `GET /api/v3/mod/quartermaster/ID`
+public struct QuartermasterEditLogData: Content {
+	/// The ID of the item.
+	var itemID: UUID
+	/// The ID of the edit.
+	var editID: UUID
+	/// The timestamp of the edit.
+	var createdAt: Date
+	/// Who initiated the edit. Usually the item's owner, but could be a moderator. Note that the saved edit shows
+	/// the state BEFORE the edit, therefore the 'author' here changed the contents to those of the NEXT edit
+	/// (or to the current state).
+	var author: UserHeader
+	/// The item name just before `author` edited it.
+	var itemName: String
+	/// The item description just before `author` edited it. Empty string if there was none.
+	var itemDescription: String
+	/// The location just before `author` edited it. Empty string if there was none.
+	var location: String
+	/// The contact user just before `author` edited it, if any.
+	var contactUser: UserHeader?
+}
+
+extension QuartermasterEditLogData {
+	init(_ edit: QuartermasterItemEdit, on req: Request) throws {
+		itemID = edit.$item.id
+		editID = try edit.requireID()
+		createdAt = edit.createdAt ?? Date()
+		author = try req.userCache.getHeader(edit.$editor.id)
+		itemName = edit.itemName
+		itemDescription = edit.itemDescription
+		location = edit.location
+		contactUser = edit.contactUser.flatMap { req.userCache.getHeaders([$0]).first }
+	}
+}
+
+/// Used to return data a moderator needs to moderate a Quartermaster item.
+///
+/// Returned by:
+/// * `GET /api/v3/mod/quartermaster/id`
+///
+/// See `ModerationController.quartermasterModerationHandler(_:)`
+public struct QuartermasterModerationData: Content {
+	/// The item in question, with quarantine masking overridden so moderators see the real text.
+	var item: QuartermasterData
+	/// TRUE if the item has been soft-deleted (A soft-deleted item appears deleted, doesn't appear in the list or
+	/// searches, but can still be viewed by moderators when accessed via a report or a moderationAction).
+	var isDeleted: Bool
+	/// The moderation status of this item. Whether it has been locked or quarantined.
+	var moderationStatus: ContentModerationStatus
+	/// Previous edits to the item.
+	var edits: [QuartermasterEditLogData]
+	/// User reports against this item.
+	var reports: [ReportModerationData]
+}

--- a/Sources/swiftarr/Controllers/UsersController.swift
+++ b/Sources/swiftarr/Controllers/UsersController.swift
@@ -179,11 +179,8 @@ struct UsersController: APIRouteCollection {
 		guard var search = req.parameters.get(searchStringParam.paramString) else {
 			throw Abort(.badRequest, reason: "No user search string in request.")
 		}
-		// postgres "_" and "%" are wildcards, so escape for literals
-		search = search.replacingOccurrences(of: "_", with: "\\_")
-		search = search.replacingOccurrences(of: "%", with: "\\%")
-		// trim and disallow "@" harvesting
-		search = search.trimmingCharacters(in: .whitespacesAndNewlines)
+		// disallow "@" harvesting
+		search = search.escapedForSQLWildcards()
 		guard search != "@", search != "(@" else {
 			throw Abort(.forbidden, reason: "'\(search)' is not a permitted search string")
 		}

--- a/Sources/swiftarr/Enumerations/AppFeatures.swift
+++ b/Sources/swiftarr/Enumerations/AppFeatures.swift
@@ -52,6 +52,7 @@ public enum SwiftarrFeature: String, Content, CaseIterable, Sendable {
 	case registration // User account creation. This is independent of .users above.
 	case hunts  // Puzzle hunts, quizzes, etc.
 	case eventFeedback  	// Form for Shadow Event hosts to give feedback on how their event went
+	case quartermaster  // Searchable "have / need" item board
 
 	case all
 

--- a/Sources/swiftarr/Enumerations/QuartermasterCategory.swift
+++ b/Sources/swiftarr/Enumerations/QuartermasterCategory.swift
@@ -1,0 +1,29 @@
+import Vapor
+
+/// The category of a `QuartermasterItem` — whether the user has the item to offer, or needs it.
+enum QuartermasterCategory: String, CaseIterable, Codable, Sendable {
+	/// The user has this item and is offering it to others.
+	case have
+	/// The user needs this item and is looking for someone who has it.
+	case need
+
+	/// `.label` returns a consumer-friendly display name.
+	var label: String {
+		switch self {
+		case .have: return "Have"
+		case .need: return "Need"
+		}
+	}
+
+	/// For use by the URL-parameter layer. Lowercases the input and maps it to a case,
+	/// throwing a 400 on unknown values.
+	///
+	/// URL parameters that take a category string should use this function.
+	static func fromAPIString(_ str: String) throws -> Self {
+		let lcString = str.lowercased()
+		if let result = QuartermasterCategory(rawValue: lcString) {
+			return result
+		}
+		throw Abort(.badRequest, reason: "Unknown category parameter value.")
+	}
+}

--- a/Sources/swiftarr/Enumerations/ReportType.swift
+++ b/Sources/swiftarr/Enumerations/ReportType.swift
@@ -23,6 +23,8 @@ enum ReportType: String, Codable {
 	case streamPhoto
 	/// a `PersonalEvent`
 	case personalEvent
+	/// a `QuartermasterItem`
+	case quartermasterItem
 }
 
 /// Moderation status of a piece of reportable content.

--- a/Sources/swiftarr/Extensions/Fluent+Extensions.swift
+++ b/Sources/swiftarr/Extensions/Fluent+Extensions.swift
@@ -213,6 +213,25 @@ extension QueryBuilder {
 		}
 	}
 
+	// Same as above, but for fields declared with `@OptionalField` (Field.Value == String?).
+	@discardableResult public func fullTextFilter<Field>(_ field: KeyPath<Model, Field>, _ value: String) -> Self
+	where Field: QueryableProperty, Field.Model == Model, Field.Value == String? {
+		if database is SQLDatabase && Model.self is any Searchable.Type {
+			return filter(
+				.extendedPath(
+					[FieldKey(stringLiteral: "fulltext_search")],
+					schema: Model.schemaOrAlias,
+					space: Model.space
+				),
+				.custom("@@"),
+				DatabaseQuery.Value.custom("websearch_to_tsquery('english', \(bind: String(value)))" as SQLQueryString)
+			)
+		}
+		else {
+			return filter(field, .custom("ILIKE"), "%\(value)%")
+		}
+	}
+
 	// Same as above, but for joined tables in a query
 	@discardableResult public func fullTextFilter<Joined, Field>(
 		_ joined: Joined.Type,

--- a/Sources/swiftarr/Extensions/Foundation+Extensions.swift
+++ b/Sources/swiftarr/Extensions/Foundation+Extensions.swift
@@ -66,6 +66,15 @@ extension String {
 	var iso8601ms: Date? {
 		return dateFromISO8601(self)
 	}
+
+	/// Escapes Postgres LIKE/ILIKE wildcard characters ("_" and "%") so they're matched as literals
+	/// instead of being interpreted as wildcards, then trims leading/trailing whitespace.
+	/// Use this on any user-supplied string before passing it to `ILIKE`, `~~`, or `fullTextFilter`.
+	func escapedForSQLWildcards() -> String {
+		return self.replacingOccurrences(of: "_", with: "\\_")
+			.replacingOccurrences(of: "%", with: "\\%")
+			.trimmingCharacters(in: .whitespacesAndNewlines)
+	}
 }
 
 @available(OSX 10.13, *)

--- a/Sources/swiftarr/Extensions/SQLDatabase+FullTextSearch.swift
+++ b/Sources/swiftarr/Extensions/SQLDatabase+FullTextSearch.swift
@@ -1,0 +1,46 @@
+import FluentSQL
+
+/// Shared helpers for the `Create*SearchIndexes` migrations (see `SearchIndexCreation.swift`,
+/// `SeamailSearchIndexCreation.swift`, `QuartermasterSearchIndexCreation.swift`), which each add a
+/// stored generated `fulltext_search` tsvector column plus a GIN index to one or more tables.
+/// Centralized here so the full-text index strategy only needs to change in one place.
+extension SQLDatabase {
+
+	/// Adds a `fulltext_search` tsvector column to `tableName`, generated from `tsvectorExpression`
+	/// (a raw SQL expression, e.g. `"to_tsvector('english', text)"`), and creates a GIN index over it.
+	func addFullTextSearchColumn(tableName: String, tsvectorExpression: String) async throws {
+		try await self.raw(
+			"""
+			  ALTER TABLE \(unsafeRaw: tableName)
+			  ADD COLUMN IF NOT EXISTS fulltext_search tsvector
+			    GENERATED ALWAYS AS (\(unsafeRaw: tsvectorExpression)) STORED;
+			"""
+		)
+		.run()
+
+		try await createSearchIndex(tableName: tableName)
+	}
+
+	func createSearchIndex(tableName: String) async throws {
+		try await self.raw(
+			"""
+			  CREATE INDEX IF NOT EXISTS idx_\(unsafeRaw: tableName)_search
+			  ON \(ident: tableName)
+			  USING GIN
+			  (fulltext_search)
+			"""
+		)
+		.run()
+	}
+
+	func dropSearchIndexAndColumn(tableName: String) async throws {
+		try await self
+			.drop(index: "idx_\(tableName)_search")
+			.run()
+
+		try await self
+			.alter(table: tableName)
+			.dropColumn("fulltext_search")
+			.run()
+	}
+}

--- a/Sources/swiftarr/Migrations/Schema Creation/QuartermasterSearchIndexCreation.swift
+++ b/Sources/swiftarr/Migrations/Schema Creation/QuartermasterSearchIndexCreation.swift
@@ -1,0 +1,54 @@
+import FluentSQL
+
+struct CreateQuartermasterSearchIndexes: AsyncMigration {
+	func prepare(on database: Database) async throws {
+		let sqlDatabase = (database as! SQLDatabase)
+		try await createQuartermasterItemSearch(on: sqlDatabase)
+	}
+
+	func revert(on database: Database) async throws {
+		let sqlDatabase = (database as! SQLDatabase)
+		try await dropSearchIndexAndColumn(on: sqlDatabase, tableName: "quartermaster_item")
+	}
+
+	func createQuartermasterItemSearch(on database: SQLDatabase) async throws {
+		try await database.raw(
+			"""
+			  ALTER TABLE quartermaster_item
+			  ADD COLUMN IF NOT EXISTS fulltext_search tsvector
+			    GENERATED ALWAYS AS (
+			      to_tsvector('english',
+			        coalesce(item_name, '') || ' ' ||
+			        coalesce(item_description, '') || ' ' ||
+			        coalesce(location, ''))
+			    ) STORED;
+			"""
+		)
+		.run()
+
+		try await createSearchIndex(on: database, tableName: "quartermaster_item")
+	}
+
+	func createSearchIndex(on database: SQLDatabase, tableName: String) async throws {
+		try await database.raw(
+			"""
+			  CREATE INDEX IF NOT EXISTS idx_\(unsafeRaw: tableName)_search
+			  ON \(ident: tableName)
+			  USING GIN
+			  (fulltext_search)
+			"""
+		)
+		.run()
+	}
+
+	func dropSearchIndexAndColumn(on database: SQLDatabase, tableName: String) async throws {
+		try await database
+			.drop(index: "idx_\(tableName)_search")
+			.run()
+
+		try await database
+			.alter(table: tableName)
+			.dropColumn("fulltext_search")
+			.run()
+	}
+}

--- a/Sources/swiftarr/Migrations/Schema Creation/QuartermasterSearchIndexCreation.swift
+++ b/Sources/swiftarr/Migrations/Schema Creation/QuartermasterSearchIndexCreation.swift
@@ -3,52 +3,19 @@ import FluentSQL
 struct CreateQuartermasterSearchIndexes: AsyncMigration {
 	func prepare(on database: Database) async throws {
 		let sqlDatabase = (database as! SQLDatabase)
-		try await createQuartermasterItemSearch(on: sqlDatabase)
+		try await sqlDatabase.addFullTextSearchColumn(
+			tableName: "quartermaster_item",
+			tsvectorExpression: """
+				to_tsvector('english',
+				  coalesce(item_name, '') || ' ' ||
+				  coalesce(item_description, '') || ' ' ||
+				  coalesce(location, ''))
+				"""
+		)
 	}
 
 	func revert(on database: Database) async throws {
 		let sqlDatabase = (database as! SQLDatabase)
-		try await dropSearchIndexAndColumn(on: sqlDatabase, tableName: "quartermaster_item")
-	}
-
-	func createQuartermasterItemSearch(on database: SQLDatabase) async throws {
-		try await database.raw(
-			"""
-			  ALTER TABLE quartermaster_item
-			  ADD COLUMN IF NOT EXISTS fulltext_search tsvector
-			    GENERATED ALWAYS AS (
-			      to_tsvector('english',
-			        coalesce(item_name, '') || ' ' ||
-			        coalesce(item_description, '') || ' ' ||
-			        coalesce(location, ''))
-			    ) STORED;
-			"""
-		)
-		.run()
-
-		try await createSearchIndex(on: database, tableName: "quartermaster_item")
-	}
-
-	func createSearchIndex(on database: SQLDatabase, tableName: String) async throws {
-		try await database.raw(
-			"""
-			  CREATE INDEX IF NOT EXISTS idx_\(unsafeRaw: tableName)_search
-			  ON \(ident: tableName)
-			  USING GIN
-			  (fulltext_search)
-			"""
-		)
-		.run()
-	}
-
-	func dropSearchIndexAndColumn(on database: SQLDatabase, tableName: String) async throws {
-		try await database
-			.drop(index: "idx_\(tableName)_search")
-			.run()
-
-		try await database
-			.alter(table: tableName)
-			.dropColumn("fulltext_search")
-			.run()
+		try await sqlDatabase.dropSearchIndexAndColumn(tableName: "quartermaster_item")
 	}
 }

--- a/Sources/swiftarr/Migrations/Schema Creation/SeamailSearchIndexCreation.swift
+++ b/Sources/swiftarr/Migrations/Schema Creation/SeamailSearchIndexCreation.swift
@@ -4,63 +4,17 @@ struct CreateSeamailSearchIndexes: AsyncMigration {
 	func prepare(on database: Database) async throws {
 		let sqlDatabase = (database as! SQLDatabase)
 
-		try await createFezPostsSearch(on: sqlDatabase)
-		try await createFriendlyFezSearch(on: sqlDatabase)
+		try await sqlDatabase.addFullTextSearchColumn(tableName: "fezposts", tsvectorExpression: "to_tsvector('english', text)")
+		try await sqlDatabase.addFullTextSearchColumn(
+			tableName: "friendlyfez",
+			tsvectorExpression: "to_tsvector('english', coalesce(title, '') || ' ' || coalesce(info, ''))"
+		)
 	}
 
 	func revert(on database: Database) async throws {
 		let sqlDatabase = (database as! SQLDatabase)
 
-		try await dropSearchIndexAndColumn(on: sqlDatabase, tableName: "fezposts")
-		try await dropSearchIndexAndColumn(on: sqlDatabase, tableName: "friendlyfez")
-	}
-
-	func createFezPostsSearch(on database: SQLDatabase) async throws {
-		try await database.raw(
-			"""
-			  ALTER TABLE fezposts
-			  ADD COLUMN IF NOT EXISTS fulltext_search tsvector
-			    GENERATED ALWAYS AS (to_tsvector('english', text)) STORED;
-			"""
-		)
-		.run()
-
-		try await createSearchIndex(on: database, tableName: "fezposts")
-	}
-
-	func createFriendlyFezSearch(on database: SQLDatabase) async throws {
-		try await database.raw(
-			"""
-			  ALTER TABLE friendlyfez
-			  ADD COLUMN IF NOT EXISTS fulltext_search tsvector
-			    GENERATED ALWAYS AS (to_tsvector('english', coalesce(title, '') || ' ' || coalesce(info, ''))) STORED;
-			"""
-		)
-		.run()
-
-		try await createSearchIndex(on: database, tableName: "friendlyfez")
-	}
-
-	func createSearchIndex(on database: SQLDatabase, tableName: String) async throws {
-		try await database.raw(
-			"""
-			  CREATE INDEX IF NOT EXISTS idx_\(unsafeRaw: tableName)_search
-			  ON \(ident: tableName)
-			  USING GIN
-			  (fulltext_search)
-			"""
-		)
-		.run()
-	}
-
-	func dropSearchIndexAndColumn(on database: SQLDatabase, tableName: String) async throws {
-		try await database
-			.drop(index: "idx_\(tableName)_search")
-			.run()
-
-		try await database
-			.alter(table: tableName)
-			.dropColumn("fulltext_search")
-			.run()
+		try await sqlDatabase.dropSearchIndexAndColumn(tableName: "fezposts")
+		try await sqlDatabase.dropSearchIndexAndColumn(tableName: "friendlyfez")
 	}
 }

--- a/Sources/swiftarr/Migrations/Schema Creation/SearchIndexCreation.swift
+++ b/Sources/swiftarr/Migrations/Schema Creation/SearchIndexCreation.swift
@@ -5,125 +5,30 @@ struct CreateSearchIndexes: AsyncMigration {
 		let sqlDatabase = (database as! SQLDatabase)
 		try await sqlDatabase.raw("CREATE EXTENSION IF NOT EXISTS pg_trgm").run()
 
-		try await createTwarrtSearch(on: sqlDatabase)
-		try await createForumSearch(on: sqlDatabase)
-		try await createForumPostSearch(on: sqlDatabase)
-		try await createEventSearch(on: sqlDatabase)
-		try await createBoardgameSearch(on: sqlDatabase)
-		try await createKaraokeSongSearch(on: sqlDatabase)
+		try await sqlDatabase.addFullTextSearchColumn(tableName: "twarrt", tsvectorExpression: "to_tsvector('english', text)")
+		try await sqlDatabase.addFullTextSearchColumn(tableName: "forum", tsvectorExpression: "to_tsvector('english', title)")
+		try await sqlDatabase.addFullTextSearchColumn(tableName: "forumpost", tsvectorExpression: "to_tsvector('english', text)")
+		try await sqlDatabase.addFullTextSearchColumn(
+			tableName: "event",
+			tsvectorExpression: "to_tsvector('english', coalesce(title, '') || ' ' || coalesce(info, ''))"
+		)
+		try await sqlDatabase.addFullTextSearchColumn(tableName: "boardgame", tsvectorExpression: "to_tsvector('english', \"gameName\")")
+		try await sqlDatabase.addFullTextSearchColumn(
+			tableName: "karaoke_song",
+			tsvectorExpression: "to_tsvector('english', coalesce(artist, '') || ' ' || coalesce(title, ''))"
+		)
 	}
 
 	func revert(on database: Database) async throws {
 		let sqlDatabase = (database as! SQLDatabase)
 
-		try await dropSearchIndexAndColumn(on: sqlDatabase, tableName: "twarrt")
-		try await dropSearchIndexAndColumn(on: sqlDatabase, tableName: "forum")
-		try await dropSearchIndexAndColumn(on: sqlDatabase, tableName: "forumpost")
-		try await dropSearchIndexAndColumn(on: sqlDatabase, tableName: "event")
-		try await dropSearchIndexAndColumn(on: sqlDatabase, tableName: "boardgame")
-		try await dropSearchIndexAndColumn(on: sqlDatabase, tableName: "karaoke_song")
+		try await sqlDatabase.dropSearchIndexAndColumn(tableName: "twarrt")
+		try await sqlDatabase.dropSearchIndexAndColumn(tableName: "forum")
+		try await sqlDatabase.dropSearchIndexAndColumn(tableName: "forumpost")
+		try await sqlDatabase.dropSearchIndexAndColumn(tableName: "event")
+		try await sqlDatabase.dropSearchIndexAndColumn(tableName: "boardgame")
+		try await sqlDatabase.dropSearchIndexAndColumn(tableName: "karaoke_song")
 
 		try await sqlDatabase.raw("DROP EXTENSION IF EXISTS pg_trgm").run()
-	}
-
-	func createTwarrtSearch(on database: SQLDatabase) async throws {
-		try await database.raw(
-			"""
-			  ALTER TABLE twarrt
-			  ADD COLUMN IF NOT EXISTS fulltext_search tsvector
-			    GENERATED ALWAYS AS (to_tsvector('english', text)) STORED;
-			"""
-		)
-		.run()
-
-		try await createSearchIndex(on: database, tableName: "twarrt")
-	}
-
-	func createForumSearch(on database: SQLDatabase) async throws {
-		try await database.raw(
-			"""
-			  ALTER TABLE forum
-			  ADD COLUMN IF NOT EXISTS fulltext_search tsvector
-			    GENERATED ALWAYS AS (to_tsvector('english', title)) STORED;
-			"""
-		)
-		.run()
-
-		try await createSearchIndex(on: database, tableName: "forum")
-	}
-
-	func createForumPostSearch(on database: SQLDatabase) async throws {
-		try await database.raw(
-			"""
-			  ALTER TABLE forumpost
-			  ADD COLUMN IF NOT EXISTS fulltext_search tsvector
-			    GENERATED ALWAYS AS (to_tsvector('english', text)) STORED;
-			"""
-		)
-		.run()
-
-		try await createSearchIndex(on: database, tableName: "forumpost")
-	}
-
-	func createEventSearch(on database: SQLDatabase) async throws {
-		try await database.raw(
-			"""
-			  ALTER TABLE event
-			  ADD COLUMN IF NOT EXISTS fulltext_search tsvector
-			    GENERATED ALWAYS AS (to_tsvector('english', coalesce(title, '') || ' ' || coalesce(info, ''))) STORED;
-			"""
-		)
-		.run()
-
-		try await createSearchIndex(on: database, tableName: "event")
-	}
-
-	func createBoardgameSearch(on database: SQLDatabase) async throws {
-		try await database.raw(
-			"""
-			  ALTER TABLE boardgame
-			  ADD COLUMN IF NOT EXISTS fulltext_search tsvector
-			    GENERATED ALWAYS AS (to_tsvector('english', "gameName")) STORED;
-			"""
-		)
-		.run()
-
-		try await createSearchIndex(on: database, tableName: "boardgame")
-	}
-
-	func createKaraokeSongSearch(on database: SQLDatabase) async throws {
-		try await database.raw(
-			"""
-			  ALTER TABLE karaoke_song
-			  ADD COLUMN IF NOT EXISTS fulltext_search tsvector
-			    GENERATED ALWAYS AS (to_tsvector('english', coalesce(artist, '') || ' ' || coalesce(title, ''))) STORED;
-			"""
-		)
-		.run()
-
-		try await createSearchIndex(on: database, tableName: "karaoke_song")
-	}
-
-	func createSearchIndex(on database: SQLDatabase, tableName: String) async throws {
-		try await database.raw(
-			"""
-			  CREATE INDEX IF NOT EXISTS idx_\(unsafeRaw: tableName)_search
-			  ON \(ident: tableName)
-			  USING GIN
-			  (fulltext_search)
-			"""
-		)
-		.run()
-	}
-
-	func dropSearchIndexAndColumn(on database: SQLDatabase, tableName: String) async throws {
-		try await database
-			.drop(index: "idx_\(tableName)_search")
-			.run()
-
-		try await database
-			.alter(table: tableName)
-			.dropColumn("fulltext_search")
-			.run()
 	}
 }

--- a/Sources/swiftarr/Models/QuartermasterItem.swift
+++ b/Sources/swiftarr/Models/QuartermasterItem.swift
@@ -1,0 +1,146 @@
+import Fluent
+import Foundation
+import Vapor
+
+/// 	A QuartermasterItem is a single entry on the Quartermaster "have / need" board.
+///
+/// 	Any logged-in user can post an item they have to offer or an item they are looking for. Each entry
+/// 	may optionally specify a free-text location and/or a contact user (another registered Twitarr user).
+/// 	At least one of {location, contact user} must be present (validated in the controller).
+///
+/// 	Items are searchable, filterable by category (have/need) and by owner, and are individually
+/// 	reportable to the mod queue. Moderators may quarantine or delete entries exactly as they do
+/// 	for forum posts. Edits to text fields are snapshotted in `QuartermasterItemEdit` for accountability.
+///
+/// 	- See Also: [QuartermasterData](QuartermasterData) the DTO for returning item data.
+/// 	- See Also: [QuartermasterContentData](QuartermasterContentData) the DTO for creating or editing items.
+/// 	- See Also: [CreateQuartermasterItemSchema](CreateQuartermasterItemSchema) the Migration creating the table.
+final class QuartermasterItem: Model, Searchable, @unchecked Sendable {
+	static let schema = "quartermaster_item"
+
+	// MARK: Properties
+
+	/// Unique ID for this item.
+	@ID(key: .id) var id: UUID?
+
+	/// Whether the owner has this item to offer, or needs it.
+	@Field(key: "category") var category: QuartermasterCategory
+
+	/// A short name or title for the item. Required; 2–100 characters (validated in controller).
+	@Field(key: "item_name") var itemName: String
+
+	/// An optional longer description of the item. ≤2048 characters when present.
+	@OptionalField(key: "item_description") var itemDescription: String?
+
+	/// An optional free-text location where the item can be picked up / exchanged.
+	/// When present: 3–100 characters (validated in the controller DTO).
+	@OptionalField(key: "location") var location: String?
+
+	/// Moderators can set several statuses on items that modify editability and visibility.
+	@Enum(key: "mod_status") var moderationStatus: ContentModerationStatus
+
+	// MARK: Relationships
+
+	/// The user who created this item listing.
+	@Parent(key: "owner") var owner: User
+
+	/// An optional contact user — the person to approach about this item. Defaults to the owner
+	/// in clients, but may be overridden to any real Twitarr user. When this user is deleted,
+	/// the field is nulled out rather than cascading deletion to the item.
+	@OptionalParent(key: "contact_user") var contactUser: User?
+
+	/// The child `QuartermasterItemEdit` accountability records for this item.
+	@Children(for: \.$item) var edits: [QuartermasterItemEdit]
+
+	// MARK: Record-keeping
+
+	/// Timestamp of the model's creation, set automatically.
+	@Timestamp(key: "created_at", on: .create) var createdAt: Date?
+
+	/// Timestamp of the model's last update, set automatically.
+	@Timestamp(key: "updated_at", on: .update) var updatedAt: Date?
+
+	/// Timestamp of the model's soft-deletion, set automatically.
+	/// Soft-delete allows moderators to view deleted entries.
+	@Timestamp(key: "deleted_at", on: .delete) var deletedAt: Date?
+
+	// MARK: Initialization
+
+	// Used by Fluent.
+	init() {}
+
+	/// Initializes a new QuartermasterItem.
+	///
+	/// - Parameters:
+	///   - ownerID: The UUID of the user creating the listing.
+	///   - category: Whether the owner has or needs the item.
+	///   - itemName: A short name for the item (2–100 chars).
+	///   - itemDescription: An optional longer description (≤2048 chars).
+	///   - location: An optional free-text pickup/exchange location.
+	///   - contactUserID: An optional UUID of the contact user; nil means no contact user is set.
+	init(
+		ownerID: UUID,
+		category: QuartermasterCategory,
+		itemName: String,
+		itemDescription: String? = nil,
+		location: String? = nil,
+		contactUserID: UUID? = nil
+	) {
+		self.$owner.id = ownerID
+		self.category = category
+		self.itemName = itemName
+		self.itemDescription = itemDescription
+		self.location = location
+		self.$contactUser.id = contactUserID
+		self.moderationStatus = .normal
+	}
+}
+
+// MARK: - Reportable
+
+/// Items can be reported to the moderator queue by any user.
+/// No auto-quarantine threshold — mods must manually quarantine (same policy as FriendlyFez).
+extension QuartermasterItem: Reportable {
+	/// The report type for `QuartermasterItem` reports.
+	var reportType: ReportType { .quartermasterItem }
+
+	/// Standardizes how to get the author ID of a Reportable object.
+	var authorUUID: UUID { $owner.id }
+
+	/// No auto-quarantine for Quartermaster items.
+	var autoQuarantineThreshold: Int { Int.max }
+}
+
+// MARK: - ContentFilterable
+
+/// Items participate in mute-word and alert-word processing.
+extension QuartermasterItem: ContentFilterable {
+	func contentTextStrings() -> [String] {
+		[itemName, itemDescription ?? "", location ?? ""]
+	}
+}
+
+// MARK: - Migration
+
+struct CreateQuartermasterItemSchema: AsyncMigration {
+	func prepare(on database: Database) async throws {
+		let modStatusEnum = try await database.enum("moderation_status").read()
+		try await database.schema("quartermaster_item")
+			.id()
+			.field("category", .string, .required)
+			.field("item_name", .string, .required)
+			.field("item_description", .string)
+			.field("location", .string)
+			.field("mod_status", modStatusEnum, .required)
+			.field("owner", .uuid, .required, .references("user", "id", onDelete: .cascade))
+			.field("contact_user", .uuid, .references("user", "id", onDelete: .setNull))
+			.field("created_at", .datetime)
+			.field("updated_at", .datetime)
+			.field("deleted_at", .datetime)
+			.create()
+	}
+
+	func revert(on database: Database) async throws {
+		try await database.schema("quartermaster_item").delete()
+	}
+}

--- a/Sources/swiftarr/Models/QuartermasterItemEdit.swift
+++ b/Sources/swiftarr/Models/QuartermasterItemEdit.swift
@@ -28,6 +28,9 @@ final class QuartermasterItemEdit: Model, @unchecked Sendable {
 	/// The previous location string (empty string when nil at edit time).
 	@Field(key: "location") var location: String
 
+	/// The previous contact user UUID (nil when no contact user was set at edit time).
+	@OptionalField(key: "contact_user") var contactUser: UUID?
+
 	/// Timestamp of the model's creation, set automatically.
 	@Timestamp(key: "created_at", on: .create) var createdAt: Date?
 
@@ -57,6 +60,7 @@ final class QuartermasterItemEdit: Model, @unchecked Sendable {
 		self.itemName = item.itemName
 		self.itemDescription = item.itemDescription ?? ""
 		self.location = item.location ?? ""
+		self.contactUser = item.$contactUser.id
 	}
 }
 
@@ -67,6 +71,7 @@ struct CreateQuartermasterItemEditSchema: AsyncMigration {
 			.field("item_name", .string, .required)
 			.field("item_description", .string, .required)
 			.field("location", .string, .required)
+			.field("contact_user", .uuid, .references("user", "id", onDelete: .setNull))
 			.field("created_at", .datetime)
 			.field("item", .uuid, .required, .references("quartermaster_item", "id"))
 			.field("editor", .uuid, .required, .references("user", "id"))

--- a/Sources/swiftarr/Models/QuartermasterItemEdit.swift
+++ b/Sources/swiftarr/Models/QuartermasterItemEdit.swift
@@ -1,0 +1,79 @@
+import Fluent
+import Vapor
+
+/// 	When the TEXT FIELDS of a `QuartermasterItem` are edited, a `QuartermasterItemEdit` is created
+/// 	to save the previous values of those text fields.
+///
+/// 	Edits that only change the category — without touching item_name, item_description, or location —
+/// 	do not create a QuartermasterItemEdit. This is done for accountability purposes; the data collected
+/// 	is intended to be viewable only by moderators.
+///
+/// 	- See Also: [QuartermasterModerationData](QuartermasterModerationData) the DTO returning data
+/// 	  moderators need to review items. Specifically, [QuartermasterEditLogData](QuartermasterEditLogData)
+/// 	  delivers values from the `QuartermasterItemEdit`.
+/// 	- See Also: [CreateQuartermasterItemEditSchema](CreateQuartermasterItemEditSchema) the Migration
+/// 	  for creating the QuartermasterItemEdit table.
+final class QuartermasterItemEdit: Model, @unchecked Sendable {
+	static let schema = "quartermaster_item_edit"
+
+	/// The edit's ID.
+	@ID(key: .id) var id: UUID?
+
+	/// The previous item name.
+	@Field(key: "item_name") var itemName: String
+
+	/// The previous item description (empty string when nil at edit time).
+	@Field(key: "item_description") var itemDescription: String
+
+	/// The previous location string (empty string when nil at edit time).
+	@Field(key: "location") var location: String
+
+	/// Timestamp of the model's creation, set automatically.
+	@Timestamp(key: "created_at", on: .create) var createdAt: Date?
+
+	// MARK: Relations
+
+	/// The parent `QuartermasterItem` that was edited.
+	@Parent(key: "item") var item: QuartermasterItem
+
+	/// The `User` that performed the edit.
+	@Parent(key: "editor") var editor: User
+
+	// MARK: Initialization
+
+	// Used by Fluent.
+	init() {}
+
+	/// Initializes a new QuartermasterItemEdit with the CURRENT text fields of the item.
+	/// Call this **before** applying the edit so that the prior state is captured.
+	///
+	/// - Parameters:
+	///   - item: The QuartermasterItem about to be edited.
+	///   - editorID: The UUID of the User making the change.
+	init(item: QuartermasterItem, editorID: UUID) throws {
+		self.$item.id = try item.requireID()
+		self.$item.value = item
+		self.$editor.id = editorID
+		self.itemName = item.itemName
+		self.itemDescription = item.itemDescription ?? ""
+		self.location = item.location ?? ""
+	}
+}
+
+struct CreateQuartermasterItemEditSchema: AsyncMigration {
+	func prepare(on database: Database) async throws {
+		try await database.schema("quartermaster_item_edit")
+			.id()
+			.field("item_name", .string, .required)
+			.field("item_description", .string, .required)
+			.field("location", .string, .required)
+			.field("created_at", .datetime)
+			.field("item", .uuid, .required, .references("quartermaster_item", "id"))
+			.field("editor", .uuid, .required, .references("user", "id"))
+			.create()
+	}
+
+	func revert(on database: Database) async throws {
+		try await database.schema("quartermaster_item_edit").delete()
+	}
+}

--- a/Sources/swiftarr/Protocols/APIRouteCollection.swift
+++ b/Sources/swiftarr/Protocols/APIRouteCollection.swift
@@ -108,6 +108,7 @@ extension APIRouteCollection {
 	var puzzleIDParam: PathComponent { PathComponent(":puzzle_id") }
 	var eventUIDParam: PathComponent { PathComponent(":event_uid") }
 	var feedbackIDParam: PathComponent { PathComponent(":feedback_id") }
+	var quartermasterIDParam: PathComponent { PathComponent(":quartermaster_id") }
 
 	/// Transforms a string that might represent a date (either a `Double` or an ISO 8601
 	/// representation) into a `Date`, if possible.

--- a/Sources/swiftarr/Site/SiteModController.swift
+++ b/Sources/swiftarr/Site/SiteModController.swift
@@ -963,6 +963,7 @@ func generateContentGroups(from reports: [ReportModerationData]) -> [ReportConte
 		case .mkSongSnippet: contentURL = "/moderate/microkaraoke/song/\(report.reportedID)"  // Individual snippets aren't actually reportable yet.
 		case .streamPhoto: contentURL = "/moderate/photostream/\(report.reportedID)"
 		case .personalEvent: contentURL = "/moderate/personalevent/\(report.reportedID)"
+		case .quartermasterItem: contentURL = "/moderate/quartermaster/\(report.reportedID)"
 		}
 		var newGroup = ReportContentGroup(
 			reportType: report.type,

--- a/Sources/swiftarr/configure.swift
+++ b/Sources/swiftarr/configure.swift
@@ -605,6 +605,8 @@ struct SwiftarrConfigurator {
 		app.migrations.add(CreateFezParticipantSchema(), to: .psql)
 		app.migrations.add(CreateFezPostSchema(), to: .psql)
 		app.migrations.add(CreateFriendlyFezEditSchema(), to: .psql)
+		app.migrations.add(CreateQuartermasterItemSchema(), to: .psql)
+		app.migrations.add(CreateQuartermasterItemEditSchema(), to: .psql)
 		app.migrations.add(CreateDailyThemeSchema(), to: .psql)
 		app.migrations.add(CreateBoardgameSchema(), to: .psql)
 		app.migrations.add(CreateBoardgameFavoriteSchema(), to: .psql)
@@ -678,7 +680,8 @@ struct SwiftarrConfigurator {
 		app.migrations.add(AddFoodDrinkCategory(), to: .psql)
 		app.migrations.add(CreateMicroKaraokeUser(), to: .psql)
 		app.migrations.add(RemoveCovidCategory(), to: .psql)
-		
+		app.migrations.add(CreateQuartermasterSearchIndexes(), to: .psql)
+
 		// DON'T add schema-modification migrations down here. Appending migrations that modify a table's schema at the end will
 		// break migrations that use Fluent to populate that table with data, as Fluent only models the current db schema.
 		// When resetting the db (or a new install), all the migrations run in the listed order, and the schema needs to match Fluent before

--- a/Sources/swiftarr/routes.swift
+++ b/Sources/swiftarr/routes.swift
@@ -30,6 +30,7 @@ public func routes(_ app: Application) throws {
 		PerformerController(),
 		PersonalEventController(),
 		EventFeedbackController(),
+		QuartermasterController(),
 	]
 	try apiControllers.forEach { try $0.registerRoutes(app) }
 

--- a/Tests/AppTests/QuartermasterControllerTests.swift
+++ b/Tests/AppTests/QuartermasterControllerTests.swift
@@ -1,0 +1,634 @@
+import XCTVapor
+@testable import swiftarr
+
+// Tests for Quartermaster Phase 2: DTO validation and HTTP controller behaviour.
+//
+// Validation tests (QuartermasterValidationTests) are pure-Swift — no DB or network required.
+// Controller tests (QuartermasterControllerTests) use SwiftarrBaseTest and a live Postgres instance
+// (port 5433) plus Redis (port 6380) in the same way as ForumQuarantineVisibilityTests.
+
+// MARK: - DTO Validation
+
+class QuartermasterValidationTests: XCTestCase {
+
+	private let decoder = ValidatingJSONDecoder()
+
+	// Collect tester.validate() failures for a given JSON string.
+	// Returns an empty array when validation passes.
+	// Throws when runValidations() calls `throw Abort(...)` (cross-field / throw-based checks).
+	private func validationErrors<T: Decodable>(_ type: T.Type, _ json: String) throws -> [String] {
+		let data = json.data(using: .utf8)!
+		let result = try decoder.validate(type, from: data)
+		return result?.validationFailures.map { $0.errorString } ?? []
+	}
+
+	// MARK: - QuartermasterCreateData — location/contact cross-field rule
+
+	func testCreate_BothLocationAndContactNil_Throws() {
+		let json = #"{"category":"have","items":[{"itemName":"Widget"}]}"#
+		XCTAssertThrowsError(try validationErrors(QuartermasterCreateData.self, json)) { err in
+			let abort = err as? Abort
+			XCTAssertEqual(abort?.status, .badRequest)
+			XCTAssertTrue(abort?.reason.contains("location") ?? false || abort?.reason.contains("contact") ?? false)
+		}
+	}
+
+	func testCreate_LocationPresent_PassesCrossFieldCheck() throws {
+		let json = #"{"category":"have","location":"Deck 5","items":[{"itemName":"Widget"}]}"#
+		let errs = try validationErrors(QuartermasterCreateData.self, json)
+		// Only check cross-field did not throw; length errors are separate.
+		XCTAssertFalse(errs.isEmpty == false && errs.allSatisfy { $0.contains("location") || $0.contains("contact") },
+			"cross-field check should not fire when location is present")
+	}
+
+	func testCreate_ContactUsernamePresent_PassesCrossFieldCheck() throws {
+		let json = #"{"category":"need","contactUsername":"someuser","items":[{"itemName":"Widget"}]}"#
+		let errs = try validationErrors(QuartermasterCreateData.self, json)
+		XCTAssertFalse(errs.contains { $0.contains("location") && $0.contains("contact") })
+	}
+
+	// MARK: - QuartermasterCreateData — items array bounds
+
+	func testCreate_EmptyItemsArray_FailsValidation() throws {
+		let json = #"{"category":"have","location":"Deck 5","items":[]}"#
+		let errs = try validationErrors(QuartermasterCreateData.self, json)
+		XCTAssertTrue(errs.contains("must include at least one item"), "errs=\(errs)")
+	}
+
+	func testCreate_51Items_FailsValidation() throws {
+		let items = Array(repeating: #"{"itemName":"Widget"}"#, count: 51).joined(separator: ",")
+		let json = #"{"category":"have","location":"Deck 5","items":[\#(items)]}"#
+		let errs = try validationErrors(QuartermasterCreateData.self, json)
+		XCTAssertTrue(errs.contains("cannot create more than 50 items at once"), "errs=\(errs)")
+	}
+
+	func testCreate_50Items_PassesValidation() throws {
+		let items = Array(repeating: #"{"itemName":"Widget"}"#, count: 50).joined(separator: ",")
+		let json = #"{"category":"have","location":"Deck 5","items":[\#(items)]}"#
+		XCTAssertNoThrow(try validationErrors(QuartermasterCreateData.self, json))
+	}
+
+	// MARK: - QuartermasterCreateData — per-item itemName bounds
+
+	func testCreate_ItemNameTooShort_Throws() {
+		let json = #"{"category":"have","location":"Deck 5","items":[{"itemName":"x"}]}"#
+		XCTAssertThrowsError(try validationErrors(QuartermasterCreateData.self, json)) { err in
+			let abort = err as? Abort
+			XCTAssertEqual(abort?.status, .badRequest)
+			XCTAssertTrue(abort?.reason.contains("2 character minimum") ?? false, "reason=\(abort?.reason ?? "")")
+		}
+	}
+
+	func testCreate_ItemNameTooLong_Throws() {
+		let name = String(repeating: "a", count: 101)
+		let json = #"{"category":"have","location":"Deck 5","items":[{"itemName":"\#(name)"}]}"#
+		XCTAssertThrowsError(try validationErrors(QuartermasterCreateData.self, json)) { err in
+			let abort = err as? Abort
+			XCTAssertEqual(abort?.status, .badRequest)
+			XCTAssertTrue(abort?.reason.contains("100 character limit") ?? false)
+		}
+	}
+
+	func testCreate_ItemDescriptionTooLong_Throws() {
+		let desc = String(repeating: "a", count: 2049)
+		let json = #"{"category":"have","location":"Deck 5","items":[{"itemName":"Widget","itemDescription":"\#(desc)"}]}"#
+		XCTAssertThrowsError(try validationErrors(QuartermasterCreateData.self, json)) { err in
+			let abort = err as? Abort
+			XCTAssertEqual(abort?.status, .badRequest)
+			XCTAssertTrue(abort?.reason.contains("2048 character limit") ?? false)
+		}
+	}
+
+	// MARK: - QuartermasterCreateData — shared location bounds
+
+	func testCreate_LocationTooShort_FailsValidation() throws {
+		let json = #"{"category":"have","location":"ab","items":[{"itemName":"Widget"}]}"#
+		let errs = try validationErrors(QuartermasterCreateData.self, json)
+		XCTAssertTrue(errs.contains("location field has a 3 character minimum"), "errs=\(errs)")
+	}
+
+	func testCreate_LocationTooLong_FailsValidation() throws {
+		let loc = String(repeating: "a", count: 101)
+		let json = #"{"category":"have","location":"\#(loc)","items":[{"itemName":"Widget"}]}"#
+		let errs = try validationErrors(QuartermasterCreateData.self, json)
+		XCTAssertTrue(errs.contains("location field has a 100 character limit"), "errs=\(errs)")
+	}
+
+	// MARK: - QuartermasterCreateData — happy paths
+
+	func testCreate_HappyPath_WithLocation() throws {
+		let json = #"{"category":"have","location":"Deck 5","items":[{"itemName":"Widget","itemDescription":"Nice widget"}]}"#
+		let errs = try validationErrors(QuartermasterCreateData.self, json)
+		XCTAssertEqual(errs, [], "unexpected validation errors: \(errs)")
+	}
+
+	func testCreate_HappyPath_WithContact() throws {
+		let json = #"{"category":"need","contactUsername":"alice","items":[{"itemName":"Sunscreen"}]}"#
+		let errs = try validationErrors(QuartermasterCreateData.self, json)
+		XCTAssertEqual(errs, [], "unexpected validation errors: \(errs)")
+	}
+
+	func testCreate_HappyPath_WithBothLocationAndContact() throws {
+		let json = #"{"category":"have","location":"Lido Deck","contactUsername":"bob","items":[{"itemName":"Sunscreen"},{"itemName":"Hat"}]}"#
+		let errs = try validationErrors(QuartermasterCreateData.self, json)
+		XCTAssertEqual(errs, [], "unexpected validation errors: \(errs)")
+	}
+
+	// MARK: - QuartermasterContentData (update) — cross-field rule
+
+	func testUpdate_BothLocationAndContactNil_Throws() {
+		let json = #"{"category":"have","itemName":"Widget"}"#
+		XCTAssertThrowsError(try validationErrors(QuartermasterContentData.self, json)) { err in
+			XCTAssertEqual((err as? Abort)?.status, .badRequest)
+		}
+	}
+
+	// MARK: - QuartermasterContentData — itemName bounds
+
+	func testUpdate_ItemNameTooShort_FailsValidation() throws {
+		let json = #"{"category":"have","itemName":"x","location":"Deck 5"}"#
+		let errs = try validationErrors(QuartermasterContentData.self, json)
+		XCTAssertTrue(errs.contains("itemName field has a 2 character minimum"), "errs=\(errs)")
+	}
+
+	func testUpdate_ItemNameTooLong_FailsValidation() throws {
+		let name = String(repeating: "a", count: 101)
+		let json = #"{"category":"have","itemName":"\#(name)","location":"Deck 5"}"#
+		let errs = try validationErrors(QuartermasterContentData.self, json)
+		XCTAssertTrue(errs.contains("itemName field has a 100 character limit"), "errs=\(errs)")
+	}
+
+	func testUpdate_DescriptionTooLong_FailsValidation() throws {
+		let desc = String(repeating: "a", count: 2049)
+		let json = #"{"category":"have","itemName":"Widget","location":"Deck 5","itemDescription":"\#(desc)"}"#
+		let errs = try validationErrors(QuartermasterContentData.self, json)
+		XCTAssertTrue(errs.first(where: { $0.contains("2048 character limit") }) != nil, "errs=\(errs)")
+	}
+
+	func testUpdate_HappyPath() throws {
+		let json = #"{"category":"need","itemName":"Widget","location":"Deck 5"}"#
+		let errs = try validationErrors(QuartermasterContentData.self, json)
+		XCTAssertEqual(errs, [], "unexpected validation errors: \(errs)")
+	}
+}
+
+// MARK: - HTTP Controller Tests
+
+final class QuartermasterControllerTests: XCTestCase, SwiftarrBaseTest {
+
+	// MARK: - Helpers
+
+	private func makeUser(_ app: Application, username: String, accessLevel: UserAccessLevel) async throws -> User {
+		let user = User(
+			username: username,
+			password: try Bcrypt.hash("password1"),
+			recoveryKey: try Bcrypt.hash("recovery key"),
+			accessLevel: accessLevel
+		)
+		try await user.save(on: app.db)
+		return user
+	}
+
+	private func makeToken(_ app: Application, for user: User) async throws -> String {
+		let token = try Token.generate(for: user)
+		try await token.save(on: app.db)
+		return token.token
+	}
+
+	private func bearer(_ token: String) -> HTTPHeaders {
+		var headers = HTTPHeaders()
+		headers.bearerAuthorization = BearerAuthorization(token: token)
+		return headers
+	}
+
+	private func contentHeaders(_ token: String) -> HTTPHeaders {
+		var headers = bearer(token)
+		headers.contentType = .json
+		return headers
+	}
+
+	/// Builds a valid batch-create JSON payload with a single item.
+	private func createPayload(
+		category: String = "have",
+		itemName: String = "Extra sunscreen",
+		itemDescription: String? = nil,
+		location: String? = "Deck 5",
+		contactUsername: String? = nil
+	) -> String {
+		var fields = [#""category":"\#(category)""#]
+		if let loc = location { fields.append(#""location":"\#(loc)""#) }
+		if let cu = contactUsername { fields.append(#""contactUsername":"\#(cu)""#) }
+		var itemFields = [#""itemName":"\#(itemName)""#]
+		if let desc = itemDescription { itemFields.append(#""itemDescription":"\#(desc)""#) }
+		let itemJSON = "{" + itemFields.joined(separator: ",") + "}"
+		fields.append(#""items":[\#(itemJSON)]"#)
+		return "{" + fields.joined(separator: ",") + "}"
+	}
+
+	// MARK: - Test: unauthenticated access is rejected
+
+	func testList_Unauthenticated_Returns401() async throws {
+		try await withApp { app in
+			try await app.asyncBoot()
+			try await app.test(.GET, "/api/v3/quartermaster") { res async throws in
+				XCTAssertEqual(res.status, .unauthorized)
+			}
+		}
+	}
+
+	// MARK: - Test: batch create
+
+	func testCreate_BatchCreate_ReturnsCreatedItems() async throws {
+		try await withApp { app in
+			let user = try await makeUser(app, username: "qm-creator-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let token = try await makeToken(app, for: user)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			// Two items in one call sharing location.
+			let items = Array(repeating: #"{"itemName":"Extra sunscreen"},{"itemName":"Spare hat"}"#, count: 1)
+			let _ = items
+			let payload = #"{"category":"have","location":"Deck 5","items":[{"itemName":"Extra sunscreen"},{"itemName":"Spare hat"}]}"#
+
+			try await app.test(
+				.POST, "/api/v3/quartermaster/create",
+				headers: contentHeaders(token),
+				body: ByteBuffer(string: payload)
+			) { res async throws in
+				XCTAssertEqual(res.status, .created, "body=\(String(buffer: res.body))")
+				let created = try res.content.decode([QuartermasterData].self)
+				XCTAssertEqual(created.count, 2, "expected 2 created items")
+				XCTAssertEqual(created[0].itemName, "Extra sunscreen")
+				XCTAssertEqual(created[1].itemName, "Spare hat")
+				XCTAssertTrue(created.allSatisfy { $0.location == "Deck 5" }, "shared location should apply to all")
+				XCTAssertTrue(created.allSatisfy { $0.category == .have }, "shared category should apply to all")
+			}
+
+			// Verify rows persisted.
+			let count = try await QuartermasterItem.query(on: app.db).count()
+			XCTAssertEqual(count, 2, "expected 2 rows in the database")
+		}
+	}
+
+	// MARK: - Test: list
+
+	func testList_Returns200() async throws {
+		try await withApp { app in
+			let user = try await makeUser(app, username: "qm-lister-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let token = try await makeToken(app, for: user)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			try await app.test(.GET, "/api/v3/quartermaster", headers: bearer(token)) { res async throws in
+				XCTAssertEqual(res.status, .ok, "body=\(String(buffer: res.body))")
+				let list = try res.content.decode(QuartermasterListData.self)
+				XCTAssertNotNil(list.paginator)
+			}
+		}
+	}
+
+	// MARK: - Test: category filter
+
+	func testList_CategoryFilter_ReturnsOnlyMatchingCategory() async throws {
+		try await withApp { app in
+			let user = try await makeUser(app, username: "qm-cat-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let token = try await makeToken(app, for: user)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			// Create one "have" and one "need".
+			let havePayload = #"{"category":"have","location":"Deck 5","items":[{"itemName":"Sunscreen"}]}"#
+			let needPayload = #"{"category":"need","location":"Deck 5","items":[{"itemName":"Sunscreen"}]}"#
+			for payload in [havePayload, needPayload] {
+				try await app.test(.POST, "/api/v3/quartermaster/create",
+					headers: contentHeaders(token), body: ByteBuffer(string: payload)) { _ async throws in }
+			}
+
+			try await app.test(.GET, "/api/v3/quartermaster?category=have", headers: bearer(token)) { res async throws in
+				XCTAssertEqual(res.status, .ok)
+				let list = try res.content.decode(QuartermasterListData.self)
+				XCTAssertTrue(list.items.allSatisfy { $0.category == .have },
+					"?category=have should return only 'have' items")
+			}
+		}
+	}
+
+	// MARK: - Test: mine filter
+
+	func testList_MineFilter_ReturnsOnlyCallerItems() async throws {
+		try await withApp { app in
+			let userA = try await makeUser(app, username: "qm-mine-a-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let userB = try await makeUser(app, username: "qm-mine-b-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let tokenA = try await makeToken(app, for: userA)
+			let tokenB = try await makeToken(app, for: userB)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			let payloadA = #"{"category":"have","location":"Lido Deck","items":[{"itemName":"User A item"}]}"#
+			let payloadB = #"{"category":"have","location":"Pool Deck","items":[{"itemName":"User B item"}]}"#
+			try await app.test(.POST, "/api/v3/quartermaster/create",
+				headers: contentHeaders(tokenA), body: ByteBuffer(string: payloadA)) { _ async throws in }
+			try await app.test(.POST, "/api/v3/quartermaster/create",
+				headers: contentHeaders(tokenB), body: ByteBuffer(string: payloadB)) { _ async throws in }
+
+			try await app.test(.GET, "/api/v3/quartermaster?mine=true", headers: bearer(tokenA)) { res async throws in
+				XCTAssertEqual(res.status, .ok)
+				let list = try res.content.decode(QuartermasterListData.self)
+				XCTAssertTrue(list.items.allSatisfy { $0.owner.username == userA.username },
+					"?mine=true should return only the caller's own items, not other users'")
+				XCTAssertFalse(list.items.contains { $0.itemName == "User B item" },
+					"user B's item should not appear in user A's mine list")
+			}
+		}
+	}
+
+	// MARK: - Test: get single item
+
+	func testGet_ExistingItem_Returns200() async throws {
+		try await withApp { app in
+			let user = try await makeUser(app, username: "qm-get-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let token = try await makeToken(app, for: user)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			var createdID: UUID?
+			let payload = #"{"category":"have","location":"Deck 5","items":[{"itemName":"Widget"}]}"#
+			try await app.test(.POST, "/api/v3/quartermaster/create",
+				headers: contentHeaders(token), body: ByteBuffer(string: payload)
+			) { res async throws in
+				let items = try res.content.decode([QuartermasterData].self)
+				createdID = items.first?.itemID
+			}
+
+			guard let id = createdID else { XCTFail("no created ID"); return }
+			try await app.test(.GET, "/api/v3/quartermaster/\(id)", headers: bearer(token)) { res async throws in
+				XCTAssertEqual(res.status, .ok)
+				let item = try res.content.decode(QuartermasterData.self)
+				XCTAssertEqual(item.itemID, id)
+				XCTAssertEqual(item.itemName, "Widget")
+			}
+		}
+	}
+
+	// MARK: - Test: update creates edit record when text changes
+
+	func testUpdate_TextChange_CreatesEditRecord() async throws {
+		try await withApp { app in
+			let user = try await makeUser(app, username: "qm-upd-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let token = try await makeToken(app, for: user)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			var itemID: UUID?
+			let createPayload = #"{"category":"have","location":"Deck 5","items":[{"itemName":"Original name"}]}"#
+			try await app.test(.POST, "/api/v3/quartermaster/create",
+				headers: contentHeaders(token), body: ByteBuffer(string: createPayload)
+			) { res async throws in
+				itemID = try res.content.decode([QuartermasterData].self).first?.itemID
+			}
+			guard let id = itemID else { XCTFail("no item"); return }
+
+			let updatePayload = #"{"category":"have","itemName":"Updated name","location":"Deck 5"}"#
+			try await app.test(.POST, "/api/v3/quartermaster/\(id)/update",
+				headers: contentHeaders(token), body: ByteBuffer(string: updatePayload)
+			) { res async throws in
+				XCTAssertEqual(res.status, .ok, "body=\(String(buffer: res.body))")
+				let updated = try res.content.decode(QuartermasterData.self)
+				XCTAssertEqual(updated.itemName, "Updated name")
+			}
+
+			guard let savedItem = try await QuartermasterItem.find(id, on: app.db) else {
+				XCTFail("item not found after update"); return
+			}
+			try await savedItem.$edits.load(on: app.db)
+			XCTAssertEqual(savedItem.edits.count, 1, "a text change should create a QuartermasterItemEdit")
+		}
+	}
+
+	func testUpdate_CategoryOnlyChange_CreatesNoEditRecord() async throws {
+		try await withApp { app in
+			let user = try await makeUser(app, username: "qm-cat-upd-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let token = try await makeToken(app, for: user)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			var itemID: UUID?
+			let createPayload = #"{"category":"have","location":"Deck 5","items":[{"itemName":"Widget"}]}"#
+			try await app.test(.POST, "/api/v3/quartermaster/create",
+				headers: contentHeaders(token), body: ByteBuffer(string: createPayload)
+			) { res async throws in
+				itemID = try res.content.decode([QuartermasterData].self).first?.itemID
+			}
+			guard let id = itemID else { XCTFail("no item"); return }
+
+			// Only category changes; text fields stay identical.
+			let updatePayload = #"{"category":"need","itemName":"Widget","location":"Deck 5"}"#
+			try await app.test(.POST, "/api/v3/quartermaster/\(id)/update",
+				headers: contentHeaders(token), body: ByteBuffer(string: updatePayload)
+			) { res async throws in
+				XCTAssertEqual(res.status, .ok)
+			}
+
+			guard let savedItem = try await QuartermasterItem.find(id, on: app.db) else {
+				XCTFail("item not found after update"); return
+			}
+			try await savedItem.$edits.load(on: app.db)
+			XCTAssertEqual(savedItem.edits.count, 0, "category-only change must not create a QuartermasterItemEdit")
+		}
+	}
+
+	func testUpdate_ContactUserChange_CreatesEditRecord() async throws {
+		try await withApp { app in
+			let user = try await makeUser(app, username: "qm-cu-upd-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let contact = try await makeUser(app, username: "qm-cu-ct-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let token = try await makeToken(app, for: user)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			var itemID: UUID?
+			let createPayload = #"{"category":"have","location":"Deck 5","items":[{"itemName":"Widget"}]}"#
+			try await app.test(.POST, "/api/v3/quartermaster/create",
+				headers: contentHeaders(token), body: ByteBuffer(string: createPayload)
+			) { res async throws in
+				itemID = try res.content.decode([QuartermasterData].self).first?.itemID
+			}
+			guard let id = itemID else { XCTFail("no item"); return }
+
+			// Only the contact user changes; text fields and category stay identical.
+			let updatePayload = "{\"category\":\"have\",\"itemName\":\"Widget\",\"location\":\"Deck 5\",\"contactUsername\":\"\(contact.username)\"}"
+			try await app.test(.POST, "/api/v3/quartermaster/\(id)/update",
+				headers: contentHeaders(token), body: ByteBuffer(string: updatePayload)
+			) { res async throws in
+				XCTAssertEqual(res.status, .ok)
+			}
+
+			guard let savedItem = try await QuartermasterItem.find(id, on: app.db) else {
+				XCTFail("item not found after update"); return
+			}
+			try await savedItem.$edits.load(on: app.db)
+			XCTAssertEqual(savedItem.edits.count, 1, "a contact user change should create a QuartermasterItemEdit")
+		}
+	}
+
+	// MARK: - Test: delete
+
+	func testDelete_Owner_Succeeds() async throws {
+		try await withApp { app in
+			let user = try await makeUser(app, username: "qm-del-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let token = try await makeToken(app, for: user)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			var itemID: UUID?
+			let createPayload = #"{"category":"have","location":"Deck 5","items":[{"itemName":"Delete me"}]}"#
+			try await app.test(.POST, "/api/v3/quartermaster/create",
+				headers: contentHeaders(token), body: ByteBuffer(string: createPayload)
+			) { res async throws in
+				itemID = try res.content.decode([QuartermasterData].self).first?.itemID
+			}
+			guard let id = itemID else { XCTFail("no item"); return }
+
+			try await app.test(.POST, "/api/v3/quartermaster/\(id)/delete", headers: bearer(token)) { res async throws in
+				XCTAssertEqual(res.status, .noContent)
+			}
+			// Verify the row is soft-deleted (not found without withDeleted).
+			let found = try await QuartermasterItem.find(id, on: app.db)
+			XCTAssertNil(found, "deleted item should not appear in normal queries (soft-delete)")
+		}
+	}
+
+	func testDelete_OtherUserAsNonMod_Returns403() async throws {
+		try await withApp { app in
+			let owner = try await makeUser(app, username: "qm-del-own-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let other = try await makeUser(app, username: "qm-del-oth-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let ownerToken = try await makeToken(app, for: owner)
+			let otherToken = try await makeToken(app, for: other)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			var itemID: UUID?
+			let createPayload = #"{"category":"have","location":"Deck 5","items":[{"itemName":"My item"}]}"#
+			try await app.test(.POST, "/api/v3/quartermaster/create",
+				headers: contentHeaders(ownerToken), body: ByteBuffer(string: createPayload)
+			) { res async throws in
+				itemID = try res.content.decode([QuartermasterData].self).first?.itemID
+			}
+			guard let id = itemID else { XCTFail("no item"); return }
+
+			try await app.test(.POST, "/api/v3/quartermaster/\(id)/delete", headers: bearer(otherToken)) { res async throws in
+				XCTAssertEqual(res.status, .forbidden, "non-owner non-mod must not delete another user's item")
+			}
+		}
+	}
+
+	func testDelete_ModeratorCanDeleteOthers() async throws {
+		try await withApp { app in
+			let owner = try await makeUser(app, username: "qm-del-own2-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let mod = try await makeUser(app, username: "qm-del-mod-\(UUID().uuidString.prefix(6))", accessLevel: .moderator)
+			let ownerToken = try await makeToken(app, for: owner)
+			let modToken = try await makeToken(app, for: mod)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			var itemID: UUID?
+			let createPayload = #"{"category":"have","location":"Deck 5","items":[{"itemName":"Mod target"}]}"#
+			try await app.test(.POST, "/api/v3/quartermaster/create",
+				headers: contentHeaders(ownerToken), body: ByteBuffer(string: createPayload)
+			) { res async throws in
+				itemID = try res.content.decode([QuartermasterData].self).first?.itemID
+			}
+			guard let id = itemID else { XCTFail("no item"); return }
+
+			try await app.test(.POST, "/api/v3/quartermaster/\(id)/delete", headers: bearer(modToken)) { res async throws in
+				XCTAssertEqual(res.status, .noContent, "moderator must be able to delete any item")
+			}
+		}
+	}
+
+	// MARK: - Test: block-list filtering
+
+	func testList_BlockedUserItems_HiddenFromBlocker() async throws {
+		try await withApp { app in
+			let blocker = try await makeUser(app, username: "qm-blk-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let blocked = try await makeUser(app, username: "qm-blkd-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let blockerToken = try await makeToken(app, for: blocker)
+			let blockedToken = try await makeToken(app, for: blocked)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			// Post from the blocked user.
+			let payload = #"{"category":"have","location":"Deck 5","items":[{"itemName":"Should be hidden"}]}"#
+			try await app.test(.POST, "/api/v3/quartermaster/create",
+				headers: contentHeaders(blockedToken), body: ByteBuffer(string: payload)) { _ async throws in }
+
+			// Block that user.
+			let blockedID = try blocked.requireID()
+			try await app.test(.POST, "/api/v3/users/\(blockedID)/block", headers: bearer(blockerToken)) { res async throws in
+				// Accept 200 or 201; just make sure the block request doesn't error.
+				XCTAssertTrue([.ok, .created].contains(res.status),
+					"block request failed: \(res.status)")
+			}
+
+			try await app.test(.GET, "/api/v3/quartermaster", headers: bearer(blockerToken)) { res async throws in
+				XCTAssertEqual(res.status, .ok)
+				let list = try res.content.decode(QuartermasterListData.self)
+				XCTAssertFalse(list.items.contains { $0.itemName == "Should be hidden" },
+					"items from a blocked user must not appear in the list")
+			}
+		}
+	}
+
+	// MARK: - Test: report
+
+	func testReport_Creates201() async throws {
+		try await withApp { app in
+			let owner = try await makeUser(app, username: "qm-rpt-own-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let reporter = try await makeUser(app, username: "qm-rpt-usr-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let ownerToken = try await makeToken(app, for: owner)
+			let reporterToken = try await makeToken(app, for: reporter)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			var itemID: UUID?
+			let createPayload = #"{"category":"have","location":"Deck 5","items":[{"itemName":"Reportable item"}]}"#
+			try await app.test(.POST, "/api/v3/quartermaster/create",
+				headers: contentHeaders(ownerToken), body: ByteBuffer(string: createPayload)
+			) { res async throws in
+				itemID = try res.content.decode([QuartermasterData].self).first?.itemID
+			}
+			guard let id = itemID else { XCTFail("no item"); return }
+
+			let reportPayload = #"{"message":"Inappropriate content"}"#
+			try await app.test(
+				.POST, "/api/v3/quartermaster/\(id)/report",
+				headers: contentHeaders(reporterToken),
+				body: ByteBuffer(string: reportPayload)
+			) { res async throws in
+				XCTAssertEqual(res.status, .created, "report should return 201 Created")
+			}
+
+			// Verify a Report row was created (fresh test DB so any report is from this test).
+			let reports = try await Report.query(on: app.db).all()
+			let quartermasterReports = reports.filter { $0.reportType == .quartermasterItem }
+			XCTAssertEqual(quartermasterReports.count, 1, "filing a report should create one Report row")
+		}
+	}
+
+	// MARK: - Test: create rejects empty batch
+
+	func testCreate_EmptyBatch_Returns400() async throws {
+		try await withApp { app in
+			let user = try await makeUser(app, username: "qm-emp-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let token = try await makeToken(app, for: user)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			let payload = #"{"category":"have","location":"Deck 5","items":[]}"#
+			try await app.test(.POST, "/api/v3/quartermaster/create",
+				headers: contentHeaders(token), body: ByteBuffer(string: payload)
+			) { res async throws in
+				XCTAssertEqual(res.status, .badRequest, "empty items array must be rejected with 400")
+			}
+		}
+	}
+}

--- a/Tests/AppTests/QuartermasterControllerTests.swift
+++ b/Tests/AppTests/QuartermasterControllerTests.swift
@@ -1,3 +1,4 @@
+import Fluent
 import XCTVapor
 @testable import swiftarr
 
@@ -246,10 +247,9 @@ final class QuartermasterControllerTests: XCTestCase, SwiftarrBaseTest {
 			try await app.initializeUserCache(app)
 
 			// Two items in one call sharing location.
-			let items = Array(repeating: #"{"itemName":"Extra sunscreen"},{"itemName":"Spare hat"}"#, count: 1)
-			let _ = items
 			let payload = #"{"category":"have","location":"Deck 5","items":[{"itemName":"Extra sunscreen"},{"itemName":"Spare hat"}]}"#
 
+			var createdIDs: [UUID] = []
 			try await app.test(
 				.POST, "/api/v3/quartermaster/create",
 				headers: contentHeaders(token),
@@ -262,10 +262,12 @@ final class QuartermasterControllerTests: XCTestCase, SwiftarrBaseTest {
 				XCTAssertEqual(created[1].itemName, "Spare hat")
 				XCTAssertTrue(created.allSatisfy { $0.location == "Deck 5" }, "shared location should apply to all")
 				XCTAssertTrue(created.allSatisfy { $0.category == .have }, "shared category should apply to all")
+				createdIDs = created.map { $0.itemID }
 			}
 
-			// Verify rows persisted.
-			let count = try await QuartermasterItem.query(on: app.db).count()
+			// Verify rows persisted (the DB is shared across the test run, so scope by the IDs
+			// this call actually returned rather than counting the whole table).
+			let count = try await QuartermasterItem.query(on: app.db).filter(\.$id ~~ createdIDs).count()
 			XCTAssertEqual(count, 2, "expected 2 rows in the database")
 		}
 	}
@@ -309,6 +311,48 @@ final class QuartermasterControllerTests: XCTestCase, SwiftarrBaseTest {
 				let list = try res.content.decode(QuartermasterListData.self)
 				XCTAssertTrue(list.items.allSatisfy { $0.category == .have },
 					"?category=have should return only 'have' items")
+			}
+		}
+	}
+
+	// MARK: - Test: search filter
+
+	func testList_SearchFilter_MatchesDescription() async throws {
+		try await withApp { app in
+			let user = try await makeUser(app, username: "qm-search-desc-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let token = try await makeToken(app, for: user)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			let payload = #"{"category":"have","location":"Deck 5","items":[{"itemName":"Widget","itemDescription":"a rare narwhal figurine"}]}"#
+			try await app.test(.POST, "/api/v3/quartermaster/create",
+				headers: contentHeaders(token), body: ByteBuffer(string: payload)) { _ async throws in }
+
+			try await app.test(.GET, "/api/v3/quartermaster?search=narwhal", headers: bearer(token)) { res async throws in
+				XCTAssertEqual(res.status, .ok, "body=\(String(buffer: res.body))")
+				let list = try res.content.decode(QuartermasterListData.self)
+				XCTAssertTrue(list.items.contains { $0.itemName == "Widget" },
+					"search=narwhal should match items via itemDescription")
+			}
+		}
+	}
+
+	func testList_SearchFilter_MatchesLocation() async throws {
+		try await withApp { app in
+			let user = try await makeUser(app, username: "qm-search-loc-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let token = try await makeToken(app, for: user)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			let payload = #"{"category":"have","location":"Promenade Deck","items":[{"itemName":"Gadget"}]}"#
+			try await app.test(.POST, "/api/v3/quartermaster/create",
+				headers: contentHeaders(token), body: ByteBuffer(string: payload)) { _ async throws in }
+
+			try await app.test(.GET, "/api/v3/quartermaster?search=promenade", headers: bearer(token)) { res async throws in
+				XCTAssertEqual(res.status, .ok, "body=\(String(buffer: res.body))")
+				let list = try res.content.decode(QuartermasterListData.self)
+				XCTAssertTrue(list.items.contains { $0.itemName == "Gadget" },
+					"search=promenade should match items via location")
 			}
 		}
 	}
@@ -557,9 +601,13 @@ final class QuartermasterControllerTests: XCTestCase, SwiftarrBaseTest {
 			try await app.initializeUserCache(app)
 
 			// Post from the blocked user.
+			var hiddenItemID: UUID?
 			let payload = #"{"category":"have","location":"Deck 5","items":[{"itemName":"Should be hidden"}]}"#
 			try await app.test(.POST, "/api/v3/quartermaster/create",
-				headers: contentHeaders(blockedToken), body: ByteBuffer(string: payload)) { _ async throws in }
+				headers: contentHeaders(blockedToken), body: ByteBuffer(string: payload)) { res async throws in
+				hiddenItemID = try res.content.decode([QuartermasterData].self).first?.itemID
+			}
+			guard let hiddenItemID else { XCTFail("no item"); return }
 
 			// Block that user.
 			let blockedID = try blocked.requireID()
@@ -572,7 +620,9 @@ final class QuartermasterControllerTests: XCTestCase, SwiftarrBaseTest {
 			try await app.test(.GET, "/api/v3/quartermaster", headers: bearer(blockerToken)) { res async throws in
 				XCTAssertEqual(res.status, .ok)
 				let list = try res.content.decode(QuartermasterListData.self)
-				XCTAssertFalse(list.items.contains { $0.itemName == "Should be hidden" },
+				// Match on the ID this test actually created, not the item name: the DB is shared
+				// across the test run, and "Should be hidden" isn't unique to this test.
+				XCTAssertFalse(list.items.contains { $0.itemID == hiddenItemID },
 					"items from a blocked user must not appear in the list")
 			}
 		}
@@ -607,10 +657,13 @@ final class QuartermasterControllerTests: XCTestCase, SwiftarrBaseTest {
 				XCTAssertEqual(res.status, .created, "report should return 201 Created")
 			}
 
-			// Verify a Report row was created (fresh test DB so any report is from this test).
-			let reports = try await Report.query(on: app.db).all()
-			let quartermasterReports = reports.filter { $0.reportType == .quartermasterItem }
-			XCTAssertEqual(quartermasterReports.count, 1, "filing a report should create one Report row")
+			// Verify a Report row was created for this specific item (the DB is shared across the
+			// test run, so scope by reportedID rather than counting all Report rows).
+			let reportCount = try await Report.query(on: app.db)
+				.filter(\.$reportType == .quartermasterItem)
+				.filter(\.$reportedID == id.uuidString)
+				.count()
+			XCTAssertEqual(reportCount, 1, "filing a report should create one Report row")
 		}
 	}
 

--- a/Tests/AppTests/QuartermasterModerationTests.swift
+++ b/Tests/AppTests/QuartermasterModerationTests.swift
@@ -1,0 +1,280 @@
+import Fluent
+import XCTVapor
+@testable import swiftarr
+
+// Tests for Quartermaster Phase 3: moderation integration.
+//
+// Uses SwiftarrBaseTest and a live Postgres instance (port 5433) plus Redis (port 6380), in the
+// same way as QuartermasterControllerTests and ForumQuarantineVisibilityTests. There were no
+// tests against any /api/v3/mod/* route before this file -- these are the first.
+
+final class QuartermasterModerationTests: XCTestCase, SwiftarrBaseTest {
+
+	// MARK: - Helpers
+
+	private func makeUser(_ app: Application, username: String, accessLevel: UserAccessLevel) async throws -> User {
+		let user = User(
+			username: username,
+			password: try Bcrypt.hash("password1"),
+			recoveryKey: try Bcrypt.hash("recovery key"),
+			accessLevel: accessLevel
+		)
+		try await user.save(on: app.db)
+		return user
+	}
+
+	private func makeToken(_ app: Application, for user: User) async throws -> String {
+		let token = try Token.generate(for: user)
+		try await token.save(on: app.db)
+		return token.token
+	}
+
+	private func bearer(_ token: String) -> HTTPHeaders {
+		var headers = HTTPHeaders()
+		headers.bearerAuthorization = BearerAuthorization(token: token)
+		return headers
+	}
+
+	private func contentHeaders(_ token: String) -> HTTPHeaders {
+		var headers = bearer(token)
+		headers.contentType = .json
+		return headers
+	}
+
+	/// Creates one item owned by `token`, returning its ID.
+	private func createItem(_ app: Application, token: String, itemName: String = "Widget") async throws -> UUID {
+		let payload = "{\"category\":\"have\",\"location\":\"Deck 5\",\"items\":[{\"itemName\":\"\(itemName)\"}]}"
+		var itemID: UUID?
+		try await app.test(
+			.POST, "/api/v3/quartermaster/create",
+			headers: contentHeaders(token), body: ByteBuffer(string: payload)
+		) { res async throws in
+			itemID = try res.content.decode([QuartermasterData].self).first?.itemID
+		}
+		guard let id = itemID else { XCTFail("failed to create fixture item"); throw Abort(.internalServerError) }
+		return id
+	}
+
+	// MARK: - GET /api/v3/mod/quartermaster/:id
+
+	func testModGet_ReturnsItemReportsAndEdits() async throws {
+		try await withApp { app in
+			let owner = try await makeUser(app, username: "qm-mg-own-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let reporter = try await makeUser(app, username: "qm-mg-rpt-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let moderator = try await makeUser(app, username: "qm-mg-mod-\(UUID().uuidString.prefix(6))", accessLevel: .moderator)
+			let ownerToken = try await makeToken(app, for: owner)
+			let reporterToken = try await makeToken(app, for: reporter)
+			let modToken = try await makeToken(app, for: moderator)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			let id = try await createItem(app, token: ownerToken, itemName: "Original name")
+
+			// One text edit.
+			let updatePayload = #"{"category":"have","itemName":"Updated name","location":"Deck 5"}"#
+			try await app.test(.POST, "/api/v3/quartermaster/\(id)/update",
+				headers: contentHeaders(ownerToken), body: ByteBuffer(string: updatePayload)
+			) { res async throws in
+				XCTAssertEqual(res.status, .ok, "body=\(String(buffer: res.body))")
+			}
+
+			// One report.
+			let reportPayload = #"{"message":"Inappropriate content"}"#
+			try await app.test(.POST, "/api/v3/quartermaster/\(id)/report",
+				headers: contentHeaders(reporterToken), body: ByteBuffer(string: reportPayload)
+			) { res async throws in
+				XCTAssertEqual(res.status, .created)
+			}
+
+			try await app.test(.GET, "/api/v3/mod/quartermaster/\(id)", headers: bearer(modToken)) { res async throws in
+				XCTAssertEqual(res.status, .ok, "body=\(String(buffer: res.body))")
+				let modData = try res.content.decode(QuartermasterModerationData.self)
+				XCTAssertEqual(modData.item.itemID, id)
+				XCTAssertFalse(modData.isDeleted)
+				XCTAssertEqual(modData.edits.count, 1, "the text update should show up as one edit")
+				XCTAssertEqual(modData.edits.first?.itemName, "Original name", "edit log stores the pre-edit text")
+				XCTAssertEqual(modData.reports.count, 1)
+				XCTAssertEqual(modData.reports.first?.submitterMessage, "Inappropriate content")
+			}
+		}
+	}
+
+	func testModGet_SeesQuarantinedTextUnmasked() async throws {
+		try await withApp { app in
+			let owner = try await makeUser(app, username: "qm-mq-own-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let moderator = try await makeUser(app, username: "qm-mq-mod-\(UUID().uuidString.prefix(6))", accessLevel: .moderator)
+			let ownerToken = try await makeToken(app, for: owner)
+			let modToken = try await makeToken(app, for: moderator)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			let id = try await createItem(app, token: ownerToken, itemName: "Secret widget")
+
+			guard let item = try await QuartermasterItem.find(id, on: app.db) else {
+				XCTFail("item not found"); return
+			}
+			item.moderationStatus = .quarantined
+			try await item.save(on: app.db)
+
+			try await app.test(.GET, "/api/v3/mod/quartermaster/\(id)", headers: bearer(modToken)) { res async throws in
+				let modData = try res.content.decode(QuartermasterModerationData.self)
+				XCTAssertEqual(modData.item.itemName, "Secret widget", "a moderator must see quarantined text unmasked")
+			}
+
+			try await app.test(.GET, "/api/v3/quartermaster/\(id)", headers: bearer(ownerToken)) { res async throws in
+				let itemData = try res.content.decode(QuartermasterData.self)
+				XCTAssertEqual(itemData.itemName, "Item name is under moderator review", "quarantine must still mask text for non-mods")
+			}
+		}
+	}
+
+	func testModGet_DeletedItem_StillVisible() async throws {
+		try await withApp { app in
+			let owner = try await makeUser(app, username: "qm-md-own-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let moderator = try await makeUser(app, username: "qm-md-mod-\(UUID().uuidString.prefix(6))", accessLevel: .moderator)
+			let ownerToken = try await makeToken(app, for: owner)
+			let modToken = try await makeToken(app, for: moderator)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			let id = try await createItem(app, token: ownerToken)
+
+			try await app.test(.POST, "/api/v3/quartermaster/\(id)/delete", headers: bearer(ownerToken)) { res async throws in
+				XCTAssertEqual(res.status, .noContent)
+			}
+
+			try await app.test(.GET, "/api/v3/mod/quartermaster/\(id)", headers: bearer(modToken)) { res async throws in
+				XCTAssertEqual(res.status, .ok, "mods must be able to review deleted items")
+				let modData = try res.content.decode(QuartermasterModerationData.self)
+				XCTAssertTrue(modData.isDeleted)
+			}
+		}
+	}
+
+	func testModGet_UnknownID_Returns404() async throws {
+		try await withApp { app in
+			let moderator = try await makeUser(app, username: "qm-mu-mod-\(UUID().uuidString.prefix(6))", accessLevel: .moderator)
+			let modToken = try await makeToken(app, for: moderator)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			try await app.test(.GET, "/api/v3/mod/quartermaster/\(UUID())", headers: bearer(modToken)) { res async throws in
+				XCTAssertEqual(res.status, .notFound)
+			}
+		}
+	}
+
+	func testModGet_NonModerator_Rejected() async throws {
+		try await withApp { app in
+			let owner = try await makeUser(app, username: "qm-mn-own-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let ownerToken = try await makeToken(app, for: owner)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			let id = try await createItem(app, token: ownerToken)
+
+			try await app.test(.GET, "/api/v3/mod/quartermaster/\(id)", headers: bearer(ownerToken)) { res async throws in
+				XCTAssertTrue(res.status == .forbidden || res.status == .unauthorized, "status=\(res.status)")
+			}
+		}
+	}
+
+	// MARK: - POST /api/v3/mod/quartermaster/:id/setstate/:state
+
+	func testSetState_Quarantine_MasksForRegularUser() async throws {
+		try await withApp { app in
+			let owner = try await makeUser(app, username: "qm-sq-own-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let moderator = try await makeUser(app, username: "qm-sq-mod-\(UUID().uuidString.prefix(6))", accessLevel: .moderator)
+			let ownerToken = try await makeToken(app, for: owner)
+			let modToken = try await makeToken(app, for: moderator)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			let id = try await createItem(app, token: ownerToken, itemName: "Flagged widget")
+
+			try await app.test(
+				.POST, "/api/v3/mod/quartermaster/\(id)/setstate/quarantined", headers: bearer(modToken)
+			) { res async throws in
+				XCTAssertEqual(res.status, .ok, "body=\(String(buffer: res.body))")
+			}
+
+			try await app.test(.GET, "/api/v3/quartermaster/\(id)", headers: bearer(ownerToken)) { res async throws in
+				let itemData = try res.content.decode(QuartermasterData.self)
+				XCTAssertEqual(itemData.itemName, "Item name is under moderator review")
+			}
+
+			try await app.test(.GET, "/api/v3/mod/quartermaster/\(id)", headers: bearer(modToken)) { res async throws in
+				let modData = try res.content.decode(QuartermasterModerationData.self)
+				XCTAssertEqual(modData.item.itemName, "Flagged widget", "mods still see the real text after quarantine")
+				XCTAssertEqual(modData.moderationStatus, .quarantined)
+			}
+
+			let actionCount = try await ModeratorAction.query(on: app.db)
+				.filter(\.$contentType == .quartermasterItem)
+				.filter(\.$contentID == id.uuidString)
+				.filter(\.$actionType == .quarantine)
+				.count()
+			XCTAssertEqual(actionCount, 1, "quarantining should log one ModeratorAction")
+		}
+	}
+
+	func testSetState_Reviewed_SetsModReviewed() async throws {
+		try await withApp { app in
+			let owner = try await makeUser(app, username: "qm-sr-own-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let moderator = try await makeUser(app, username: "qm-sr-mod-\(UUID().uuidString.prefix(6))", accessLevel: .moderator)
+			let ownerToken = try await makeToken(app, for: owner)
+			let modToken = try await makeToken(app, for: moderator)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			let id = try await createItem(app, token: ownerToken)
+
+			try await app.test(
+				.POST, "/api/v3/mod/quartermaster/\(id)/setstate/reviewed", headers: bearer(modToken)
+			) { res async throws in
+				XCTAssertEqual(res.status, .ok, "body=\(String(buffer: res.body))")
+			}
+
+			guard let item = try await QuartermasterItem.find(id, on: app.db) else {
+				XCTFail("item not found"); return
+			}
+			XCTAssertEqual(item.moderationStatus, .modReviewed)
+		}
+	}
+
+	func testSetState_InvalidState_Returns400() async throws {
+		try await withApp { app in
+			let owner = try await makeUser(app, username: "qm-si-own-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let moderator = try await makeUser(app, username: "qm-si-mod-\(UUID().uuidString.prefix(6))", accessLevel: .moderator)
+			let ownerToken = try await makeToken(app, for: owner)
+			let modToken = try await makeToken(app, for: moderator)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			let id = try await createItem(app, token: ownerToken)
+
+			try await app.test(
+				.POST, "/api/v3/mod/quartermaster/\(id)/setstate/bogus", headers: bearer(modToken)
+			) { res async throws in
+				XCTAssertEqual(res.status, .badRequest)
+			}
+		}
+	}
+
+	func testSetState_NonModerator_Rejected() async throws {
+		try await withApp { app in
+			let owner = try await makeUser(app, username: "qm-sn-own-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let ownerToken = try await makeToken(app, for: owner)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			let id = try await createItem(app, token: ownerToken)
+
+			try await app.test(
+				.POST, "/api/v3/mod/quartermaster/\(id)/setstate/quarantined", headers: bearer(ownerToken)
+			) { res async throws in
+				XCTAssertTrue(res.status == .forbidden || res.status == .unauthorized, "status=\(res.status)")
+			}
+		}
+	}
+}

--- a/Tests/AppTests/QuartermasterSchemaTests.swift
+++ b/Tests/AppTests/QuartermasterSchemaTests.swift
@@ -12,18 +12,23 @@ class QuartermasterSchemaTests: XCTestCase, SwiftarrBaseTest {
 
 	/// Verifies that the new migrations apply cleanly: if the app boots and autoMigrate()
 	/// succeeds inside withApp, the quartermaster_item table exists.
+	///
+	/// The test DB is shared across the whole test run (not reset per-test), so this can't assert
+	/// the table is empty -- it only asserts the table is queryable, which is proof enough that the
+	/// migration created it (a query against a missing table throws before returning).
 	func testSchema_TablesExistAfterMigration() async throws {
 		try await withApp { app in
 			let count = try await QuartermasterItem.query(on: app.db).count()
-			XCTAssertEqual(count, 0, "Expected empty quartermaster_item table after migration")
+			XCTAssertGreaterThanOrEqual(count, 0, "Expected quartermaster_item table to exist and be queryable after migration")
 		}
 	}
 
-	/// Verifies the edit table also exists.
+	/// Verifies the edit table also exists. See `testSchema_TablesExistAfterMigration` for why this
+	/// doesn't assert emptiness.
 	func testSchema_EditTableExistsAfterMigration() async throws {
 		try await withApp { app in
 			let count = try await QuartermasterItemEdit.query(on: app.db).count()
-			XCTAssertEqual(count, 0, "Expected empty quartermaster_item_edit table after migration")
+			XCTAssertGreaterThanOrEqual(count, 0, "Expected quartermaster_item_edit table to exist and be queryable after migration")
 		}
 	}
 

--- a/Tests/AppTests/QuartermasterSchemaTests.swift
+++ b/Tests/AppTests/QuartermasterSchemaTests.swift
@@ -1,0 +1,84 @@
+import XCTVapor
+@testable import swiftarr
+
+// Tests for the Quartermaster Phase 1 schema foundation.
+//
+// The DB-touching tests (table existence) rely on SwiftarrBaseTest which runs autoMigrate()
+// against the test Postgres instance (port 5433). The pure-Swift tests (enum round-trips,
+// feature flag) don't need a live DB and are plain XCTestCase functions.
+class QuartermasterSchemaTests: XCTestCase, SwiftarrBaseTest {
+
+	// MARK: - Schema / boot
+
+	/// Verifies that the new migrations apply cleanly: if the app boots and autoMigrate()
+	/// succeeds inside withApp, the quartermaster_item table exists.
+	func testSchema_TablesExistAfterMigration() async throws {
+		try await withApp { app in
+			let count = try await QuartermasterItem.query(on: app.db).count()
+			XCTAssertEqual(count, 0, "Expected empty quartermaster_item table after migration")
+		}
+	}
+
+	/// Verifies the edit table also exists.
+	func testSchema_EditTableExistsAfterMigration() async throws {
+		try await withApp { app in
+			let count = try await QuartermasterItemEdit.query(on: app.db).count()
+			XCTAssertEqual(count, 0, "Expected empty quartermaster_item_edit table after migration")
+		}
+	}
+
+	// MARK: - Feature flag
+
+	func testFeatureFlag_RawValueDecodes() {
+		XCTAssertEqual(SwiftarrFeature(rawValue: "quartermaster"), .quartermaster)
+	}
+
+	func testFeatureFlag_PresentInAllCases() {
+		XCTAssertTrue(SwiftarrFeature.allCases.contains(.quartermaster),
+			"quartermaster must appear in CaseIterable so admin UI can enable/disable it")
+	}
+
+	// MARK: - ReportType round-trip
+
+	func testReportType_QuartermasterItemRoundTrips() throws {
+		let encoder = JSONEncoder()
+		let decoder = JSONDecoder()
+		let data = try encoder.encode(ReportType.quartermasterItem)
+		let decoded = try decoder.decode(ReportType.self, from: data)
+		XCTAssertEqual(decoded, .quartermasterItem)
+	}
+
+	func testReportType_QuartermasterItemRawValue() {
+		XCTAssertEqual(ReportType.quartermasterItem.rawValue, "quartermasterItem")
+	}
+
+	// MARK: - QuartermasterCategory
+
+	func testCategory_HaveFromAPIString() throws {
+		XCTAssertEqual(try QuartermasterCategory.fromAPIString("have"), .have)
+	}
+
+	func testCategory_NeedFromAPIString() throws {
+		XCTAssertEqual(try QuartermasterCategory.fromAPIString("need"), .need)
+	}
+
+	func testCategory_CaseInsensitive() throws {
+		XCTAssertEqual(try QuartermasterCategory.fromAPIString("HAVE"), .have)
+		XCTAssertEqual(try QuartermasterCategory.fromAPIString("Need"), .need)
+	}
+
+	func testCategory_UnknownThrows() {
+		XCTAssertThrowsError(try QuartermasterCategory.fromAPIString("want")) { error in
+			guard let abortError = error as? Abort else {
+				XCTFail("Expected Abort error, got \(type(of: error))")
+				return
+			}
+			XCTAssertEqual(abortError.status, .badRequest)
+		}
+	}
+
+	func testCategory_Labels() {
+		XCTAssertEqual(QuartermasterCategory.have.label, "Have")
+		XCTAssertEqual(QuartermasterCategory.need.label, "Need")
+	}
+}


### PR DESCRIPTION
Wires Quartermaster items into the standard moderation flow: adds a moderator-facing content view and action endpoints to `ModerationController`, along with the supporting DTOs in `ModeratorControllerStructs`. This gives mods the same visibility and controls over Quartermaster items that other reportable content types already have.

Covered by a new `QuartermasterModerationTests` suite.

Stacked on #570 (core CRUD API) — this diff will include phases 1-2's changes until that PR merges, then shrink to just the moderation layer. Part 3 of 4; please merge in order.