### PR TITLE
ci: pin mustache to 1.1.2 so the docs job stops failing

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -15,7 +15,15 @@ jobs:
           apt-get update && apt-get install -y --no-install-recommends \
             libvips-dev pkg-config ruby-full build-essential git
       - name: Install Jazzy
-        run: gem install jazzy --no-document
+        # mustache 1.1.3 (released 2026-08-20) rewrote template_path= to expect a String or
+        # Array; jazzy 0.15.4 hands it a Pathname, so `jazzy` aborts before it renders a page:
+        # "undefined method `map' for #<Pathname:...>". jazzy allows `mustache ~> 1.1`, so an
+        # unpinned install picks 1.1.3 and every docs run fails. Install 1.1.2 first; the
+        # resolver leaves an already-satisfied dependency alone. Drop the pin once jazzy ships
+        # a release that passes a String.
+        run: |
+          gem install mustache -v 1.1.2 --no-document
+          gem install jazzy --no-document
       - name: Install SourceKitten
         run: |
           git clone --depth 1 https://github.com/jpsim/SourceKitten.git /tmp/sourcekitten


### PR DESCRIPTION
## What broke

`mustache` **1.1.3** was published today, 2026-08-20. It rewrote `template_path=` to run its argument through a new `setup_path`, which splits a `String` on the path separator and calls `.map` on anything else:

```ruby
def self.setup_path path
  path = path.split(File::PATH_SEPARATOR) if path.is_a? String
  path.map{|p| File.expand_path(p)}
end
```

In 1.1.2 the same setter was just `File.expand_path(path)`, which accepts a `Pathname`.

jazzy 0.15.4's `theme_directory=` passes a `Pathname`, so `jazzy` now dies before rendering a page:

```
mustache-1.1.3/lib/mustache/settings.rb:47:in `setup_path':
undefined method `map' for #<Pathname:/var/lib/gems/3.2.0/gems/jazzy-0.15.4/lib/jazzy/themes/apple/templates> (NoMethodError)
    path.map{|p| File.expand_path(p)}
```

jazzy declares `mustache ~> 1.1`, so the unpinned `gem install jazzy` in this workflow picks up 1.1.3 and the Generate Documentation job fails on every PR and every push to `master`.

Same branch, no workflow or source change in between:

| Run | Result |
| --- | --- |
| 2026-08-19 11:22 | success |
| 2026-08-20 12:08 | failure, at `Generate Docs` |

## The fix

Install `mustache 1.1.2` before jazzy. RubyGems leaves an already-satisfied dependency alone, so jazzy resolves against 1.1.2 and never fetches 1.1.3.

I checked that claim rather than assuming it, using a gem with the same loose requirement (`mustache ~> 1.0`):

- Preinstall 1.1.2, then install the dependent gem → `mustache (1.1.2)`, unchanged.
- Control, clean `GEM_HOME`, no preinstall → `mustache (1.1.3)` installed.

The comment in the workflow says why the pin exists and when to drop it, so it does not become permanent by accident. This is a workaround in the right place: the actual bug is jazzy passing a `Pathname`, or mustache 1.1.3 no longer accepting one, and neither is yours to fix.

The docs job is the only place this repository installs jazzy, so nothing else needs the pin.
