### PR TITLE
Password Reset Enhancements

### DIFF
--- a/Sources/swiftarr/Controllers/AdminController.swift
+++ b/Sources/swiftarr/Controllers/AdminController.swift
@@ -422,9 +422,7 @@ struct AdminController: APIRouteCollection {
 		let user = try await User.findFromParameter(userIDParam, on: req)
 		let allAccounts = try await user.allAccounts(on: req.db)
 		for account in allAccounts {
-			if let verification = account.verification, verification.hasPrefix("*") {
-				account.verification = String(verification.dropFirst())
-			}
+			account.unlockVerification()
 			account.recoveryAttempts = 0
 			try await account.save(on: req.db)
 		}
@@ -442,7 +440,7 @@ struct AdminController: APIRouteCollection {
 		let regCodeResult = try await RegistrationCode.query(on: req.db).filter(\.$user.$id ~~ userIDs).first()
 		let regCode = regCodeResult?.code ?? ""
 		let resultUsers = req.userCache.getHeaders(userIDs)
-		let hasUsed = allAccounts.contains { $0.verification?.hasPrefix("*") == true }
+		let hasUsed = allAccounts.contains { $0.verificationUsed }
 		return RegistrationCodeUserData(
 			users: resultUsers,
 			regCode: regCode,

--- a/Sources/swiftarr/Controllers/AdminController.swift
+++ b/Sources/swiftarr/Controllers/AdminController.swift
@@ -17,6 +17,13 @@ struct AdminController: APIRouteCollection {
 		// Open routes with no auth requirements
 		adminRoutes.get("timezonechanges", use: timeZoneChangeHandler).setUsedForPreregistration()
 
+		// endpoints available to TwitarrTeam and above, or users with the Account Manager role
+		let accountMgrAuthGroup = adminRoutes.tokenRoutes(minAccess: .verified)
+		accountMgrAuthGroup.get("regcodes", "stats", use: regCodeStatsHandler)
+		accountMgrAuthGroup.get("regcodes", "find", searchStringParam, use: userForRegCodeHandler)
+		accountMgrAuthGroup.get("regcodes", "findbyuser", userIDParam, use: regCodeForUserHandler)
+		accountMgrAuthGroup.post("regcodes", "unlock", userIDParam, use: unlockRegCodeHandler)
+
 		// endpoints available to TwitarrTeam and above
 		let ttAuthGroup = adminRoutes.tokenRoutes(minAccess: .twitarrteam)
 		ttAuthGroup.post("schedule", "update", use: scheduleUploadPostHandler)
@@ -26,9 +33,6 @@ struct AdminController: APIRouteCollection {
 		ttAuthGroup.get("schedule", "viewlog", scheduleLogIDParam, use: scheduleGetLogEntryHandler)
 		ttAuthGroup.post("schedule", "reload", use: reloadScheduleHandler)
 
-		ttAuthGroup.get("regcodes", "stats", use: regCodeStatsHandler)
-		ttAuthGroup.get("regcodes", "find", searchStringParam, use: userForRegCodeHandler)
-		ttAuthGroup.get("regcodes", "findbyuser", userIDParam, use: regCodeForUserHandler)
 		ttAuthGroup.get("regcodes", "discord", "allocate", searchStringParam, use: assignDiscordRegCode)
 
 		ttAuthGroup.get("serversettings", use: settingsHandler)
@@ -344,6 +348,7 @@ struct AdminController: APIRouteCollection {
 	///
 	/// - Returns: `RegistrationCodeStatsData`
 	func regCodeStatsHandler(_ req: Request) async throws -> RegistrationCodeStatsData {
+		try req.auth.require(UserCacheData.self).guardCanManageAccounts()
 		let codeCount = try await RegistrationCode.query(on: req.db).filter(\.$isDiscordUser == false).count()
 		let usedCodes = try await RegistrationCode.query(on: req.db).filter(\.$isDiscordUser == false).filter(\.$user.$id != nil).count()
 		let allocatedDiscord = try await RegistrationCode.query(on: req.db).filter(\.$isDiscordUser == true).count()
@@ -369,6 +374,7 @@ struct AdminController: APIRouteCollection {
 	/// - Returns: [] if no user has created an account using this reg code yet. If they have, returns an array containing the UserHeaders of all users associated with
 	/// the registration code. The first item in the array will be the primary account.
 	func userForRegCodeHandler(_ req: Request) async throws -> [UserHeader] {
+		try req.auth.require(UserCacheData.self).guardCanManageAccounts()
 		guard let regCode = req.parameters.get(searchStringParam.paramString, as: String.self)?.lowercased() else {
 			throw Abort(.badRequest, reason: "Missing search parameter")
 		}
@@ -395,14 +401,54 @@ struct AdminController: APIRouteCollection {
 	/// - Throws: 400 Bad Request if the userID isn't found in the db or if it's malformed.
 	/// - Returns: [] if no user has created an account using this reg code yet. If they have, returns a one-item array containing the UserHeader of that user.
 	func regCodeForUserHandler(_ req: Request) async throws -> RegistrationCodeUserData {
+		try req.auth.require(UserCacheData.self).guardCanManageAccounts()
 		let user = try await User.findFromParameter(userIDParam, on: req)
+		return try await registrationCodeUserData(for: user, on: req)
+	}
+
+	/// `POST /api/v3/admin/regcodes/unlock/:userID`
+	///
+	/// Re-enables one-time password recovery via registration code for the given user and all of their alt accounts.
+	/// Strips the '*' prefix from `User.verification` (see `AuthController.recoveryHandler`) and clears
+	/// `recoveryAttempts` so a lockout after 5 failed recoveries can be reset by staff.
+	///
+	/// - Throws: 403 if the caller is not TwitarrTeam or an Account Manager. 400 if the userID is missing or unknown.
+	/// - Returns: Updated `RegistrationCodeUserData`.
+	func unlockRegCodeHandler(_ req: Request) async throws -> RegistrationCodeUserData {
+		let cacheUser = try req.auth.require(UserCacheData.self)
+		try cacheUser.guardCanManageAccounts()
+		let user = try await User.findFromParameter(userIDParam, on: req)
+		let allAccounts = try await user.allAccounts(on: req.db)
+		for account in allAccounts {
+			if let verification = account.verification, verification.hasPrefix("*") {
+				account.verification = String(verification.dropFirst())
+			}
+			account.recoveryAttempts = 0
+			try await account.save(on: req.db)
+		}
+		let targetUserID = try user.requireID()
+		req.logger.info(
+			"User \(cacheUser.username) (\(cacheUser.userID)) unlocked password recovery for \(user.username) (\(targetUserID))"
+		)
+		return try await registrationCodeUserData(for: user, on: req)
+	}
+
+	/// Builds `RegistrationCodeUserData` for a user (primary plus alts).
+	func registrationCodeUserData(for user: User, on req: Request) async throws -> RegistrationCodeUserData {
 		let allAccounts = try await user.allAccounts(on: req.db)
 		let userIDs = try allAccounts.map { try $0.requireID() }
 		let regCodeResult = try await RegistrationCode.query(on: req.db).filter(\.$user.$id ~~ userIDs).first()
 		let regCode = regCodeResult?.code ?? ""
 		let resultUsers = req.userCache.getHeaders(userIDs)
-		return RegistrationCodeUserData(users: resultUsers, regCode: regCode, isForDiscordUser: regCodeResult?.isDiscordUser ?? false,
-				discordUsername: regCodeResult?.discordUsername)
+		let hasUsed = allAccounts.contains { $0.verification?.hasPrefix("*") == true }
+		return RegistrationCodeUserData(
+			users: resultUsers,
+			regCode: regCode,
+			isForDiscordUser: regCodeResult?.isDiscordUser ?? false,
+			discordUsername: regCodeResult?.discordUsername,
+			hasUsedRegCodeForPasswordRecovery: hasUsed,
+			accountCreatedAt: allAccounts.first?.createdAt
+		)
 	}
 	
 	/// `POST /api/v3/admin/regcodes/discord/allocate/:username`
@@ -428,7 +474,14 @@ struct AdminController: APIRouteCollection {
 		}
 		registrationCode.discordUsername = discordUser
 		try await registrationCode.save(on: req.db)
-		return RegistrationCodeUserData(users: [], regCode: registrationCode.code, isForDiscordUser: true, discordUsername: discordUser)
+		return RegistrationCodeUserData(
+			users: [],
+			regCode: registrationCode.code,
+			isForDiscordUser: true,
+			discordUsername: discordUser,
+			hasUsedRegCodeForPasswordRecovery: false,
+			accountCreatedAt: nil
+		)
 	}
 
 	// MARK: - Promote/Demote

--- a/Sources/swiftarr/Controllers/AdminController.swift
+++ b/Sources/swiftarr/Controllers/AdminController.swift
@@ -375,12 +375,14 @@ struct AdminController: APIRouteCollection {
 	/// the registration code. The first item in the array will be the primary account.
 	func userForRegCodeHandler(_ req: Request) async throws -> [UserHeader] {
 		try req.auth.require(UserCacheData.self).guardCanManageAccounts()
-		guard let regCode = req.parameters.get(searchStringParam.paramString, as: String.self)?.lowercased() else {
+		guard let rawCode = req.parameters.get(searchStringParam.paramString, as: String.self) else {
 			throw Abort(.badRequest, reason: "Missing search parameter")
 		}
-		guard regCode.count == 6, regCode.allSatisfy({ $0.isLetter || $0.isNumber }) else {
+		let decoded = rawCode.removingPercentEncoding ?? rawCode
+		guard RegistrationCode.isWellFormed(decoded) else {
 			throw Abort(.badRequest, reason: "Registration code search parameter is malformed.")
 		}
+		let regCode = RegistrationCode.normalized(decoded)
 		guard let foundRecord = try await RegistrationCode.query(on: req.db).filter(\.$code == regCode).first() else {
 			throw Abort(.badRequest, reason: "\(regCode) is not found in the registration code table.")
 		}

--- a/Sources/swiftarr/Controllers/AuthController.swift
+++ b/Sources/swiftarr/Controllers/AuthController.swift
@@ -101,7 +101,8 @@ struct AuthController: APIRouteCollection {
 		// see `UserRecoveryData.validations()`
 		let data = try ValidatingJSONDecoder().decode(UserRecoveryData.self, fromBodyOf: req)
 		// find data.username user
-		guard let user = try await User.query(on: req.db).filter(\.$username, .custom("ilike"), data.username).first() else {
+		guard let user = try await User.query(on: req.db).filter(\.$username, .custom("ilike"), data.username).first()
+		else {
 			throw Abort(.badRequest, reason: "username \"\(data.username)\" not found")
 		}
 		// no login for punks
@@ -120,7 +121,10 @@ struct AuthController: APIRouteCollection {
 			// A 6-character alphanumeric key is a registration code, not a password or recovery key.
 			// Spent codes are stored with a '*' prefix on User.verification; do not fall through.
 			if user.verificationUsed {
-				throw Abort(.badRequest, reason: "account must be recovered using the recovery key")
+				throw Abort(
+					.badRequest,
+					reason: "account must be recovered using the recovery key or an account manager"
+				)
 			}
 			let normalizedKey = RegistrationCode.normalized(data.recoveryKey)
 			if let stored = user.unspentVerification,

--- a/Sources/swiftarr/Controllers/AuthController.swift
+++ b/Sources/swiftarr/Controllers/AuthController.swift
@@ -119,16 +119,15 @@ struct AuthController: APIRouteCollection {
 		if RegistrationCode.isWellFormed(data.recoveryKey) {
 			// A 6-character alphanumeric key is a registration code, not a password or recovery key.
 			// Spent codes are stored with a '*' prefix on User.verification; do not fall through.
-			if let verification = user.verification, verification.hasPrefix("*") {
+			if user.verificationUsed {
 				throw Abort(.badRequest, reason: "account must be recovered using the recovery key")
 			}
 			let normalizedKey = RegistrationCode.normalized(data.recoveryKey)
-			if let verification = user.verification {
-				let storedCode = RegistrationCode.normalized(verification)
-				if normalizedKey == storedCode {
-					foundMatch = true
-					user.verification = "*" + storedCode
-				}
+			if let stored = user.unspentVerification,
+				RegistrationCode.normalized(stored) == normalizedKey
+			{
+				foundMatch = true
+				user.markVerificationUsed()
 			}
 		}
 		else {

--- a/Sources/swiftarr/Controllers/AuthController.swift
+++ b/Sources/swiftarr/Controllers/AuthController.swift
@@ -113,27 +113,23 @@ struct AuthController: APIRouteCollection {
 			throw Abort(.forbidden, reason: "please see a Twit-arr Team member for password recovery")
 		}
 
-		// registration codes and recovery keys are normalized prior to storage
-		let normalizedKey = data.recoveryKey.lowercased().replacingOccurrences(of: " ", with: "")
-
-		// protect against ping-pong attack from compromised registration code...
-		// if the code being sent normalizes to 6 characters, it is most likely a
-		// registration code, so abort if it's already been used
-		if normalizedKey.count == 6 {
-			guard user.verification?.first != "*" else {
+		// Registration codes are normalized (lowercase, all whitespace stripped) prior to storage.
+		// Recovery keys are hashed after ASCII spaces are removed; passwords are matched as typed.
+		var foundMatch = false
+		if RegistrationCode.isWellFormed(data.recoveryKey) {
+			// A 6-character alphanumeric key is a registration code, not a password or recovery key.
+			// Spent codes are stored with a '*' prefix on User.verification; do not fall through.
+			if let verification = user.verification, verification.hasPrefix("*") {
 				throw Abort(.badRequest, reason: "account must be recovered using the recovery key")
 			}
-		}
-
-		// attempt data.recoveryKey match
-		var foundMatch = false
-		// A spent registration code is disabled by prefixing its stored `verification` with '*'.
-		// Only match an unspent verification, so the marked value ("*code") can't be replayed to
-		// reuse a spent code -- the password/recoveryKey paths below still accept any input.
-		if let verification = user.verification, !verification.hasPrefix("*"), normalizedKey == verification {
-			foundMatch = true
-			// prevent .verification from being used again
-			user.verification = "*" + verification
+			let normalizedKey = RegistrationCode.normalized(data.recoveryKey)
+			if let verification = user.verification {
+				let storedCode = RegistrationCode.normalized(verification)
+				if normalizedKey == storedCode {
+					foundMatch = true
+					user.verification = "*" + storedCode
+				}
+			}
 		}
 		else {
 			// password and recoveryKey require hash verification
@@ -142,8 +138,9 @@ struct AuthController: APIRouteCollection {
 				foundMatch = true
 			}
 			else {
-				// user.recoveryKey is normalized prior to hashing
-				if try verifier.verify(normalizedKey, created: user.recoveryKey) {
+				// user.recoveryKey is hashed from the 3-word key with ASCII spaces removed
+				let normalizedRecoveryKey = data.recoveryKey.lowercased().replacingOccurrences(of: " ", with: "")
+				if try verifier.verify(normalizedRecoveryKey, created: user.recoveryKey) {
 					foundMatch = true
 				}
 			}

--- a/Sources/swiftarr/Controllers/Structs/AdminControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/AdminControllerStructs.swift
@@ -329,6 +329,11 @@ public struct RegistrationCodeUserData: Content {
 	var isForDiscordUser: Bool
 	/// If this reg code has been allocated to a Discord user, the name of the user. Nil if not a Discord regcode or if not yet allocated.
 	var discordUsername: String?
+	/// TRUE if this account already used its registration code for password recovery
+	/// (stored as a '*' prefix on User.verification; see AuthController.recoveryHandler).
+	var hasUsedRegCodeForPasswordRecovery: Bool
+	/// Account creation time of the primary user. Nil if the code has not been used to create an account.
+	var accountCreatedAt: Date?
 }
 
 /// Returns general info about registration codes.

--- a/Sources/swiftarr/Controllers/Structs/AdminControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/AdminControllerStructs.swift
@@ -614,11 +614,8 @@ struct UserSaveRestoreData: Content, Sendable {
 extension UserSaveRestoreData {
 	/// For this to work: Must use `.with(\.$roles).with(\.$favoriteEvents).with(\.$favorites).with(\.$performer).with(\.$performer.events)` in query
 	init?(user: User) {
-		guard var regCode = user.verification else {
+		guard let regCode = user.unspentVerification else {
 			return nil
-		}
-		if regCode.first == "*" {
-			regCode = String(regCode.dropFirst())
 		}
 		// Stuff that's important to get right for security reasons
 		username = user.username

--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -2290,18 +2290,12 @@ extension UserCreateData: RCFValidatable {
 				tester.addValidationError(forKey: .username, errorString: $0)
 			}
 		// Registration code can be nil, but if it isn't, it must be a properly formed code.
-		if let normalizedCode = verification?.lowercased().replacingOccurrences(of: " ", with: ""),
-			normalizedCode.count > 0
-		{
-			if normalizedCode.rangeOfCharacter(from: CharacterSet.alphanumerics.inverted) != nil
-				|| normalizedCode.count != 6
-			{
-				tester.addValidationError(
-					forKey: .verification,
-					errorString: "Malformed registration code. Registration code "
-						+ "must be 6 alphanumeric letters; spaces optional"
-				)
-			}
+		if let verification, !verification.isEmpty, !RegistrationCode.isWellFormed(verification) {
+			tester.addValidationError(
+				forKey: .verification,
+				errorString: "Malformed registration code. Registration code "
+					+ "must be 6 alphanumeric letters; spaces optional"
+			)
 		}
 	}
 }
@@ -2710,7 +2704,7 @@ extension UserVerifyData: RCFValidatable {
 	func runValidations(using decoder: ValidatingDecoder) throws {
 		let tester = try decoder.validator(keyedBy: CodingKeys.self)
 		tester.validate(
-			verification.count >= 6 && verification.count <= 7,
+			RegistrationCode.isWellFormed(verification),
 			forKey: .verification,
 			or: "verification code is 6 letters long (with an optional space in the middle)"
 		)

--- a/Sources/swiftarr/Controllers/UserController.swift
+++ b/Sources/swiftarr/Controllers/UserController.swift
@@ -152,11 +152,10 @@ struct UserController: APIRouteCollection {
 
 		// Reg Codes may be delivered in user's emails as "ABC DEF", but the normalized form is lowercase, no spaces.
 		// Note: We don't check the reg code against the table until we're inside the transaction
-		guard let normalizedRegCode = data.verification?.lowercased().replacingOccurrences(of: " ", with: ""),
-				normalizedRegCode.rangeOfCharacter(from: CharacterSet.alphanumerics.inverted) == nil,
-				normalizedRegCode.count == 6 else {
+		guard let submittedCode = data.verification, RegistrationCode.isWellFormed(submittedCode) else {
 			throw Abort(.badRequest, reason: "Malformed verification code. Verification code must be 6 alphanumeric letters; spaces optional.")
 		}
+		let normalizedRegCode = RegistrationCode.normalized(submittedCode)
 
 		// create user
 		let recoveryKey = try UserController.generateRecoveryKey(on: req)
@@ -217,7 +216,10 @@ struct UserController: APIRouteCollection {
 	func verifyHandler(_ req: Request) async throws -> HTTPStatus {
 		let cacheUser = try req.auth.require(UserCacheData.self)
 		let data = try ValidatingJSONDecoder().decode(UserVerifyData.self, fromBodyOf: req)
-		let normalizedCode = data.verification.lowercased().replacingOccurrences(of: " ", with: "")
+		guard RegistrationCode.isWellFormed(data.verification) else {
+			throw Abort(.badRequest, reason: "Malformed verification code. Verification code must be 6 alphanumeric letters; spaces optional.")
+		}
+		let normalizedCode = RegistrationCode.normalized(data.verification)
 		// update models and return 200
 		try await req.db.transaction { database in
 			let user = try await cacheUser.getUser(on: database)

--- a/Sources/swiftarr/Enumerations/UserRoleType.swift
+++ b/Sources/swiftarr/Enumerations/UserRoleType.swift
@@ -25,6 +25,8 @@ enum UserRoleType: String, CaseIterable, Codable {
 	case karaokeambassador
 	/// Users that may create/edit their Performer profile outside of Pre-Registration, that is, on-board.
 	case performerselfeditor
+	/// Account Managers can look up accounts by registration code and re-enable one-time password recovery.
+	case accountmanager
 
 	/// `.label` returns consumer-friendly case names.
 	var label: String {
@@ -34,6 +36,7 @@ enum UserRoleType: String, CaseIterable, Codable {
 		case .shutternaut: return "Shutternaut"
 		case .karaokeambassador: return "Micro Karaoke Ambassador"
 		case .performerselfeditor: return "\"Allowed to create/edit their Shadow Event Performer\""
+		case .accountmanager: return "Account Manager"
 		}
 	}
 

--- a/Sources/swiftarr/Helpers/UserCache.swift
+++ b/Sources/swiftarr/Helpers/UserCache.swift
@@ -65,6 +65,18 @@ public struct UserCacheData: Authenticatable, SessionAuthenticatable, Sendable {
 		return mutes ?? []
 	}
 
+	/// TwitarrTeam and above, or users granted the Account Manager role, may look up accounts by
+	/// registration code and re-enable one-time password recovery.
+	var canManageAccounts: Bool {
+		accessLevel.hasAccess(.twitarrteam) || userRoles.contains(.accountmanager)
+	}
+
+	func guardCanManageAccounts() throws {
+		guard canManageAccounts else {
+			throw Abort(.forbidden, reason: "Access is restricted to TwitarrTeam or Account Managers.")
+		}
+	}
+
 	func makeHeader() -> UserHeader {
 		return UserHeader(
 			userID: userID,

--- a/Sources/swiftarr/Migrations/Data Import/RegistrationCodes.swift
+++ b/Sources/swiftarr/Migrations/Data Import/RegistrationCodes.swift
@@ -38,17 +38,15 @@ struct ImportRegistrationCodes: AsyncMigration {
 			else {
 				fatalError("Could not read registration codes file.")
 			}
-			// normalize contents
-			let normalizedString = dataString.lowercased().replacingOccurrences(of: " ", with: "")
-			// transform to array
-			let codesArray = normalizedString.components(separatedBy: .newlines)
+			// transform to array, then normalize each line (codes may be mailed as "ABC DEF")
+			let codesArray = dataString.components(separatedBy: .newlines)
 
 			// Creating one reg code at a time is slow, but we get timeout errros if we try to stuff too many
 			// creates into a single flatten. So, chunking the creates into batches of 100.
 			for startIndex in stride(from: 0, through: codesArray.count, by: 100) {
 				let endIndex = min(startIndex + 100, codesArray.count)
 				var regCodes: [RegistrationCode] = []
-				for codeIndex in startIndex..<endIndex where codesArray[codeIndex].count == 6 {
+				for codeIndex in startIndex..<endIndex where RegistrationCode.isWellFormed(codesArray[codeIndex]) {
 					let registrationCode = RegistrationCode(code: codesArray[codeIndex])
 					regCodes.append(registrationCode)
 				}

--- a/Sources/swiftarr/Models/RegistrationCode.swift
+++ b/Sources/swiftarr/Models/RegistrationCode.swift
@@ -65,13 +65,9 @@ final class RegistrationCode: Model, @unchecked Sendable {
 		return normalized.count == 6 && normalized.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber) }
 	}
 
-	/// THO-style display form, e.g. "abcabc" → "ABC ABC". Strips a spent `*` prefix so the real code is shown.
+	/// THO-style display form, e.g. "abcabc" → "ABC ABC".
 	static func displayString(_ code: String) -> String {
-		var normalized = Self.normalized(code)
-		if normalized.first == "*" {
-			normalized.removeFirst()
-		}
-		let display = normalized.uppercased()
+		let display = Self.normalized(User.unspentVerification(code)).uppercased()
 		guard display.count == 6 else {
 			return display
 		}

--- a/Sources/swiftarr/Models/RegistrationCode.swift
+++ b/Sources/swiftarr/Models/RegistrationCode.swift
@@ -50,8 +50,33 @@ final class RegistrationCode: Model, @unchecked Sendable {
 	/// - Parameters:
 	///   - code: The registration code string.
 	init(code: String, isForDiscord: Bool = false) {
-		self.code = code
+		self.code = RegistrationCode.normalized(code)
 		self.isDiscordUser = isForDiscord
+	}
+
+	/// Lowercase with all whitespace removed. THO mails codes as "ABC DEF"; storage and matching use "abcdef".
+	static func normalized(_ code: String) -> String {
+		String(code.lowercased().filter { !$0.isWhitespace })
+	}
+
+	/// TRUE if `code` is a 6-character alphanumeric registration code, with optional whitespace (including non-breaking spaces).
+	static func isWellFormed(_ code: String) -> Bool {
+		let normalized = Self.normalized(code)
+		return normalized.count == 6 && normalized.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber) }
+	}
+
+	/// THO-style display form, e.g. "abcabc" → "ABC ABC". Strips a spent `*` prefix so the real code is shown.
+	static func displayString(_ code: String) -> String {
+		var normalized = Self.normalized(code)
+		if normalized.first == "*" {
+			normalized.removeFirst()
+		}
+		let display = normalized.uppercased()
+		guard display.count == 6 else {
+			return display
+		}
+		let mid = display.index(display.startIndex, offsetBy: 3)
+		return "\(display[..<mid]) \(display[mid...])"
 	}
 }
 

--- a/Sources/swiftarr/Models/User.swift
+++ b/Sources/swiftarr/Models/User.swift
@@ -245,6 +245,37 @@ final class User: Model, @unchecked Sendable {
 	// }
 }
 
+// MARK: - Registration-code recovery
+
+extension User {
+	/// TRUE if this account already used its registration code for one-time password recovery.
+	var verificationUsed: Bool {
+		verification?.hasPrefix("*") == true
+	}
+
+	/// Registration code with a spent `*` prefix removed. Use when the value is a raw string, not a `User`.
+	static func unspentVerification(_ code: String) -> String {
+		code.hasPrefix("*") ? String(code.dropFirst()) : code
+	}
+
+	/// The registration code without a spent `*` prefix, if any.
+	var unspentVerification: String? {
+		guard let verification else { return nil }
+		return Self.unspentVerification(verification)
+	}
+
+	/// Re-enables one-time password recovery by stripping a spent `*` prefix. No-op if unused or nil.
+	func unlockVerification() {
+		verification = unspentVerification
+	}
+
+	/// Marks the stored registration code as spent. No-op if already spent or nil.
+	func markVerificationUsed() {
+		guard !verificationUsed, let verification else { return }
+		self.verification = "*" + RegistrationCode.normalized(verification)
+	}
+}
+
 /// Creates the `User` table in the database and specifies its fields.
 struct CreateUserSchema: AsyncMigration {
 	func prepare(on database: Database) async throws {
@@ -294,7 +325,7 @@ struct CreateUserSchema: AsyncMigration {
 
 // MARK: - ModelAuthenticatable Conformance
 
-extension User: ModelAuthenticatable {	
+extension User: ModelAuthenticatable {
 	/// Required username key for HTTP Basic Authorization.
 	static let usernameKey: KeyPath<User, Field<String>> = \User.$username
 	/// Required password key for HTTP Basic Authorization.

--- a/Sources/swiftarr/Resources/Assets/js/swiftarr.js
+++ b/Sources/swiftarr/Resources/Assets/js/swiftarr.js
@@ -23,6 +23,7 @@ for (let btn of document.querySelectorAll('[data-action]')) {
 		case "alertWordDelete":
 		case "muteWordDelete":
 		case "redirect":
+		case "showSuccess":
 			btn.addEventListener("click", spinnerButtonAction);
 			break;
 		case "delete": btn.addEventListener("click", deleteAction); break;
@@ -152,6 +153,16 @@ async function spinnerButtonAction() {
 				case "unmute": acknowledgeRemovalAction(tappedButton, "unmuted"); break;
 				case "alertWordDelete": acknowledgeRemovalAction(tappedButton, "removed"); break;
 				case "muteWordDelete": acknowledgeRemovalAction(tappedButton, "removed"); break;
+				case "showSuccess":
+					document.getElementById(tappedButton.dataset.successdiv)?.classList.remove("d-none");
+					if (tappedButton.dataset.statustarget) {
+						let statusElem = document.getElementById(tappedButton.dataset.statustarget);
+						if (statusElem) {
+							statusElem.innerText = tappedButton.dataset.statusvalue ?? "";
+						}
+					}
+					tappedButton.classList.add("d-none");
+					break;
 			}
 		}
 		else {

--- a/Sources/swiftarr/Resources/Views/User/userProfile.html
+++ b/Sources/swiftarr/Resources/Views/User/userProfile.html
@@ -100,6 +100,9 @@
 							<a class="btn btn-sm btn-outline-primary" href="/moderate/userprofile/#(profile.header.userID)">Mod Profile</a>
 							<a class="btn btn-sm btn-outline-primary" href="/moderate/user/#(profile.header.userID)">Mod User</a>
 						#endif
+						#if(trunk.userCanManageAccounts):
+							<a class="btn btn-sm btn-outline-primary" href="/admin/regcodes/showuser/#(profile.header.userID)">Registration Code</a>
+						#endif
 					#endif
 				</div>
 			</div>

--- a/Sources/swiftarr/Resources/Views/admin/regCodeForUser.html
+++ b/Sources/swiftarr/Resources/Views/admin/regCodeForUser.html
@@ -14,13 +14,47 @@
 			</div>
 			<div class="row my-2">
 				<div class="col">
-					<b>Registered using code:</b> #(regCode)
+					<b>Registered using code:</b> #if(notEmpty(data.regCode)):#regCode(data.regCode)#else:No registration code found for this user#endif
 				</div>
 			</div>
+			#if(data.accountCreatedAt):
+				<div class="row my-2">
+					<div class="col">
+						<b>Account created:</b> #staticTime(data.accountCreatedAt)
+					</div>
+				</div>
+			#endif
 			#if(data.isForDiscordUser):
 				<div class="row my-2">
 					<div class="col">
 						This is a Discord reg code, given to Discord user "#(data.discordUsername)"
+					</div>
+				</div>
+			#endif
+			<div class="row my-2">
+				<div class="col">
+					<b>Code used to reset password:</b> <span id="recovery-status">#if(data.hasUsedRegCodeForPasswordRecovery):yes#else:no#endif</span>
+				</div>
+			</div>
+			#if(data.hasUsedRegCodeForPasswordRecovery):
+				<div class="row my-2">
+					<div class="col">
+						<button type="button" class="btn btn-primary" autocomplete="off" data-action="showSuccess"
+								data-actionpath="/admin/regcodes/showuser/#(primaryUser.userID)/unlock"
+								data-errordiv="unlock_errorDisplay"
+								data-successdiv="unlock_successDisplay"
+								data-statustarget="recovery-status"
+								data-statusvalue="no">
+							Unlock Password Reset
+							<span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
+							<span class="visually-hidden">Loading...</span>
+						</button>
+						<div class="alert alert-success d-none mt-2" id="unlock_successDisplay" role="alert">
+							Password reset unlocked.
+						</div>
+						<div class="text-danger d-none mt-2" id="unlock_errorDisplay">
+							Could not unlock password reset: <span class="errortext"></span>
+						</div>
 					</div>
 				</div>
 			#endif

--- a/Sources/swiftarr/Resources/Views/admin/regcodes.html
+++ b/Sources/swiftarr/Resources/Views/admin/regcodes.html
@@ -48,7 +48,17 @@
 			</div>
 			<div class="row my-2">
 				<div class="col">
-					#(searchResults)
+					#if(notEmpty(searchedRegCode)):
+						#if(count(searchResultUsers) > 0):
+							User "#(associatedUsername)" is associated with registration code #regCode(searchedRegCode)
+						#elseif(notEmpty(searchResults)):
+							#(searchResults)
+						#else:
+							#regCode(searchedRegCode) is a valid code, not associated with a user.
+						#endif
+					#else:
+						#(searchResults)
+					#endif
 				</div>
 			</div>
 			#if(count(searchResultUsers) > 0):
@@ -60,7 +70,9 @@
 				#for(header in searchResultUsers):
 					<div class="row mb-2 mx-0">
 						<div class="col col-auto border">
-							#avatar(header) #userByline(header)
+							<a href="/admin/regcodes/showuser/#(header.userID)">
+								#avatar(header) #userByline(header, "nolink")
+							</a>
 						</div>				
 					</div>
 				#endfor

--- a/Sources/swiftarr/Resources/Views/admin/root.html
+++ b/Sources/swiftarr/Resources/Views/admin/root.html
@@ -7,6 +7,7 @@
 				</div>
 			</div>
 			
+			#if(trunk.userIsTwitarrTeam):
 			<ul class="list-group">
 				<li class="list-group-item active">
 					<b>Communication</b>
@@ -33,45 +34,51 @@
 					<b>Event Feedback</b>: View Shadow Event Feedback responses.
 				</a>
 			</ul>
+			#endif
 			
 			<ul class="list-group mt-2">
 				<li class="list-group-item active">
 					<b>Configuration</b>
 				</li>
-				<a class="list-group-item list-group-item-action" href="/admin/serversettings">
-					<b>Server Settings</b>: Lots of inscrutable toggles and buttons here.
-				</a>
+				#if(trunk.userIsTwitarrTeam):
+					<a class="list-group-item list-group-item-action" href="/admin/serversettings">
+						<b>Server Settings</b>: Lots of inscrutable toggles and buttons here.
+					</a>
+				#endif
 				<a class="list-group-item list-group-item-action" href="/admin/regcodes">
 					<b>Registration Codes</b>: View/Manage registration code table.
 				</a>
-				<a class="list-group-item list-group-item-action" href="/admin/regcodes/discord/assign">
-					<b>Assign Reg Code</b>: Assign a reg code to a Discord user. Does not work on boat.
-				</a>
-				#if(trunk.userIsTHO):
-					#if(trunk.username == "admin"):
-						<a class="list-group-item list-group-item-action" href="/admin/tho">
-							<b>Manage THO</b>: View/Manage THO members.
+				#if(trunk.userIsTwitarrTeam):
+					<a class="list-group-item list-group-item-action" href="/admin/regcodes/discord/assign">
+						<b>Assign Reg Code</b>: Assign a reg code to a Discord user. Does not work on boat.
+					</a>
+					#if(trunk.userIsTHO):
+						#if(trunk.username == "admin"):
+							<a class="list-group-item list-group-item-action" href="/admin/tho">
+								<b>Manage THO</b>: View/Manage THO members.
+							</a>
+						#else:
+							<a class="list-group-item list-group-item-action" href="/admin/tho">
+								<b>Manage THO</b>: View THO members.
+							</a>
+						#endif
+						<a class="list-group-item list-group-item-action" href="/admin/twitarrteam">
+							<b>Manage TwitarrTeam Members</b>: View/Manage members of TwitarrTeam.
 						</a>
-					#else:
-						<a class="list-group-item list-group-item-action" href="/admin/tho">
-							<b>Manage THO</b>: View THO members.
+						<a class="list-group-item list-group-item-action" href="/admin/mods">
+							<b>Manage Moderators</b>: View/Manage moderators.
+						</a>
+						<a class="list-group-item list-group-item-action" href="/admin/userroles">
+							<b>Manage User Roles</b>: View/Manage User Roles. Roles are specific capabilities granted to users; separate from the userLevel hierarchy.
+						</a>
+						<a class="list-group-item list-group-item-action" href="/admin/rollup">
+							<b>Show Table Counts</b>: Displays a table containing row counts for a bunch of database tables.
 						</a>
 					#endif
-					<a class="list-group-item list-group-item-action" href="/admin/twitarrteam">
-						<b>Manage TwitarrTeam Members</b>: View/Manage members of TwitarrTeam.
-					</a>
-					<a class="list-group-item list-group-item-action" href="/admin/mods">
-						<b>Manage Moderators</b>: View/Manage moderators.
-					</a>
-					<a class="list-group-item list-group-item-action" href="/admin/userroles">
-						<b>Manage User Roles</b>: View/Manage User Roles. Roles are specific capabilities granted to users; separate from the userLevel hierarchy.
-					</a>
-					<a class="list-group-item list-group-item-action" href="/admin/rollup">
-						<b>Show Table Counts</b>: Displays a table containing row counts for a bunch of database tables.
-					</a>
 				#endif
 			</ul>
 			
+			#if(trunk.userIsTwitarrTeam):
 			<ul class="list-group mt-2">
 				<li class="list-group-item active">
 					<b>Data Loading</b>
@@ -100,6 +107,7 @@
 					</a>
 				#endif
 			</ul>
+			#endif
 		</div>
     #endexport
 #endextend

--- a/Sources/swiftarr/Resources/Views/admin/showUserRoles.html
+++ b/Sources/swiftarr/Resources/Views/admin/showUserRoles.html
@@ -22,6 +22,7 @@
 						<li><a class="dropdown-item #if(role == "shutternaut"):active#endif" href="/admin/userroles/shutternaut">Shutternaut</a></li>
 						<li><a class="dropdown-item #if(role == "karaokeambassador"):active#endif" href="/admin/userroles/karaokeambassador">Micro Karaoke Ambassador</a></li>
 						<li><a class="dropdown-item #if(role == "performerSelfEditor"):active#endif" href="/admin/userroles/performerSelfEditor">Shadow Event Performer Self Editor</a></li>
+						<li><a class="dropdown-item #if(role == "accountmanager"):active#endif" href="/admin/userroles/accountmanager">Account Manager</a></li>
 					</ul>
 				</div>
 			</div>

--- a/Sources/swiftarr/Resources/Views/home.html
+++ b/Sources/swiftarr/Resources/Views/home.html
@@ -263,7 +263,7 @@
 						</div>
 					</div>
 				#endif
-				#if(trunk.userIsMod || trunk.userIsTwitarrTeam && !trunk.preregistrationApplies):
+				#if(trunk.userIsMod || trunk.userCanManageAccounts && !trunk.preregistrationApplies):
 					<div class="row mt-2">
 						<div class="col">
 							<h4><b>Site Management:</b></h4>
@@ -295,7 +295,7 @@
 										#endif
 									</li>
 								#endif
-								#if(trunk.userIsTwitarrTeam):
+								#if(trunk.userCanManageAccounts):
 									<li class="list-group-item align-items-center">
 										<a class="nav-link#" href="/admin">Admin Pages</a>
 										#if(trunk.alertCounts.moderatorData.newTTSeamailMessageCount > 0):

--- a/Sources/swiftarr/Site/SiteAdminController.swift
+++ b/Sources/swiftarr/Site/SiteAdminController.swift
@@ -45,8 +45,6 @@ struct SiteAdminController: SiteControllerUtils {
 		// Routes for non-shareable content. If you're not logged in we failscreen.
 		let privateTTRoutes = getPrivateRoutes(app, minAccess: .twitarrteam, path: "admin")
 
-		privateTTRoutes.get("", use: adminRootPageHandler)
-
 		privateTTRoutes.get("announcements", use: announcementsAdminPageHandler)
 		privateTTRoutes.get("announcement", "create", use: announcementCreatePageHandler)
 		privateTTRoutes.post("announcement", "create", use: announcementCreatePostHandler)
@@ -86,8 +84,6 @@ struct SiteAdminController: SiteControllerUtils {
 		privateTTRoutes.get("bulkuser", "upload", "commit", use: bulkUserUpdateCommitHandler)
 		
 
-		privateTTRoutes.get("regcodes", use: getRegCodeHandler)
-		privateTTRoutes.get("regcodes", "showuser", userIDParam, use: getRegCodeForUserHandler)
 		privateTTRoutes.get("regcodes", "discord", "assign", use: assignRegCodeToDiscordUser)
 		privateTTRoutes.post("regcodes", "discord", "assign", use: assignRegCodeToDiscordUserResult)
 		
@@ -120,6 +116,13 @@ struct SiteAdminController: SiteControllerUtils {
 		privateAdminRoutes.post("karaoke", "reload", use: karaokePostHandler)
 		privateAdminRoutes.get("boardgames", use: boardGamesHandler)
 		privateAdminRoutes.post("boardgames", "reload", use: boardGamesPostHandler)
+
+		// TwitarrTeam and above, or users with the Account Manager role
+		let accountMgrRoutes = getPrivateRoutes(app, minAccess: .verified, path: "admin")
+		accountMgrRoutes.get("", use: adminRootPageHandler)
+		accountMgrRoutes.get("regcodes", use: getRegCodeHandler)
+		accountMgrRoutes.get("regcodes", "showuser", userIDParam, use: getRegCodeForUserHandler)
+		accountMgrRoutes.post("regcodes", "showuser", userIDParam, "unlock", use: unlockRegCodePostHandler)
 	}
 
 	// MARK: - Admin Pages
@@ -166,6 +169,7 @@ struct SiteAdminController: SiteControllerUtils {
 	// GET /admin
 	// Shows the root admin page, which just shows links to other pages.
 	func adminRootPageHandler(_ req: Request) async throws -> View {
+		try req.auth.require(UserCacheData.self).guardCanManageAccounts()
 		struct AdminRootPageContext: Encodable {
 			var trunk: TrunkContext
 
@@ -959,23 +963,20 @@ struct SiteAdminController: SiteControllerUtils {
 	//
 	// Shows stats on reg code use. Lets admins search on a regcode and get the user it's associated with, if any.
 	func getRegCodeHandler(_ req: Request) async throws -> View {
+		try req.auth.require(UserCacheData.self).guardCanManageAccounts()
 		var regCodeSearchResults = ""
+		var searchedRegCode = ""
 		var searchResultHeaders = [UserHeader]()
 		if let regCode = req.query[String.self, at: "search"]?.removingPercentEncoding?.lowercased()
 			.filter({ $0 != " " })
 		{
 			regCodeSearchResults = "Invalid registration code"
 			if regCode.count == 6, regCode.allSatisfy({ $0.isLetter || $0.isNumber }) {
+				searchedRegCode = regCode
+				regCodeSearchResults = ""
 				do {
 					let response = try await apiQuery(req, endpoint: "/admin/regcodes/find/\(regCode)")
 					searchResultHeaders = try response.content.decode([UserHeader].self)
-					if searchResultHeaders.count > 0 {
-						regCodeSearchResults =
-							"User \"\(searchResultHeaders[0].username)\" is associated with registration code \"\(regCode)\""
-					}
-					else {
-						regCodeSearchResults = "\(regCode) is a valid code, not associated with a user."
-					}
 				}
 				catch let error as ErrorResponse {
 					regCodeSearchResults = "Error: \(error.reason)"
@@ -990,24 +991,30 @@ struct SiteAdminController: SiteControllerUtils {
 		struct RegCodeStatsContext: Encodable {
 			var trunk: TrunkContext
 			var stats: RegistrationCodeStatsData
+			var searchedRegCode: String
 			var searchResults: String
 			var searchResultUsers: [UserHeader]
+			var associatedUsername: String
 
 			init(
 				_ req: Request,
 				stats: RegistrationCodeStatsData,
+				searchedRegCode: String,
 				searchResults: String,
 				searchResultUsers: [UserHeader]
 			) throws {
 				trunk = .init(req, title: "Registration Codes", tab: .admin)
 				self.stats = stats
+				self.searchedRegCode = searchedRegCode
 				self.searchResults = searchResults
 				self.searchResultUsers = searchResultUsers
+				self.associatedUsername = searchResultUsers.first?.username ?? ""
 			}
 		}
 		let ctx = try RegCodeStatsContext(
 			req,
 			stats: regCodeData,
+			searchedRegCode: searchedRegCode,
 			searchResults: regCodeSearchResults,
 			searchResultUsers: searchResultHeaders
 		)
@@ -1018,6 +1025,7 @@ struct SiteAdminController: SiteControllerUtils {
 	//
 	// Shows stats on reg code use. Lets admins search on a regcode and get the user it's associated with, if any.
 	func getRegCodeForUserHandler(_ req: Request) async throws -> View {
+		try req.auth.require(UserCacheData.self).guardCanManageAccounts()
 		guard let targetUserID = req.parameters.get(userIDParam.paramString, as: UUID.self) else {
 			throw Abort(.badRequest, reason: "Missing user_id parameter")
 		}
@@ -1031,18 +1039,28 @@ struct SiteAdminController: SiteControllerUtils {
 			var data: RegistrationCodeUserData
 			var primaryUser: UserHeader
 			var altUsers: [UserHeader]
-			var regCode: String
 
 			init(_ req: Request, data: RegistrationCodeUserData) throws {
 				trunk = .init(req, title: "Registration Code for User", tab: .admin)
 				self.data = data
 				self.primaryUser = data.users[0]
 				self.altUsers = Array(data.users.dropFirst(1))
-				self.regCode = data.regCode.isEmpty ? "No registration code found for this user" : data.regCode
 			}
 		}
 		let ctx = try RegCodeUserContext(req, data: regCodeData)
 		return try await req.view.render("admin/regCodeForUser", ctx)
+	}
+
+	// POST /admin/regcodes/showuser/:user_id/unlock
+	//
+	// Re-enables one-time password recovery via registration code for this user.
+	func unlockRegCodePostHandler(_ req: Request) async throws -> HTTPStatus {
+		try req.auth.require(UserCacheData.self).guardCanManageAccounts()
+		guard let targetUserID = req.parameters.get(userIDParam.paramString)?.percentEncodeFilePathEntry() else {
+			throw Abort(.badRequest, reason: "Missing user_id parameter")
+		}
+		let response = try await apiQuery(req, endpoint: "/admin/regcodes/unlock/\(targetUserID)", method: .POST)
+		return response.status
 	}
 	
 	// GET /admin/regcodes/discord/assign

--- a/Sources/swiftarr/Site/SiteAdminController.swift
+++ b/Sources/swiftarr/Site/SiteAdminController.swift
@@ -967,24 +967,25 @@ struct SiteAdminController: SiteControllerUtils {
 		var regCodeSearchResults = ""
 		var searchedRegCode = ""
 		var searchResultHeaders = [UserHeader]()
-		if let regCode = req.query[String.self, at: "search"]?.removingPercentEncoding?.lowercased()
-			.filter({ $0 != " " })
+		if let rawSearch = req.query[String.self, at: "search"]?.removingPercentEncoding,
+			RegistrationCode.isWellFormed(rawSearch)
 		{
-			regCodeSearchResults = "Invalid registration code"
-			if regCode.count == 6, regCode.allSatisfy({ $0.isLetter || $0.isNumber }) {
-				searchedRegCode = regCode
-				regCodeSearchResults = ""
-				do {
-					let response = try await apiQuery(req, endpoint: "/admin/regcodes/find/\(regCode)")
-					searchResultHeaders = try response.content.decode([UserHeader].self)
-				}
-				catch let error as ErrorResponse {
-					regCodeSearchResults = "Error: \(error.reason)"
-				}
-				catch {
-					regCodeSearchResults = error.localizedDescription
-				}
+			let regCode = RegistrationCode.normalized(rawSearch)
+			searchedRegCode = regCode
+			regCodeSearchResults = ""
+			do {
+				let response = try await apiQuery(req, endpoint: "/admin/regcodes/find/\(regCode)")
+				searchResultHeaders = try response.content.decode([UserHeader].self)
 			}
+			catch let error as ErrorResponse {
+				regCodeSearchResults = "Error: \(error.reason)"
+			}
+			catch {
+				regCodeSearchResults = error.localizedDescription
+			}
+		}
+		else if req.query[String.self, at: "search"] != nil {
+			regCodeSearchResults = "Invalid registration code"
 		}
 		let response = try await apiQuery(req, endpoint: "/admin/regcodes/stats")
 		let regCodeData = try response.content.decode(RegistrationCodeStatsData.self)

--- a/Sources/swiftarr/Site/SiteController.swift
+++ b/Sources/swiftarr/Site/SiteController.swift
@@ -34,6 +34,7 @@ struct TrunkContext: Encodable {
 	var userIsMod: Bool
 	var userIsTwitarrTeam: Bool
 	var userIsTHO: Bool
+	var userCanManageAccounts: Bool
 	var userRoles: [String]  // Use "contains(trunk.userRoles, "shutternautmanager")" or similar to check
 	var minAccessLevel: String?  // Minimum access required to view Twitarr pages; Value from Settings.
 	var preregistrationMode: Bool  // Mirrors the value in Settings.
@@ -59,6 +60,7 @@ struct TrunkContext: Encodable {
 			userIsMod = userAccessLevel.hasAccess(.moderator)
 			userIsTwitarrTeam = userAccessLevel.hasAccess(.twitarrteam)
 			userIsTHO = userAccessLevel.hasAccess(.tho)
+			userCanManageAccounts = user.canManageAccounts
 			username = user.username
 			userID = user.userID
 			userRoles = user.userRoles.map { $0.rawValue }
@@ -68,6 +70,7 @@ struct TrunkContext: Encodable {
 			userIsMod = false
 			userIsTwitarrTeam = false
 			userIsTHO = false
+			userCanManageAccounts = false
 			username = ""
 			userID = UUID()
 			userRoles = []

--- a/Sources/swiftarr/Site/Utilities/CustomLeafTags.swift
+++ b/Sources/swiftarr/Site/Utilities/CustomLeafTags.swift
@@ -84,7 +84,7 @@ struct AddJocomojiTag: UnsafeUnescapedLeafTag {
 }
 
 /// Renders arbitrary Markdown text
-/// 
+///
 /// Usage: #markdownTextTag(String) -> String
 struct MarkdownTextTag: UnsafeUnescapedLeafTag {
 	func render(_ ctx: LeafContext) throws -> LeafData {
@@ -92,9 +92,9 @@ struct MarkdownTextTag: UnsafeUnescapedLeafTag {
 		guard var string = ctx.parameters[0].string else {
 			return LeafData.string("")
 		}
-		
+
 		// Sanitize any HTML entities in the source string. Although Markdown allows HTML tags to be used in a .md document,
-		// we don't want to allow that as it's a security hole. 
+		// we don't want to allow that as it's a security hole.
 		string = string.htmlEscaped()
 
 		let parser = MarkdownParser()
@@ -133,16 +133,21 @@ struct FormatPostTextTag: UnsafeUnescapedLeafTag {
 		// Which also means it came from YouKnowWhere.
 		let mentionPattern = "(?<!\\S)(@[A-Za-z0-9]+(?:[-.+_][A-Za-z0-9]+)*)"
 		let mentionRegex = try NSRegularExpression(pattern: mentionPattern, options: [])
-		let mentionMatches = mentionRegex.matches(in: string, options: [], range: NSRange(location: 0, length: string.utf16.count))
+		let mentionMatches = mentionRegex.matches(
+			in: string,
+			options: [],
+			range: NSRange(location: 0, length: string.utf16.count)
+		)
 
 		var modifiedText = string
 		for mentionMatch in mentionMatches.reversed() {
 			let range = Range(mentionMatch.range(at: 1), in: modifiedText)!
 			let mention = String(modifiedText[range])
-			let username = String(mention.dropFirst()) // Drop the initial "@"
-			let linkStyle = ["admin", "THO", "TwitarrTeam", "moderator"].contains(username) ? "link-danger" : "link-primary"
-            let link = "<a class=\"\(linkStyle)\" href=\"/username/\(username)\">\(mention)</a>"
-            modifiedText.replaceSubrange(range, with: link)
+			let username = String(mention.dropFirst())  // Drop the initial "@"
+			let linkStyle =
+				["admin", "THO", "TwitarrTeam", "moderator"].contains(username) ? "link-danger" : "link-primary"
+			let link = "<a class=\"\(linkStyle)\" href=\"/username/\(username)\">\(mention)</a>"
+			modifiedText.replaceSubrange(range, with: link)
 		}
 		string = modifiedText
 
@@ -153,14 +158,18 @@ struct FormatPostTextTag: UnsafeUnescapedLeafTag {
 		// * Contain alphanumberic characters with no separators
 		let hashtagPattern = "(?<!\\S)(#[A-Za-z0-9]+)(?!\\S)"
 		let hashtagRegex = try NSRegularExpression(pattern: hashtagPattern, options: [])
-		let hashtagMatches = hashtagRegex.matches(in: string, options: [], range: NSRange(location: 0, length: string.utf16.count))
+		let hashtagMatches = hashtagRegex.matches(
+			in: string,
+			options: [],
+			range: NSRange(location: 0, length: string.utf16.count)
+		)
 
 		for hashtagMatch in hashtagMatches.reversed() {
 			let range = Range(hashtagMatch.range(at: 1), in: modifiedText)!
 			let mention = String(modifiedText[range])
-			let hashtag = String(mention.dropFirst()) // Drop the initial "#"
-            let link = "<a class=\"link-primary\" href=\"/forumpost/search?hashtag=\(hashtag)\">\(mention)</a>"
-            modifiedText.replaceSubrange(range, with: link)
+			let hashtag = String(mention.dropFirst())  // Drop the initial "#"
+			let link = "<a class=\"link-primary\" href=\"/forumpost/search?hashtag=\(hashtag)\">\(mention)</a>"
+			modifiedText.replaceSubrange(range, with: link)
 		}
 		string = modifiedText
 
@@ -530,7 +539,7 @@ struct CruiseDayIndexTag: LeafTag {
 	}
 }
 
-// MARK: - Tags for Styling Users 
+// MARK: - Tags for Styling Users
 
 /// Inserts an <img> tag for the given user's avatar image. Presents a default image if the user doesn't have an image.
 /// Note: If we implement identicons at the API level, users will always have images, and the 'generic user' image here is just a fallback.
@@ -587,9 +596,9 @@ struct UserBylineTag: UnsafeUnescapedLeafTag {
 			}
 			return false
 		}
-		let shortStyle = stylingSearch(style: "short", in: &styling) 
-		let nolinkStyle = stylingSearch(style: "nolink", in: &styling) 
-		let pronounStyle = stylingSearch(style: "pronoun", in: &styling) 
+		let shortStyle = stylingSearch(style: "short", in: &styling)
+		let nolinkStyle = stylingSearch(style: "nolink", in: &styling)
+		let pronounStyle = stylingSearch(style: "pronoun", in: &styling)
 		if ["admin", "THO", "TwitarrTeam", "moderator"].contains(username) {
 			styling.append(" text-danger")
 		}
@@ -627,7 +636,7 @@ struct UserBylineTag: UnsafeUnescapedLeafTag {
 
 // MARK: - Other Tags
 
-/// Gets the user-formatted label string for the given tyhpe of LFG. 
+/// Gets the user-formatted label string for the given tyhpe of LFG.
 ///
 /// Usage: #lfgLabel(String)
 struct LFGLabelTag: LeafTag {
@@ -678,35 +687,60 @@ struct DinnerTeamTag: LeafTag {
 //
 // Usage: #notEmpty(value)
 struct NotEmptyTag: LeafTag {
-    func render(_ ctx: LeafContext) throws -> LeafData {
+	func render(_ ctx: LeafContext) throws -> LeafData {
 		try ctx.requireParameterCount(1)
 		guard let leafData = ctx.parameters.first else {
-            throw "Couldn't extract first parameter to NotEmpty tag"
+			throw "Couldn't extract first parameter to NotEmpty tag"
 		}
 		if leafData.isNil {
 			return .bool(false)
 		}
-    	guard let str = leafData.string else {
-            throw "unable to check for empty value unexpected data"
-        }
-        return .bool(!str.isEmpty)
-    }
+		guard let str = leafData.string else {
+			throw "unable to check for empty value unexpected data"
+		}
+		return .bool(!str.isEmpty)
+	}
 }
 
-// Have I become that guy? Is inserting obvious references to forty year old Gibson books still cool? 
+// Have I become that guy? Is inserting obvious references to forty year old Gibson books still cool?
 // Anyway, unlike Leaf's #count(), this returns 0 if the parameter isn't an array or dict. Most useful
 // when the parameter is an optional that may be nil.
 //
 // Usage: #countOrZero(value)
 struct CountZeroTag: LeafTag {
-    func render(_ ctx: LeafContext) throws -> LeafData {
-        try ctx.requireParameterCount(1)
-        if let array = ctx.parameters[0].array {
-            return LeafData.int(array.count)
-        } else if let dictionary = ctx.parameters[0].dictionary {
-            return LeafData.int(dictionary.count)
-        } else {
-            return .int(0)
-        }
-    }
+	func render(_ ctx: LeafContext) throws -> LeafData {
+		try ctx.requireParameterCount(1)
+		if let array = ctx.parameters[0].array {
+			return LeafData.int(array.count)
+		}
+		else if let dictionary = ctx.parameters[0].dictionary {
+			return LeafData.int(dictionary.count)
+		}
+		else {
+			return .int(0)
+		}
+	}
+}
+
+/// Renders a registration code as bold monospace text, uppercased.
+/// For example, "abcabc" is displayed as "ABCABC".
+///
+/// We don't yet have one consistent place to format registration codes.
+/// I don't even know where the format definition came from (like was that THO thing
+/// or a Twitarr thing).
+///
+/// Usage: #regCode(String)
+struct RegCodeTag: UnsafeUnescapedLeafTag {
+	static func format(_ code: String) -> String {
+		code.filter { !$0.isWhitespace }.uppercased()
+	}
+
+	func render(_ ctx: LeafContext) throws -> LeafData {
+		try ctx.requireParameterCount(1)
+		guard let string = ctx.parameters[0].string, !string.isEmpty else {
+			return LeafData.string("")
+		}
+		let display = RegCodeTag.format(string).htmlEscaped()
+		return LeafData.string("<b class=\"font-monospace\">\(display)</b>")
+	}
 }

--- a/Sources/swiftarr/Site/Utilities/CustomLeafTags.swift
+++ b/Sources/swiftarr/Site/Utilities/CustomLeafTags.swift
@@ -736,6 +736,6 @@ struct RegCodeTag: UnsafeUnescapedLeafTag {
 			return LeafData.string("")
 		}
 		let display = RegCodeTag.format(string).htmlEscaped()
-		return LeafData.string("<b class=\"font-monospace\">\(display)</b>")
+		return LeafData.string("<span class=\"font-monospace\">\(display)</span>")
 	}
 }

--- a/Sources/swiftarr/Site/Utilities/CustomLeafTags.swift
+++ b/Sources/swiftarr/Site/Utilities/CustomLeafTags.swift
@@ -722,17 +722,12 @@ struct CountZeroTag: LeafTag {
 	}
 }
 
-/// Renders a registration code as bold monospace text, uppercased.
-/// For example, "abcabc" is displayed as "ABCABC".
-///
-/// We don't yet have one consistent place to format registration codes.
-/// I don't even know where the format definition came from (like was that THO thing
-/// or a Twitarr thing).
+/// Renders a registration code as bold monospace text in THO-style groups, e.g. "abcabc" → "ABC ABC".
 ///
 /// Usage: #regCode(String)
 struct RegCodeTag: UnsafeUnescapedLeafTag {
 	static func format(_ code: String) -> String {
-		code.filter { !$0.isWhitespace }.uppercased()
+		RegistrationCode.displayString(code)
 	}
 
 	func render(_ ctx: LeafContext) throws -> LeafData {

--- a/Sources/swiftarr/configure.swift
+++ b/Sources/swiftarr/configure.swift
@@ -522,6 +522,7 @@ struct SwiftarrConfigurator {
 		app.leaf.tags["lfgLabel"] = LFGLabelTag()
 		app.leaf.tags["notEmpty"] = NotEmptyTag()
 		app.leaf.tags["countOrZero"] = CountZeroTag()
+		app.leaf.tags["regCode"] = RegCodeTag()
 	}
 
 	func configureQueues(_ app: Application) throws {

--- a/Tests/AppTests/AdminAccountManagementTests.swift
+++ b/Tests/AppTests/AdminAccountManagementTests.swift
@@ -270,4 +270,47 @@ class AdminAccountManagementTests: XCTestCase, SwiftarrBaseTest {
 			)
 		}
 	}
+
+	func testFind_SpacedCodeMatchesUnspaced() async throws {
+		try await withApp { app in
+			let suffix = UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(5).lowercased()
+			let code = "t\(suffix)"
+			let staff = try await makeUser(app, username: "acctmgr-\(suffix)", accessLevel: .verified)
+			try await UserRole(user: staff.requireID(), role: .accountmanager).create(on: app.db)
+			let target = try await makeUser(
+				app,
+				username: "find-space-\(suffix)",
+				accessLevel: .verified,
+				verification: code
+			)
+			let record = RegistrationCode(code: code)
+			record.$user.id = try target.requireID()
+			try await record.save(on: app.db)
+			let staffToken = try await makeToken(app, for: staff)
+			try await bootCache(app)
+
+			let spaced = "\(code.prefix(3))%20\(code.dropFirst(3))"
+			try await app.test(
+				.GET,
+				"/api/v3/admin/regcodes/find/\(spaced)",
+				headers: bearer(staffToken),
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .ok)
+					let headers = try res.content.decode([UserHeader].self)
+					XCTAssertEqual(headers.first?.userID, try target.requireID())
+				}
+			)
+
+			try await app.test(
+				.GET,
+				"/api/v3/admin/regcodes/find/\(code)",
+				headers: bearer(staffToken),
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .ok)
+					let headers = try res.content.decode([UserHeader].self)
+					XCTAssertEqual(headers.first?.userID, try target.requireID())
+				}
+			)
+		}
+	}
 }

--- a/Tests/AppTests/AdminAccountManagementTests.swift
+++ b/Tests/AppTests/AdminAccountManagementTests.swift
@@ -1,0 +1,273 @@
+import Testing
+import XCTVapor
+
+@testable import swiftarr
+
+// Staff account lookup and one-time registration-code recovery unlock (issue #520).
+class AdminAccountManagementTests: XCTestCase, SwiftarrBaseTest {
+
+	private func makeUser(
+		_ app: Application,
+		username: String,
+		accessLevel: UserAccessLevel,
+		verification: String? = nil,
+		recoveryAttempts: Int = 0
+	) async throws -> User {
+		let user = User(
+			username: username,
+			password: try Bcrypt.hash("password1"),
+			recoveryKey: try Bcrypt.hash("recovery key"),
+			verification: verification,
+			accessLevel: accessLevel,
+			recoveryAttempts: recoveryAttempts
+		)
+		try await user.save(on: app.db)
+		return user
+	}
+
+	private func makeToken(_ app: Application, for user: User) async throws -> String {
+		let token = try Token.generate(for: user)
+		try await token.save(on: app.db)
+		return token.token
+	}
+
+	private func bearer(_ token: String) -> HTTPHeaders {
+		var headers = HTTPHeaders()
+		headers.bearerAuthorization = BearerAuthorization(token: token)
+		return headers
+	}
+
+	private func recoveryBody(username: String, key: String) -> UserRecoveryData {
+		UserRecoveryData(username: username, recoveryKey: key, newPassword: "newpassword1")
+	}
+
+	private func bootCache(_ app: Application) async throws {
+		try await app.asyncBoot()
+		try await app.initializeUserCache(app)
+	}
+
+	func testFindByUser_ReportsSpentRecovery() async throws {
+		try await withApp { app in
+			let suffix = UUID().uuidString.prefix(8).lowercased()
+			let staff = try await makeUser(app, username: "acctmgr-\(suffix)", accessLevel: .verified)
+			try await UserRole(user: staff.requireID(), role: .accountmanager).create(on: app.db)
+			let target = try await makeUser(
+				app,
+				username: "spent-\(suffix)",
+				accessLevel: .verified,
+				verification: "*abc123"
+			)
+			let staffToken = try await makeToken(app, for: staff)
+			try await bootCache(app)
+
+			try await app.test(
+				.GET,
+				"/api/v3/admin/regcodes/findbyuser/\(try target.requireID())",
+				headers: bearer(staffToken),
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .ok)
+					let data = try res.content.decode(RegistrationCodeUserData.self)
+					XCTAssertTrue(data.hasUsedRegCodeForPasswordRecovery)
+					XCTAssertNotNil(data.accountCreatedAt)
+				}
+			)
+		}
+	}
+
+	func testFindByUser_ReportsUnspentRecovery() async throws {
+		try await withApp { app in
+			let suffix = UUID().uuidString.prefix(8).lowercased()
+			let staff = try await makeUser(app, username: "acctmgr-\(suffix)", accessLevel: .verified)
+			try await UserRole(user: staff.requireID(), role: .accountmanager).create(on: app.db)
+			let target = try await makeUser(
+				app,
+				username: "unspent-\(suffix)",
+				accessLevel: .verified,
+				verification: "abc123"
+			)
+			let staffToken = try await makeToken(app, for: staff)
+			try await bootCache(app)
+
+			try await app.test(
+				.GET,
+				"/api/v3/admin/regcodes/findbyuser/\(try target.requireID())",
+				headers: bearer(staffToken),
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .ok)
+					let data = try res.content.decode(RegistrationCodeUserData.self)
+					XCTAssertFalse(data.hasUsedRegCodeForPasswordRecovery)
+				}
+			)
+		}
+	}
+
+	func testUnlock_ForbiddenWithoutRole() async throws {
+		try await withApp { app in
+			let suffix = UUID().uuidString.prefix(8).lowercased()
+			let verified = try await makeUser(app, username: "verified-\(suffix)", accessLevel: .verified)
+			let target = try await makeUser(
+				app,
+				username: "target-\(suffix)",
+				accessLevel: .verified,
+				verification: "*abc123"
+			)
+			let verifiedToken = try await makeToken(app, for: verified)
+			try await bootCache(app)
+
+			try await app.test(
+				.POST,
+				"/api/v3/admin/regcodes/unlock/\(try target.requireID())",
+				headers: bearer(verifiedToken),
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .forbidden)
+				}
+			)
+		}
+	}
+
+	func testUnlock_AllowedForAccountManager() async throws {
+		try await withApp { app in
+			let suffix = UUID().uuidString.prefix(8).lowercased()
+			let staff = try await makeUser(app, username: "acctmgr-\(suffix)", accessLevel: .verified)
+			try await UserRole(user: staff.requireID(), role: .accountmanager).create(on: app.db)
+			let target = try await makeUser(
+				app,
+				username: "unlock-mgr-\(suffix)",
+				accessLevel: .verified,
+				verification: "*abc123"
+			)
+			let staffToken = try await makeToken(app, for: staff)
+			try await bootCache(app)
+
+			try await app.test(
+				.POST,
+				"/api/v3/admin/regcodes/unlock/\(try target.requireID())",
+				headers: bearer(staffToken),
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .ok)
+					let data = try res.content.decode(RegistrationCodeUserData.self)
+					XCTAssertFalse(data.hasUsedRegCodeForPasswordRecovery)
+				}
+			)
+
+			let reloaded = try await User.find(target.requireID(), on: app.db)
+			XCTAssertEqual(reloaded?.verification, "abc123")
+		}
+	}
+
+	func testUnlock_AllowedForTwitarrTeam() async throws {
+		try await withApp { app in
+			let suffix = UUID().uuidString.prefix(8).lowercased()
+			let staff = try await makeUser(app, username: "tt-\(suffix)", accessLevel: .twitarrteam)
+			let target = try await makeUser(
+				app,
+				username: "unlock-tt-\(suffix)",
+				accessLevel: .verified,
+				verification: "*abc123"
+			)
+			let staffToken = try await makeToken(app, for: staff)
+			try await bootCache(app)
+
+			try await app.test(
+				.POST,
+				"/api/v3/admin/regcodes/unlock/\(try target.requireID())",
+				headers: bearer(staffToken),
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .ok)
+				}
+			)
+
+			let reloaded = try await User.find(target.requireID(), on: app.db)
+			XCTAssertEqual(reloaded?.verification, "abc123")
+		}
+	}
+
+	func testUnlock_SpentCodeRecoversAgain() async throws {
+		try await withApp { app in
+			let suffix = UUID().uuidString.prefix(8).lowercased()
+			let staff = try await makeUser(app, username: "acctmgr-\(suffix)", accessLevel: .verified)
+			try await UserRole(user: staff.requireID(), role: .accountmanager).create(on: app.db)
+			let username = "recover-again-\(suffix)"
+			let target = try await makeUser(
+				app,
+				username: username,
+				accessLevel: .verified,
+				verification: "*abc123"
+			)
+			let staffToken = try await makeToken(app, for: staff)
+			try await bootCache(app)
+
+			try await app.test(
+				.POST,
+				"/api/v3/admin/regcodes/unlock/\(try target.requireID())",
+				headers: bearer(staffToken),
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .ok)
+				}
+			)
+
+			try await app.test(
+				.POST,
+				"/api/v3/auth/recovery",
+				beforeRequest: { req async throws in
+					try req.content.encode(recoveryBody(username: username, key: "abc123"))
+				},
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .ok, "an unlocked registration code must recover the account")
+				}
+			)
+
+			let reloaded = try await User.find(target.requireID(), on: app.db)
+			XCTAssertEqual(reloaded?.verification, "*abc123")
+		}
+	}
+
+	func testUnlock_ClearsRecoveryAttemptsLockout() async throws {
+		try await withApp { app in
+			let suffix = UUID().uuidString.prefix(8).lowercased()
+			let staff = try await makeUser(app, username: "acctmgr-\(suffix)", accessLevel: .verified)
+			try await UserRole(user: staff.requireID(), role: .accountmanager).create(on: app.db)
+			let username = "lockout-\(suffix)"
+			let target = try await makeUser(
+				app,
+				username: username,
+				accessLevel: .verified,
+				verification: "abc123",
+				recoveryAttempts: 5
+			)
+			let staffToken = try await makeToken(app, for: staff)
+			try await bootCache(app)
+
+			try await app.test(
+				.POST,
+				"/api/v3/auth/recovery",
+				beforeRequest: { req async throws in
+					try req.content.encode(recoveryBody(username: username, key: "abc123"))
+				},
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .forbidden, "five failed recoveries must lock the account")
+				}
+			)
+
+			try await app.test(
+				.POST,
+				"/api/v3/admin/regcodes/unlock/\(try target.requireID())",
+				headers: bearer(staffToken),
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .ok)
+				}
+			)
+
+			try await app.test(
+				.POST,
+				"/api/v3/auth/recovery",
+				beforeRequest: { req async throws in
+					try req.content.encode(recoveryBody(username: username, key: "abc123"))
+				},
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .ok, "unlock must clear the recovery-attempts lockout")
+				}
+			)
+		}
+	}
+}

--- a/Tests/AppTests/AuthControllerTests.swift
+++ b/Tests/AppTests/AuthControllerTests.swift
@@ -89,4 +89,89 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 			XCTAssertEqual(reloaded?.verification, "*abc123")
 		}
 	}
+
+	func testRecovery_SpacedCodeIsSpent() async throws {
+		try await withApp { app in
+			let username = "recovery-spaced-\(UUID().uuidString.prefix(8))"
+			let user = try await makeRecoveryUser(app, username: username, verification: "abcabc")
+			defer { Task { try? await user.delete(on: app.db) } }
+
+			try await app.test(
+				.POST,
+				"/api/v3/auth/recovery",
+				beforeRequest: { req async throws in
+					try req.content.encode(recoveryBody(username: username, key: "abc abc"))
+				},
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .ok, "a spaced registration code must recover the account")
+				}
+			)
+
+			let reloaded = try await User.find(user.requireID(), on: app.db)
+			XCTAssertEqual(reloaded?.verification, "*abcabc")
+		}
+	}
+
+	func testRecovery_UppercaseSpacedCodeIsSpent() async throws {
+		try await withApp { app in
+			let username = "recovery-upper-\(UUID().uuidString.prefix(8))"
+			let user = try await makeRecoveryUser(app, username: username, verification: "abcabc")
+			defer { Task { try? await user.delete(on: app.db) } }
+
+			try await app.test(
+				.POST,
+				"/api/v3/auth/recovery",
+				beforeRequest: { req async throws in
+					try req.content.encode(recoveryBody(username: username, key: "ABC ABC"))
+				},
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .ok, "an uppercase spaced registration code must recover the account")
+				}
+			)
+
+			let reloaded = try await User.find(user.requireID(), on: app.db)
+			XCTAssertEqual(reloaded?.verification, "*abcabc")
+		}
+	}
+
+	func testRecovery_NonBreakingSpaceCodeIsSpent() async throws {
+		try await withApp { app in
+			let username = "recovery-nbsp-\(UUID().uuidString.prefix(8))"
+			let user = try await makeRecoveryUser(app, username: username, verification: "abcabc")
+			defer { Task { try? await user.delete(on: app.db) } }
+
+			try await app.test(
+				.POST,
+				"/api/v3/auth/recovery",
+				beforeRequest: { req async throws in
+					try req.content.encode(recoveryBody(username: username, key: "abc\u{00A0}abc"))
+				},
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .ok, "a registration code with a non-breaking space must recover the account")
+				}
+			)
+
+			let reloaded = try await User.find(user.requireID(), on: app.db)
+			XCTAssertEqual(reloaded?.verification, "*abcabc")
+		}
+	}
+
+	func testRecovery_SpacedSpentCodeIsRejected() async throws {
+		try await withApp { app in
+			let username = "recovery-spaced-spent-\(UUID().uuidString.prefix(8))"
+			let user = try await makeRecoveryUser(app, username: username, verification: "*abcabc")
+			defer { Task { try? await user.delete(on: app.db) } }
+
+			try await app.test(
+				.POST,
+				"/api/v3/auth/recovery",
+				beforeRequest: { req async throws in
+					try req.content.encode(recoveryBody(username: username, key: "abc abc"))
+				},
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .badRequest, "a spent spaced registration code must not recover the account")
+				}
+			)
+		}
+	}
 }

--- a/Tests/AppTests/UserStructValidationTests.swift
+++ b/Tests/AppTests/UserStructValidationTests.swift
@@ -91,9 +91,14 @@ class UserStructValidationTests: XCTestCase {
 		XCTAssertEqual(errs, [])
 	}
 
-	func testUserVerify_Valid7Char() throws {
-		let errs = try validationErrors(UserVerifyData.self, #"{"verification":"abc1234"}"#)
+	func testUserVerify_ValidWithSpace() throws {
+		let errs = try validationErrors(UserVerifyData.self, #"{"verification":"abc 123"}"#)
 		XCTAssertEqual(errs, [])
+	}
+
+	func testUserVerify_SevenAlphanumeric_Fails() throws {
+		let errs = try validationErrors(UserVerifyData.self, #"{"verification":"abc1234"}"#)
+		XCTAssertEqual(errs.count, 1)
 	}
 
 	func testUserVerify_TooShort_Fails() throws {

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -229,3 +229,10 @@ associated AddedToChat field value increase.
 * `GET /api/v3/photostream` now supports a `byUser` UUID query parameter.
 * `POST /api/v3/photostream/upload` now returns the created
   `PhotostreamImageData` in its successful response body.
+
+## Aug 22, 2026
+* Added `hasUsedRegCodeForPasswordRecovery` and `accountCreatedAt` to `RegistrationCodeUserData`.
+* `GET /api/v3/admin/regcodes/stats`, `GET /api/v3/admin/regcodes/find/:search_string`, and `GET /api/v3/admin/regcodes/findbyuser/:userID` are now accessible to TwitarrTeam and above **or** users with the `accountmanager` role.
+* New endpoint `POST /api/v3/admin/regcodes/unlock/:userID` re-enables one-time registration-code password recovery (strips the spent `*` prefix on `User.verification` and clears `recoveryAttempts`). TwitarrTeam or `accountmanager` only.
+
+


### PR DESCRIPTION
This adds new capabilities around "unlocking" user accounts so that they can reset their passwords using their registration code. Previous to this users could only use their registration code to unlock their account once. After that they would need their recovery key. 2026 saw a SIGNIFICANT number of users not store their passwords or recovery keys leading to lots of help desk traffic. Additionally, the Info Desk got a lot of users throughout the week looking to reset their account but were not empowered to help them.

This PR addresses these issues in two ways:

1. A discrete `unlock` action which a privileged operator can perform on a user to allow their registration code to be used again. This is done via a new API endpoint and pre-existing Site UI views. This action can be performed by TwitarrTeam and above, as well as a new role (see next).
2. Creation of an "Account Manager" role which can be entitled to authorized users allowing them to perform the unlock. The intention is that Info Desk personnel can be granted this role to allow them to unlock users without needing TwitarrTeam or above. In 2026 there was a shared InfoDesk user account that was used mostly to DM TwitarrTeam asking on behalf of users if there was anything we could do (the answer was usually no).

In addition to the new functionality a lot of the logic around the registration code formatting, verification, and recovery got some touchups.