### PR TITLE
fix: rewrite /lfg URLs in posts as LFG links

### DIFF
--- a/Sources/swiftarr/Site/Utilities/CustomLeafTags.swift
+++ b/Sources/swiftarr/Site/Utilities/CustomLeafTags.swift
@@ -192,7 +192,7 @@ struct FormatPostTextTag: UnsafeUnescapedLeafTag {
 
 		// Links in posts should be automatically clickable. Similarly, we desire to shorten Twitarr
 		// specific links. Maybe someday we could parse them and give some linktext?
-		// e.g. "http://192.168.0.19:8081/fez/ADDBA5D9-1154-4033-88AE-07B12F3AE162"
+		// e.g. "http://192.168.0.19:8081/lfg/ADDBA5D9-1154-4033-88AE-07B12F3AE162"
 		// could have linktext "[An LFG Link]" or somesuch.
 
 		// Since we have multiple potential Twitarr hostnames (twitarr.com, joco.hollandamerica.com)
@@ -250,42 +250,8 @@ struct FormatPostTextTag: UnsafeUnescapedLeafTag {
 			{
 				(components.scheme, components.host, components.port) = (nil, nil, nil)
 				var linkText = components.string
-				if let url = URL(string: urlStr), url.pathComponents.count > 1, url.pathComponents[0] == "/" {
-					switch url.pathComponents[1] {
-					case "tweets": linkText = "[Twitarr Tweet Link]"
-					case "forums":
-						if url.pathComponents.count == 2 {
-							linkText = "[Forum Categories Link]"
-						}
-						else {
-							linkText = "[Forum Category Link]"
-						}
-					case "forum": linkText = "[Forum Link]"
-					case "seamail": linkText = "[Seamail Link]"
-					case "fez":
-						if url.pathComponents.count > 2 {
-							switch url.pathComponents[2] {
-							case "joined": linkText = "[Joined LFGs Link]"
-							case "owned": linkText = "[Your LFGs Link]"
-							case "faq": linkText = "[LFG FAQ Link]"
-							default: linkText = "[LFG Link]"
-							}
-						}
-						else {
-							linkText = "[LFGs Link]"
-						}
-					case "events": linkText = "[Events Link]"
-					case "user", "profile": linkText = "[User Link]"
-					case "boardgames":
-						if url.pathComponents.count > 2 {
-							linkText = "[Boardgame Link]"
-						}
-						else {
-							linkText = "[Boardgames Link]"
-						}
-					case "karaoke": linkText = "[Karaoke Link]"
-					default: linkText = "[Twitarr Link]"
-					}
+				if let url = URL(string: urlStr) {
+					linkText = Self.canonicalLinkText(pathComponents: url.pathComponents) ?? linkText
 				}
 				// Replace the link's text with a wiki-like linkbox describing where the link goes
 				string.replaceSubrange(
@@ -300,6 +266,47 @@ struct FormatPostTextTag: UnsafeUnescapedLeafTag {
 					with: "<a href=\"\(components.string!)\">\(components.string!)</a>\(urlTextSuffix)"
 				)
 			}
+		}
+	}
+
+	/// Wiki-style label for a canonical Twitarr site path, or `nil` when the path shouldn't be rewritten.
+	/// Site LFG routes live under `/lfg`; `/fez` is kept so older posted URLs still get LFG labels.
+	static func canonicalLinkText(pathComponents: [String]) -> String? {
+		guard pathComponents.count > 1, pathComponents[0] == "/" else { return nil }
+		switch pathComponents[1] {
+		case "tweets": return "[Twitarr Tweet Link]"
+		case "forums":
+			if pathComponents.count == 2 {
+				return "[Forum Categories Link]"
+			}
+			else {
+				return "[Forum Category Link]"
+			}
+		case "forum": return "[Forum Link]"
+		case "seamail": return "[Seamail Link]"
+		case "fez", "lfg":
+			if pathComponents.count > 2 {
+				switch pathComponents[2] {
+				case "joined": return "[Joined LFGs Link]"
+				case "owned": return "[Your LFGs Link]"
+				case "faq": return "[LFG FAQ Link]"
+				default: return "[LFG Link]"
+				}
+			}
+			else {
+				return "[LFGs Link]"
+			}
+		case "events": return "[Events Link]"
+		case "user", "profile": return "[User Link]"
+		case "boardgames":
+			if pathComponents.count > 2 {
+				return "[Boardgame Link]"
+			}
+			else {
+				return "[Boardgames Link]"
+			}
+		case "karaoke": return "[Karaoke Link]"
+		default: return "[Twitarr Link]"
 		}
 	}
 

--- a/Tests/AppTests/CanonicalLinkTextTests.swift
+++ b/Tests/AppTests/CanonicalLinkTextTests.swift
@@ -1,0 +1,63 @@
+import XCTVapor
+@testable import swiftarr
+
+class CanonicalLinkTextTests: XCTestCase {
+
+	private func linkText(for url: String) -> String? {
+		FormatPostTextTag.canonicalLinkText(pathComponents: URL(string: url)!.pathComponents)
+	}
+
+	// MARK: - LFG routes (current site paths)
+
+	func testLFGRoot() {
+		XCTAssertEqual(linkText(for: "https://twitarr.com/lfg"), "[LFGs Link]")
+		XCTAssertEqual(linkText(for: "https://twitarr.com/lfg/"), "[LFGs Link]")
+	}
+
+	func testLFGJoined() {
+		XCTAssertEqual(linkText(for: "https://twitarr.com/lfg/joined"), "[Joined LFGs Link]")
+	}
+
+	func testLFGOwned() {
+		XCTAssertEqual(linkText(for: "https://twitarr.com/lfg/owned"), "[Your LFGs Link]")
+	}
+
+	func testLFGFAQ() {
+		XCTAssertEqual(linkText(for: "https://twitarr.com/lfg/faq"), "[LFG FAQ Link]")
+	}
+
+	func testLFGSpecific() {
+		XCTAssertEqual(
+			linkText(for: "https://twitarr.com/lfg/ADDBA5D9-1154-4033-88AE-07B12F3AE162"),
+			"[LFG Link]"
+		)
+	}
+
+	// MARK: - Legacy /fez paths still posted in older content
+
+	func testLegacyFezPathsStillLabeledAsLFG() {
+		XCTAssertEqual(linkText(for: "https://twitarr.com/fez"), "[LFGs Link]")
+		XCTAssertEqual(linkText(for: "https://twitarr.com/fez/joined"), "[Joined LFGs Link]")
+		XCTAssertEqual(linkText(for: "https://twitarr.com/fez/owned"), "[Your LFGs Link]")
+		XCTAssertEqual(linkText(for: "https://twitarr.com/fez/faq"), "[LFG FAQ Link]")
+		XCTAssertEqual(
+			linkText(for: "https://twitarr.com/fez/ADDBA5D9-1154-4033-88AE-07B12F3AE162"),
+			"[LFG Link]"
+		)
+	}
+
+	// MARK: - Other canonical paths still rewrite
+
+	func testTweetsPath() {
+		XCTAssertEqual(linkText(for: "https://twitarr.com/tweets"), "[Twitarr Tweet Link]")
+	}
+
+	func testUnrecognizedSitePath() {
+		XCTAssertEqual(linkText(for: "https://twitarr.com/photostream"), "[Twitarr Link]")
+	}
+
+	func testPathTooShortIsNotRewritten() {
+		XCTAssertNil(FormatPostTextTag.canonicalLinkText(pathComponents: ["/"]))
+		XCTAssertNil(FormatPostTextTag.canonicalLinkText(pathComponents: []))
+	}
+}

--- a/docs/Swiftarr/Canonical Links.md
+++ b/docs/Swiftarr/Canonical Links.md
@@ -37,11 +37,11 @@ Method | Route | Notes
 | GET | /forum/:forum_id | Shows an individual forum thread.
 | GET | /forum/containingpost/:post_id | Shows the forum containing a specific post.
 | GET | /seamail | Shows the root seamail page, with a list of all the user's seamail chats.
-| GET | /fez/ | Root LFG page.
-| GET | /fez/joined | Shows LFGs you've joined.
-| GET | /fez/owned | Shows LFGs you've created.
-| GET | /fez/:fez_id | Shows a specific LFG.
-| GET | /fez/faq | Shows a guide to using LFGs responsibly.
+| GET | /lfg/ | Root LFG page.
+| GET | /lfg/joined | Shows LFGs you've joined.
+| GET | /lfg/owned | Shows LFGs you've created.
+| GET | /lfg/:fez_id | Shows a specific LFG.
+| GET | /lfg/faq | Shows a guide to using LFGs responsibly.
 | GET | /events | Shows the Events page. Several query options.
 | GET | /avatar/full/:user_id | Returns an image (not HTML wrapping an image)
 | GET | /avatar/thumb/:user_id | Returns an image


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #573.

Site LFG pages live under `/lfg`, but the Leaf tag that turns canonical Twitarr URLs in posts into wiki-style labels still switched on `fez`. A pasted `https://twitarr.com/lfg/...` link therefore fell through to `[Twitarr Link]` instead of `[LFG Link]`.

This change:

- Labels `/lfg` the same way `/fez` was labeled (root, joined, owned, faq, and a specific LFG)
- Still accepts `/fez` so older posted URLs keep LFG labels
- Updates Canonical Links to the current `/lfg` routes
- Adds unit tests for the path-to-label mapping

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92c0b5ab-93e6-4cd8-be49-2941dc3ca582?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92c0b5ab-93e6-4cd8-be49-2941dc3ca582&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

