### PR TITLE
Expose photostream upload interval in admin server settings

### DIFF
--- a/Sources/swiftarr/Controllers/AdminController.swift
+++ b/Sources/swiftarr/Controllers/AdminController.swift
@@ -187,8 +187,8 @@ struct AdminController: APIRouteCollection {
 		if let value = data.maxForumPostImages {
 			Settings.shared.maxForumPostImages = value
 		}
-		if let value = data.photostreamUploadRateLimit, value >= 0 {
-			Settings.shared.photostreamUploadRateLimit = TimeInterval(value)
+		if let value = data.photostreamUploadRateLimit {
+			Settings.shared.photostreamUploadRateLimit = value
 		}
 		if let value = data.forumAutoQuarantineThreshold {
 			Settings.shared.forumAutoQuarantineThreshold = value

--- a/Sources/swiftarr/Controllers/AdminController.swift
+++ b/Sources/swiftarr/Controllers/AdminController.swift
@@ -187,6 +187,9 @@ struct AdminController: APIRouteCollection {
 		if let value = data.maxForumPostImages {
 			Settings.shared.maxForumPostImages = value
 		}
+		if let value = data.photostreamUploadRateLimit, value >= 0 {
+			Settings.shared.photostreamUploadRateLimit = TimeInterval(value)
+		}
 		if let value = data.forumAutoQuarantineThreshold {
 			Settings.shared.forumAutoQuarantineThreshold = value
 		}

--- a/Sources/swiftarr/Controllers/PhotostreamController.swift
+++ b/Sources/swiftarr/Controllers/PhotostreamController.swift
@@ -190,10 +190,12 @@ struct PhotostreamController: APIRouteCollection {
 	}
 
 	func photostreamRateLimitErrorReason(_ rateLimit: TimeInterval) -> String {
-		if rateLimit < 60 {
-			return "You may only upload one Photostream photo every \(Int(rateLimit)) seconds."
+		let seconds = Int(rateLimit.rounded())
+		if seconds > 0, seconds % 60 == 0 {
+			let minutes = seconds / 60
+			return "You may only upload one Photostream photo every \(minutes) \(minutes == 1 ? "minute" : "minutes")."
 		}
-		return "You may only upload one Photostream photo every \(rateLimit / 60) minutes."
+		return "You may only upload one Photostream photo every \(seconds) \(seconds == 1 ? "second" : "seconds")."
 	}
 
 	func makeUploadResponse(photo: PhotostreamImageData, rateLimit: TimeInterval) throws -> Response {

--- a/Sources/swiftarr/Controllers/PhotostreamController.swift
+++ b/Sources/swiftarr/Controllers/PhotostreamController.swift
@@ -148,9 +148,10 @@ struct PhotostreamController: APIRouteCollection {
 	func photostreamUploadHandler(_ req: Request) async throws -> Response {
 		let user = try req.auth.require(UserCacheData.self)
 		try user.guardCanCreateContent(customErrorString: "user cannot post to photostream")
+		let rateLimit = Settings.shared.photostreamUploadRateLimit
 		if let userPrevPhoto = try await StreamPhoto.query(on: req.db).filter(\.$author.$id == user.userID).sort(\.$id, .descending).first(),
-				userPrevPhoto.captureTime > Date() - Settings.shared.photostreamUploadRateLimit {
-			throw Abort(.tooManyRequests, reason: "You may only upload one Photostream photo every \(Settings.shared.photostreamUploadRateLimit / 60) minutes.")
+				isWithinUploadRateLimit(previousCaptureTime: userPrevPhoto.captureTime, rateLimit: rateLimit) {
+			throw Abort(.tooManyRequests, reason: photostreamRateLimitErrorReason(rateLimit))
 		}
 		let newPostData = try ValidatingJSONDecoder().decode(PhotostreamUploadData.self, fromBodyOf: req)
 		// The only valid place names are what getPlacenames returns
@@ -180,6 +181,19 @@ struct PhotostreamController: APIRouteCollection {
 		try await streamPhoto.save(on: req.db)
 		let photoData = try PhotostreamImageData(streamPhoto: streamPhoto, author: user.makeHeader())
 		return try makeUploadResponse(photo: photoData, rateLimit: Settings.shared.photostreamUploadRateLimit)
+	}
+
+	/// `true` when another photostream upload should be rejected. A `rateLimit` of `0` (or less) disables the limit.
+	func isWithinUploadRateLimit(previousCaptureTime: Date, now: Date = Date(), rateLimit: TimeInterval) -> Bool {
+		guard rateLimit > 0 else { return false }
+		return previousCaptureTime > now - rateLimit
+	}
+
+	func photostreamRateLimitErrorReason(_ rateLimit: TimeInterval) -> String {
+		if rateLimit < 60 {
+			return "You may only upload one Photostream photo every \(Int(rateLimit)) seconds."
+		}
+		return "You may only upload one Photostream photo every \(rateLimit / 60) minutes."
 	}
 
 	func makeUploadResponse(photo: PhotostreamImageData, rateLimit: TimeInterval) throws -> Response {

--- a/Sources/swiftarr/Controllers/PhotostreamController.swift
+++ b/Sources/swiftarr/Controllers/PhotostreamController.swift
@@ -150,8 +150,8 @@ struct PhotostreamController: APIRouteCollection {
 		try user.guardCanCreateContent(customErrorString: "user cannot post to photostream")
 		let rateLimit = Settings.shared.photostreamUploadRateLimit
 		if let userPrevPhoto = try await StreamPhoto.query(on: req.db).filter(\.$author.$id == user.userID).sort(\.$id, .descending).first(),
-				isWithinUploadRateLimit(previousCaptureTime: userPrevPhoto.captureTime, rateLimit: rateLimit) {
-			throw Abort(.tooManyRequests, reason: photostreamRateLimitErrorReason(rateLimit))
+				isWithinUploadRateLimit(previousCaptureTime: userPrevPhoto.captureTime, rateLimit: TimeInterval(rateLimit)) {
+			throw Abort(.tooManyRequests, reason: photostreamRateLimitErrorReason(TimeInterval(rateLimit)))
 		}
 		let newPostData = try ValidatingJSONDecoder().decode(PhotostreamUploadData.self, fromBodyOf: req)
 		// The only valid place names are what getPlacenames returns
@@ -180,7 +180,7 @@ struct PhotostreamController: APIRouteCollection {
 				boatLocation: boatLocation)
 		try await streamPhoto.save(on: req.db)
 		let photoData = try PhotostreamImageData(streamPhoto: streamPhoto, author: user.makeHeader())
-		return try makeUploadResponse(photo: photoData, rateLimit: Settings.shared.photostreamUploadRateLimit)
+		return try makeUploadResponse(photo: photoData, rateLimit: TimeInterval(Settings.shared.photostreamUploadRateLimit))
 	}
 
 	/// `true` when another photostream upload should be rejected. A `rateLimit` of `0` (or less) disables the limit.

--- a/Sources/swiftarr/Controllers/Structs/AdminControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/AdminControllerStructs.swift
@@ -473,7 +473,7 @@ extension SettingsAdminData {
 		self.maximumForumPosts = settings.maximumForumPosts
 		self.maxImageSize = settings.maxImageSize
 		self.maxForumPostImages = settings.maxForumPostImages
-		self.photostreamUploadRateLimit = Int(settings.photostreamUploadRateLimit)
+		self.photostreamUploadRateLimit = settings.photostreamUploadRateLimit
 		self.forumAutoQuarantineThreshold = settings.forumAutoQuarantineThreshold
 		self.postAutoQuarantineThreshold = settings.postAutoQuarantineThreshold
 		self.userAutoQuarantineThreshold = settings.userAutoQuarantineThreshold

--- a/Sources/swiftarr/Controllers/Structs/AdminControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/AdminControllerStructs.swift
@@ -447,6 +447,8 @@ public struct SettingsAdminData: Content {
 	var maxImageSize: Int
 	/// Maximum number of images allowed per forum post.
 	var maxForumPostImages: Int
+	/// Minimum seconds a user must wait between photostream uploads. `0` disables the limit.
+	var photostreamUploadRateLimit: Int
 	var forumAutoQuarantineThreshold: Int
 	var postAutoQuarantineThreshold: Int
 	var userAutoQuarantineThreshold: Int
@@ -471,6 +473,7 @@ extension SettingsAdminData {
 		self.maximumForumPosts = settings.maximumForumPosts
 		self.maxImageSize = settings.maxImageSize
 		self.maxForumPostImages = settings.maxForumPostImages
+		self.photostreamUploadRateLimit = Int(settings.photostreamUploadRateLimit)
 		self.forumAutoQuarantineThreshold = settings.forumAutoQuarantineThreshold
 		self.postAutoQuarantineThreshold = settings.postAutoQuarantineThreshold
 		self.userAutoQuarantineThreshold = settings.userAutoQuarantineThreshold
@@ -505,6 +508,8 @@ public struct SettingsUpdateData: Content {
 	var maximumForumPosts: Int?
 	var maxImageSize: Int?
 	var maxForumPostImages: Int?
+	/// Minimum seconds a user must wait between photostream uploads. `0` disables the limit.
+	var photostreamUploadRateLimit: Int?
 	var forumAutoQuarantineThreshold: Int?
 	var postAutoQuarantineThreshold: Int?
 	var userAutoQuarantineThreshold: Int?

--- a/Sources/swiftarr/Controllers/Structs/AdminControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/AdminControllerStructs.swift
@@ -473,7 +473,7 @@ extension SettingsAdminData {
 		self.maximumForumPosts = settings.maximumForumPosts
 		self.maxImageSize = settings.maxImageSize
 		self.maxForumPostImages = settings.maxForumPostImages
-		self.photostreamUploadRateLimit = settings.photostreamUploadRateLimit
+		self.photostreamUploadRateLimit = Int(settings.photostreamUploadRateLimit)
 		self.forumAutoQuarantineThreshold = settings.forumAutoQuarantineThreshold
 		self.postAutoQuarantineThreshold = settings.postAutoQuarantineThreshold
 		self.userAutoQuarantineThreshold = settings.userAutoQuarantineThreshold

--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -2842,6 +2842,8 @@ public struct ClientSettingsData: Content {
 	var maxForumPostImages: Int
 	/// Maximum size of a single uploaded image, in bytes.
 	var maxImageSize: Int
+	/// Minimum seconds a user must wait between photostream uploads. `0` disables the limit.
+	var photostreamUploadRateLimit: Int
 	/// Unique identifier for this Postgres database installation (from pg_control_system())
 	var installationID: String
 }
@@ -2860,6 +2862,7 @@ extension ClientSettingsData {
 		self.minAccessLevel = Settings.shared.minAccessLevel.rawValue
 		self.maxForumPostImages = Settings.shared.maxForumPostImages
 		self.maxImageSize = Settings.shared.maxImageSize
+		self.photostreamUploadRateLimit = Int(Settings.shared.photostreamUploadRateLimit)
 		self.installationID = installationID
 	}
 }

--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -2862,7 +2862,7 @@ extension ClientSettingsData {
 		self.minAccessLevel = Settings.shared.minAccessLevel.rawValue
 		self.maxForumPostImages = Settings.shared.maxForumPostImages
 		self.maxImageSize = Settings.shared.maxImageSize
-		self.photostreamUploadRateLimit = Int(Settings.shared.photostreamUploadRateLimit)
+		self.photostreamUploadRateLimit = Settings.shared.photostreamUploadRateLimit
 		self.installationID = installationID
 	}
 }

--- a/Sources/swiftarr/Helpers/Settings.swift
+++ b/Sources/swiftarr/Helpers/Settings.swift
@@ -103,7 +103,7 @@ final class Settings: Encodable, @unchecked Sendable {
 	/// Maximum number of images allowed per forum post.
 	@StoredSettingsValue("maxForumPostImages", defaultValue: 4) var maxForumPostImages: Int
 
-	/// How long a single user must wait between photostream uploads, in seconds.
+	/// How long a single user must wait between photostream uploads, in seconds. `0` disables the limit.
 	@StoredSettingsValue("photostreamUploadRateLimit", defaultValue: 300) var photostreamUploadRateLimit: TimeInterval
 
 	// MARK: Quarantine

--- a/Sources/swiftarr/Helpers/Settings.swift
+++ b/Sources/swiftarr/Helpers/Settings.swift
@@ -45,10 +45,6 @@ final class Settings: Encodable, @unchecked Sendable {
 			if let value = T(fromRESP: result) {
 				self.wrappedValue = value
 			}
-			else if T.self == Int.self, let intValue = Settings.intSetting(fromRESP: result) {
-				// `photostreamUploadRateLimit` used to be a TimeInterval; Redis still has values like "300.0".
-				self.wrappedValue = intValue as! T
-			}
 		}
 
 		// Call after setting value
@@ -357,18 +353,6 @@ extension Settings {
 	/// Shutternauts are allowed up to 8 images, other users are limited by the `maxForumPostImages` setting.
 	func getMaxForumPostImages(for user: UserCacheData) -> Int {
 		return user.userRoles.contains(.shutternaut) ? 8 : maxForumPostImages
-	}
-
-	/// Decode an Int stored-setting from Redis. Accepts both `"300"` and `"300.0"` because some
-	/// settings were previously stored as `TimeInterval` and written with Double's description.
-	static func intSetting(fromRESP value: RESPValue) -> Int? {
-		if let int = Int(fromRESP: value) {
-			return int
-		}
-		guard let string = String(fromRESP: value), let double = Double(string) else {
-			return nil
-		}
-		return Int(double)
 	}
 
 }

--- a/Sources/swiftarr/Helpers/Settings.swift
+++ b/Sources/swiftarr/Helpers/Settings.swift
@@ -104,7 +104,7 @@ final class Settings: Encodable, @unchecked Sendable {
 	@StoredSettingsValue("maxForumPostImages", defaultValue: 4) var maxForumPostImages: Int
 
 	/// How long a single user must wait between photostream uploads, in seconds. `0` disables the limit.
-	@StoredSettingsValue("photostreamUploadRateLimit", defaultValue: 300) var photostreamUploadRateLimit: TimeInterval
+	@StoredSettingsValue("photostreamUploadRateLimit", defaultValue: 300) var photostreamUploadRateLimit: Int
 
 	// MARK: Quarantine
 	/// The number of reports to trigger forum auto-quarantine.

--- a/Sources/swiftarr/Helpers/Settings.swift
+++ b/Sources/swiftarr/Helpers/Settings.swift
@@ -45,6 +45,10 @@ final class Settings: Encodable, @unchecked Sendable {
 			if let value = T(fromRESP: result) {
 				self.wrappedValue = value
 			}
+			else if T.self == Int.self, let intValue = Settings.intSetting(fromRESP: result) {
+				// `photostreamUploadRateLimit` used to be a TimeInterval; Redis still has values like "300.0".
+				self.wrappedValue = intValue as! T
+			}
 		}
 
 		// Call after setting value
@@ -353,6 +357,18 @@ extension Settings {
 	/// Shutternauts are allowed up to 8 images, other users are limited by the `maxForumPostImages` setting.
 	func getMaxForumPostImages(for user: UserCacheData) -> Int {
 		return user.userRoles.contains(.shutternaut) ? 8 : maxForumPostImages
+	}
+
+	/// Decode an Int stored-setting from Redis. Accepts both `"300"` and `"300.0"` because some
+	/// settings were previously stored as `TimeInterval` and written with Double's description.
+	static func intSetting(fromRESP value: RESPValue) -> Int? {
+		if let int = Int(fromRESP: value) {
+			return int
+		}
+		guard let string = String(fromRESP: value), let double = Double(string) else {
+			return nil
+		}
+		return Int(double)
 	}
 
 }

--- a/Sources/swiftarr/Resources/Views/admin/serversettings.html
+++ b/Sources/swiftarr/Resources/Views/admin/serversettings.html
@@ -95,6 +95,11 @@
 						<label for="maxForumPostImages">Maximum images per forum post</label>
 						<input type="number" id="maxForumPostImages" name="maxForumPostImages" min="0" max="8" value="#(settings.maxForumPostImages)" #if(!enableFields):disabled#endif>
 					</li>
+					<li class="list-group-item">
+						<label for="photostreamUploadRateLimit">Photostream upload interval (seconds)</label>
+						<input type="number" id="photostreamUploadRateLimit" name="photostreamUploadRateLimit" min="0" max="3600" value="#(settings.photostreamUploadRateLimit)" #if(!enableFields):disabled#endif>
+						<br>Minimum time a user must wait between photostream uploads. Production default is 300 (5 minutes). Set to 0 to disable the limit.
+					</li>
 				</ul>
 				<ul class="list-group mt-2">
 					<li class="list-group-item active">

--- a/Sources/swiftarr/Resources/Views/admin/serversettings.html
+++ b/Sources/swiftarr/Resources/Views/admin/serversettings.html
@@ -98,7 +98,6 @@
 					<li class="list-group-item">
 						<label for="photostreamUploadRateLimit">Photostream upload interval (seconds)</label>
 						<input type="number" id="photostreamUploadRateLimit" name="photostreamUploadRateLimit" min="0" max="3600" value="#(settings.photostreamUploadRateLimit)" #if(!enableFields):disabled#endif>
-						<br>Minimum time a user must wait between photostream uploads. Production default is 300 (5 minutes). Set to 0 to disable the limit.
 					</li>
 				</ul>
 				<ul class="list-group mt-2">

--- a/Sources/swiftarr/Site/SiteAdminController.swift
+++ b/Sources/swiftarr/Site/SiteAdminController.swift
@@ -449,6 +449,7 @@ struct SiteAdminController: SiteControllerUtils {
 			var maximumForumPosts: Int
 			var maxImageSize: Int
 			var maxForumPostImages: Int
+			var photostreamUploadRateLimit: Int
 			var forumAutoQuarantineThreshold: Int
 			var postAutoQuarantineThreshold: Int
 			var userAutoQuarantineThreshold: Int
@@ -493,6 +494,7 @@ struct SiteAdminController: SiteControllerUtils {
 			maximumForumPosts: postStruct.maximumForumPosts,
 			maxImageSize: postStruct.maxImageSize * 1_048_576,
 			maxForumPostImages: postStruct.maxForumPostImages,
+			photostreamUploadRateLimit: postStruct.photostreamUploadRateLimit,
 			forumAutoQuarantineThreshold: postStruct.forumAutoQuarantineThreshold,
 			postAutoQuarantineThreshold: postStruct.postAutoQuarantineThreshold,
 			userAutoQuarantineThreshold: postStruct.userAutoQuarantineThreshold,

--- a/Tests/AppTests/ContentStructValidationTests.swift
+++ b/Tests/AppTests/ContentStructValidationTests.swift
@@ -121,6 +121,18 @@ class ContentStructValidationTests: XCTestCase {
 		XCTAssertEqual(json["maxImageSize"] as? Int, Settings.shared.maxImageSize)
 	}
 
+	func testClientSettings_EncodesPhotostreamUploadRateLimit() throws {
+		let settings = ClientSettingsData(installationID: "test-installation")
+		let data = try JSONEncoder().encode(settings)
+		let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+		XCTAssertEqual(
+			json["photostreamUploadRateLimit"] as? Int,
+			Int(Settings.shared.photostreamUploadRateLimit)
+		)
+		XCTAssertEqual(json["photostreamUploadRateLimit"] as? Int, 300)
+	}
+
 	// MARK: - ImageUploadData
 
 	func testImageUploadData_EmptyFilenameBecomesNil() {

--- a/Tests/AppTests/ContentStructValidationTests.swift
+++ b/Tests/AppTests/ContentStructValidationTests.swift
@@ -126,10 +126,7 @@ class ContentStructValidationTests: XCTestCase {
 		let data = try JSONEncoder().encode(settings)
 		let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
 
-		XCTAssertEqual(
-			json["photostreamUploadRateLimit"] as? Int,
-			Int(Settings.shared.photostreamUploadRateLimit)
-		)
+		XCTAssertEqual(json["photostreamUploadRateLimit"] as? Int, Settings.shared.photostreamUploadRateLimit)
 		XCTAssertEqual(json["photostreamUploadRateLimit"] as? Int, 300)
 	}
 

--- a/Tests/AppTests/PhotostreamControllerTests.swift
+++ b/Tests/AppTests/PhotostreamControllerTests.swift
@@ -108,4 +108,74 @@ final class PhotostreamControllerTests: XCTestCase, SwiftarrBaseTest {
 		XCTAssertEqual(content.image, "photostream-42.jpg")
 		XCTAssertEqual(content.location, PhotoStreamBoatLocation.onBoat.rawValue)
 	}
+
+	// MARK: - Upload rate limit
+
+	func testRateLimit_ZeroDisablesTheLimit() {
+		let controller = PhotostreamController()
+		let now = Date(timeIntervalSince1970: 1_725_000_000)
+		XCTAssertFalse(
+			controller.isWithinUploadRateLimit(
+				previousCaptureTime: now,
+				now: now,
+				rateLimit: 0
+			),
+			"a 0 second interval must allow back-to-back uploads for testing"
+		)
+	}
+
+	func testRateLimit_DefaultBlocksARecentUpload() {
+		let controller = PhotostreamController()
+		let now = Date(timeIntervalSince1970: 1_725_000_000)
+		XCTAssertTrue(
+			controller.isWithinUploadRateLimit(
+				previousCaptureTime: now.addingTimeInterval(-60),
+				now: now,
+				rateLimit: 300
+			),
+			"the production 5 minute default must reject an upload from 1 minute ago"
+		)
+	}
+
+	func testRateLimit_AllowsAnUploadAfterTheInterval() {
+		let controller = PhotostreamController()
+		let now = Date(timeIntervalSince1970: 1_725_000_000)
+		XCTAssertFalse(
+			controller.isWithinUploadRateLimit(
+				previousCaptureTime: now.addingTimeInterval(-301),
+				now: now,
+				rateLimit: 300
+			)
+		)
+	}
+
+	func testRateLimitErrorReason_UsesSecondsBelowOneMinute() {
+		let controller = PhotostreamController()
+		XCTAssertEqual(
+			controller.photostreamRateLimitErrorReason(30),
+			"You may only upload one Photostream photo every 30 seconds."
+		)
+		XCTAssertEqual(
+			controller.photostreamRateLimitErrorReason(300),
+			"You may only upload one Photostream photo every 5.0 minutes."
+		)
+	}
+
+	func testSettingsAdminDataExposesPhotostreamRateLimit() {
+		let data = SettingsAdminData(Settings.shared)
+		XCTAssertEqual(data.photostreamUploadRateLimit, Int(Settings.shared.photostreamUploadRateLimit))
+		XCTAssertEqual(data.photostreamUploadRateLimit, 300, "production default is 5 minutes")
+	}
+
+	func testSettingsUpdateDataDecodesPhotostreamRateLimit() throws {
+		let json = """
+			{
+				"enableFeatures": [],
+				"disableFeatures": [],
+				"photostreamUploadRateLimit": 0
+			}
+			""".data(using: .utf8)!
+		let data = try JSONDecoder().decode(SettingsUpdateData.self, from: json)
+		XCTAssertEqual(data.photostreamUploadRateLimit, 0)
+	}
 }

--- a/Tests/AppTests/PhotostreamControllerTests.swift
+++ b/Tests/AppTests/PhotostreamControllerTests.swift
@@ -1,6 +1,5 @@
 import XCTVapor
 import XCTest
-import Redis
 
 @testable import swiftarr
 
@@ -166,13 +165,6 @@ final class PhotostreamControllerTests: XCTestCase, SwiftarrBaseTest {
 		let data = SettingsAdminData(Settings.shared)
 		XCTAssertEqual(data.photostreamUploadRateLimit, Settings.shared.photostreamUploadRateLimit)
 		XCTAssertEqual(data.photostreamUploadRateLimit, 300, "production default is 5 minutes")
-	}
-
-	func testIntSetting_ReadsLegacyTimeIntervalRedisValues() {
-		XCTAssertEqual(Settings.intSetting(fromRESP: 300.convertedToRESPValue()), 300)
-		XCTAssertEqual(Settings.intSetting(fromRESP: 300.0.convertedToRESPValue()), 300)
-		XCTAssertEqual(Settings.intSetting(fromRESP: 0.0.convertedToRESPValue()), 0)
-		XCTAssertEqual(Int(fromRESP: 0.0.convertedToRESPValue()), nil, "plain Int must not parse Double's Redis encoding")
 	}
 
 	func testSettingsUpdateDataDecodesPhotostreamRateLimit() throws {

--- a/Tests/AppTests/PhotostreamControllerTests.swift
+++ b/Tests/AppTests/PhotostreamControllerTests.swift
@@ -1,5 +1,6 @@
 import XCTVapor
 import XCTest
+import Redis
 
 @testable import swiftarr
 
@@ -165,6 +166,13 @@ final class PhotostreamControllerTests: XCTestCase, SwiftarrBaseTest {
 		let data = SettingsAdminData(Settings.shared)
 		XCTAssertEqual(data.photostreamUploadRateLimit, Settings.shared.photostreamUploadRateLimit)
 		XCTAssertEqual(data.photostreamUploadRateLimit, 300, "production default is 5 minutes")
+	}
+
+	func testIntSetting_ReadsLegacyTimeIntervalRedisValues() {
+		XCTAssertEqual(Settings.intSetting(fromRESP: 300.convertedToRESPValue()), 300)
+		XCTAssertEqual(Settings.intSetting(fromRESP: 300.0.convertedToRESPValue()), 300)
+		XCTAssertEqual(Settings.intSetting(fromRESP: 0.0.convertedToRESPValue()), 0)
+		XCTAssertEqual(Int(fromRESP: 0.0.convertedToRESPValue()), nil, "plain Int must not parse Double's Redis encoding")
 	}
 
 	func testSettingsUpdateDataDecodesPhotostreamRateLimit() throws {

--- a/Tests/AppTests/PhotostreamControllerTests.swift
+++ b/Tests/AppTests/PhotostreamControllerTests.swift
@@ -163,7 +163,7 @@ final class PhotostreamControllerTests: XCTestCase, SwiftarrBaseTest {
 
 	func testSettingsAdminDataExposesPhotostreamRateLimit() {
 		let data = SettingsAdminData(Settings.shared)
-		XCTAssertEqual(data.photostreamUploadRateLimit, Int(Settings.shared.photostreamUploadRateLimit))
+		XCTAssertEqual(data.photostreamUploadRateLimit, Settings.shared.photostreamUploadRateLimit)
 		XCTAssertEqual(data.photostreamUploadRateLimit, 300, "production default is 5 minutes")
 	}
 

--- a/Tests/AppTests/PhotostreamControllerTests.swift
+++ b/Tests/AppTests/PhotostreamControllerTests.swift
@@ -149,15 +149,23 @@ final class PhotostreamControllerTests: XCTestCase, SwiftarrBaseTest {
 		)
 	}
 
-	func testRateLimitErrorReason_UsesSecondsBelowOneMinute() {
+	func testRateLimitErrorReason_FormatsWholeMinutesAndOddSeconds() {
 		let controller = PhotostreamController()
 		XCTAssertEqual(
 			controller.photostreamRateLimitErrorReason(30),
 			"You may only upload one Photostream photo every 30 seconds."
 		)
 		XCTAssertEqual(
+			controller.photostreamRateLimitErrorReason(85),
+			"You may only upload one Photostream photo every 85 seconds."
+		)
+		XCTAssertEqual(
+			controller.photostreamRateLimitErrorReason(60),
+			"You may only upload one Photostream photo every 1 minute."
+		)
+		XCTAssertEqual(
 			controller.photostreamRateLimitErrorReason(300),
-			"You may only upload one Photostream photo every 5.0 minutes."
+			"You may only upload one Photostream photo every 5 minutes."
 		)
 	}
 

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -231,4 +231,5 @@ associated AddedToChat field value increase.
   `PhotostreamImageData` in its successful response body.
 
 ## Aug 22, 2026
-* Added `photostreamUploadRateLimit` (seconds between photostream uploads; `0` disables the limit) to `SettingsAdminData` and `SettingsUpdateData`.
+* Added `photostreamUploadRateLimit` (seconds between photostream uploads; `0` disables the limit) to `SettingsAdminData`, `SettingsUpdateData`, and `ClientSettingsData`.
+* `GET /api/v3/client/settings` now also includes `photostreamUploadRateLimit`.

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -229,3 +229,6 @@ associated AddedToChat field value increase.
 * `GET /api/v3/photostream` now supports a `byUser` UUID query parameter.
 * `POST /api/v3/photostream/upload` now returns the created
   `PhotostreamImageData` in its successful response body.
+
+## Aug 22, 2026
+* Added `photostreamUploadRateLimit` (seconds between photostream uploads; `0` disables the limit) to `SettingsAdminData` and `SettingsUpdateData`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/jocosocial/swiftarr/issues/440

The photostream upload cooldown was already a StoredSetting (`photostreamUploadRateLimit`, default 300 seconds). It was not exposed on `/admin/serversettings`, so production stayed at 5 minutes with no way to drop it to 0 during feature testing.

This wires the existing setting through the admin API, the server settings form, and client settings:

- `SettingsAdminData` / `SettingsUpdateData` include `photostreamUploadRateLimit` (seconds)
- `GET/POST /admin/serversettings` can view and save it
- `GET /api/v3/client/settings` (`ClientSettingsData`) includes the same value so client apps can honor it
- Setting the value to `0` disables the cooldown so consecutive uploads are allowed

Production default remains 300 seconds (5 minutes).

## Testing

`swift test --enable-test-discovery --filter PhotostreamControllerTests` — 8 tests, 0 failures.

`ContentStructValidationTests.testClientSettings_EncodesPhotostreamUploadRateLimit` — encodes `photostreamUploadRateLimit` from Settings (default 300).

Live `GET /api/v3/client/settings`:

- default response includes `photostreamUploadRateLimit: 300`
- after admin POST of `0`, client settings returns `0`
- after restore to `300`, client settings returns `300`

Admin UI: the Limits section shows the new field; saving `0` survives reload, then restoring `300` also survives reload.

![Server settings showing photostream interval 300](https://cursor.com/artifacts/c/art-102e3023-9113-4742-8754-f86778def726)
![Server settings after saving photostream interval 0](https://cursor.com/artifacts/c/art-3ff71a78-a547-4696-b5b5-e1df4924c4c8)
![Server settings after restoring photostream interval 300](https://cursor.com/artifacts/c/art-7e0974fa-c5a1-4b96-9c13-8b1f8bb99906)
<a href="https://cursor.com/agents/bc-c0cc7553-652c-4ada-95c5-7297d9b5c580/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphotostream_interval_admin_settings.mp4"><img src="https://cursor.com/artifacts/c/art-40cf460a-5cfc-4570-9451-6e1c4b6cae7e" alt="photostream_interval_admin_settings.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0cc7553-652c-4ada-95c5-7297d9b5c580?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0cc7553-652c-4ada-95c5-7297d9b5c580&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

