### PR TITLE
fix: allow multiple photos on private event posts

### DIFF
--- a/Sources/swiftarr/Controllers/FezController.swift
+++ b/Sources/swiftarr/Controllers/FezController.swift
@@ -461,7 +461,8 @@ struct FezController: APIRouteCollection {
 	///
 	/// Add a `FezPost` to the specified `FriendlyFez`.
 	///
-	/// Open fez types are only permitted to have 1 image per post. Private fezzes (aka Seamail) cannot have any images.
+	/// LFG posts are limited to 1 image. Private Event posts use the forum post image limit
+	/// (`maxForumPostImages`, or 8 for Shutternauts). Seamail cannot have any images.
 	///
 	/// - Parameter fezID: in URL path
 	/// - Parameter requestBody: `PostContentData`
@@ -477,12 +478,7 @@ struct FezController: APIRouteCollection {
 		guard fez.fezType != .personalEvent else {
 			throw Abort(.badRequest, reason: "Personal Events don't have posts.")
 		}
-		guard ![.closed, .open].contains(fez.fezType) || data.images.count == 0 else {
-			throw Abort(.badRequest, reason: "Private conversations can't contain photos.")
-		}
-		guard data.images.count <= 1 else {
-			throw Abort(.badRequest, reason: "posts may only have one image")
-		}
+		try guardFezPostImages(data.images, for: cacheUser, in: fez)
 		guard fez.participantArray.contains(cacheUser.userID) || cacheUser.accessLevel.hasAccess(.moderator) else {
 			throw Abort(.forbidden, reason: "user is not member of \(fez.fezType.lfgLabel); cannot post")
 		}
@@ -494,11 +490,12 @@ struct FezController: APIRouteCollection {
 			throw Abort(.badRequest, reason: "\(fez.fezType.lfgLabel) is locked; cannot post.")
 		}
 		// process image
-		let filenames = try await processImages(data.images, usage: .fezPost, on: req)
+		let maxImages = maxImagesForFezPost(fez, user: cacheUser)
+		let filenames = try await processImages(data.images, usage: .fezPost, maxImages: maxImages, on: req)
 		// create and save the new post, update fezzes' cached post count
 		let effectiveAuthor = data.effectiveAuthor(actualAuthor: cacheUser, on: req)
-		let filename = filenames.count > 0 ? filenames[0] : nil
-		let post = try FezPost(fez: fez, authorID: effectiveAuthor.userID, text: data.text, image: filename)
+		let storedImages: [String]? = filenames.isEmpty ? nil : filenames
+		let post = try FezPost(fez: fez, authorID: effectiveAuthor.userID, text: data.text, images: storedImages)
 		fez.postCount += 1
 		try await post.save(on: req.db)
 		try await fez.save(on: req.db)
@@ -1001,6 +998,30 @@ struct FezController: APIRouteCollection {
 // MARK: - Helper Functions
 
 extension FezController {
+
+	/// Returns how many images a post in this fez may attach.
+	/// Seamail cannot have images. LFGs are limited to one. Private Events use the forum post
+	/// limit, with Shutternauts allowed up to 8.
+	func maxImagesForFezPost(_ fez: FriendlyFez, user: UserCacheData) -> Int {
+		if fez.fezType.isSeamailType {
+			return 0
+		}
+		if fez.fezType == .privateEvent {
+			return Settings.shared.getMaxForumPostImages(for: user)
+		}
+		return 1
+	}
+
+	/// Ensures the given user's images array doesn't exceed the allowed limit for this fez type.
+	func guardFezPostImages(_ images: [ImageUploadData], for user: UserCacheData, in fez: FriendlyFez) throws {
+		let maxImages = maxImagesForFezPost(fez, user: user)
+		guard images.count <= maxImages else {
+			if maxImages == 0 {
+				throw Abort(.badRequest, reason: "Private conversations can't contain photos.")
+			}
+			throw Abort(.badRequest, reason: "posts are limited to \(maxImages) image attachments")
+		}
+	}
 
 	// This is the bulk of the joinedHandler, pulled out into a separate fn. This allows us to modify the urlQuery arguments
 	// before calling.

--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -768,8 +768,12 @@ public struct FezPostData: Content {
 	var text: String
 	/// The time the post was submitted.
 	var timestamp: Date
-	/// The image content of the fez post.
+	/// The first image attached to the fez post. Kept for backward compatibility with older clients;
+	/// prefer `images` when present.
 	var image: String?
+	/// All images attached to the fez post. Private Event posts may include up to `Settings.shared.maxForumPostImages`
+	/// (8 for Shutternauts). LFG posts remain limited to one image. Seamail posts cannot have images.
+	var images: [String]?
 }
 
 extension FezPostData {
@@ -782,7 +786,9 @@ extension FezPostData {
 		self.text =
 			post.moderationStatus.showsContent() || overrideQuarantine ? post.text : "Post is under moderator review."
 		self.timestamp = post.createdAt ?? post.updatedAt ?? Date()
-		self.image = post.moderationStatus.showsContent() || overrideQuarantine ? post.image : nil
+		let visibleImages = post.moderationStatus.showsContent() || overrideQuarantine ? post.images : nil
+		self.images = visibleImages
+		self.image = visibleImages?.first
 	}
 }
 
@@ -1824,7 +1830,7 @@ struct PhotostreamUploadData: Content {
 public struct PostContentData: Content {
 	/// The new text of the forum post.
 	var text: String
-	/// An array of images (up to `Settings.shared.maxForumPostImages` for forum posts, 1 when used in a Fez post). Each image can specify either new image data or an existing image filename.
+	/// An array of images (up to `Settings.shared.maxForumPostImages` for forum posts and private event posts, 1 when used in an LFG post). Each image can specify either new image data or an existing image filename.
 	/// For new posts, images will generally contain all new image data. When editing existing posts, images may contain a mix of new and existing images.
 	/// Reorder ImageUploadDatas to change presentation order. Set images to [] to remove images attached to post when editing.
 	var images: [ImageUploadData]

--- a/Sources/swiftarr/Controllers/Structs/SocketStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/SocketStructs.swift
@@ -25,8 +25,10 @@ struct SocketFezPostData: Content {
 	var text: String
 	/// When the post was made.
 	var timestamp: Date
-	/// An optional image that may be attached to the post.
+	/// The first image attached to the post. Kept for backward compatibility with older clients; prefer `images`.
 	var image: String?
+	/// All images attached to the post.
+	var images: [String]?
 	/// HTML fragment for the post, using the Swiftarr Web UI's front end. Fragment is built using the same semantic data available in the other fields in this struct.
 	/// Please don't try parsing this to gather data. This field is here so the Javascript can insert HTML that matches what the HTTP endpoints render.
 	var html: String?
@@ -39,6 +41,7 @@ extension SocketFezPostData {
 		self.text = post.text
 		self.timestamp = post.timestamp
 		self.image = post.image
+		self.images = post.images
 	}
 
 	init(post: FezPost, author: UserHeader) throws {
@@ -46,7 +49,8 @@ extension SocketFezPostData {
 		self.author = author
 		self.text = post.text
 		self.timestamp = post.createdAt ?? Date()
-		self.image = post.image
+		self.images = post.images
+		self.image = post.images?.first
 	}
 }
 

--- a/Sources/swiftarr/Helpers/Settings.swift
+++ b/Sources/swiftarr/Helpers/Settings.swift
@@ -349,7 +349,7 @@ extension Settings {
 		return filterDate
 	}
 
-	/// Returns the maximum number of images allowed for forum posts for the given user.
+	/// Returns the maximum number of images allowed for forum posts and private event posts for the given user.
 	/// Shutternauts are allowed up to 8 images, other users are limited by the `maxForumPostImages` setting.
 	func getMaxForumPostImages(for user: UserCacheData) -> Int {
 		return user.userRoles.contains(.shutternaut) ? 8 : maxForumPostImages

--- a/Sources/swiftarr/Migrations/Test Data/TestData.swift
+++ b/Sources/swiftarr/Migrations/Test Data/TestData.swift
@@ -153,7 +153,7 @@ struct CreateTestData: AsyncMigration {
 				fez: bigFez,
 				authorID: users.randomElement()!.requireID(),
 				text: "Post #\(index): \(postStr)",
-				image: nil
+				images: nil
 			)
 			try await post.save(on: database)
 		}

--- a/Sources/swiftarr/Models/FezPost.swift
+++ b/Sources/swiftarr/Models/FezPost.swift
@@ -1,4 +1,5 @@
 import Fluent
+import FluentSQL
 import Vapor
 
 /// 	An individual post within a `FriendlyFez` discussion. A FezPost must contain
@@ -18,8 +19,9 @@ final class FezPost: Model, Searchable, @unchecked Sendable {
 	/// The text content of the post.
 	@Field(key: "text") var text: String
 
-	/// The filename of any image content of the post. FezPosts are limited to one image, and "closed" Fez types cannot have any.
-	@OptionalField(key: "image") var image: String?
+	/// The filenames of any image content of the post. Seamail (closed/open) posts cannot have images.
+	/// LFG posts are limited to one image. Private Event posts use the forum post image limit.
+	@OptionalField(key: "images") var images: [String]?
 
 	/// Moderators can set several statuses on fezPosts that modify editability and visibility.
 	@Enum(key: "mod_status") var moderationStatus: ContentModerationStatus
@@ -52,12 +54,12 @@ final class FezPost: Model, Searchable, @unchecked Sendable {
 	///   - fezID: The ID of the post's FriendlyFez.
 	///   - authorID: The ID of the author of the post.
 	///   - text: The text content of the post.
-	///   - image: The filename of any image content of the post.
+	///   - images: The filenames of any image content of the post.
 	init(
 		fez: FriendlyFez,
 		authorID: UUID,
 		text: String,
-		image: String?
+		images: [String]? = nil
 	) throws {
 		self.$fez.id = try fez.requireID()
 		self.$fez.value = fez
@@ -65,7 +67,7 @@ final class FezPost: Model, Searchable, @unchecked Sendable {
 
 		// Generally I'm in favor of "validate input, sanitize output" but I hate "\r\n" with the fury of a thousand suns.
 		self.text = text.replacingOccurrences(of: "\r\n", with: "\r")
-		self.image = image
+		self.images = images
 		self.moderationStatus = .normal
 	}
 }
@@ -106,5 +108,39 @@ struct CreateFezPostSchema: AsyncMigration {
 
 	func revert(on database: Database) async throws {
 		try await database.schema("fezposts").delete()
+	}
+}
+
+/// Converts the single `image` column into an `images` string array so Private Event posts
+/// can attach more than one photo.
+struct UpdateFezPostImagesMigration: AsyncMigration {
+	func prepare(on database: Database) async throws {
+		try await database.schema("fezposts")
+			.field("images", .array(of: .string))
+			.update()
+		if let sql = database as? SQLDatabase {
+			_ = try await sql.raw(
+				#"UPDATE "fezposts" SET "images" = ARRAY["image"] WHERE "image" IS NOT NULL AND "image" <> ''"#
+			)
+			.all()
+		}
+		try await database.schema("fezposts")
+			.deleteField("image")
+			.update()
+	}
+
+	func revert(on database: Database) async throws {
+		try await database.schema("fezposts")
+			.field("image", .string)
+			.update()
+		if let sql = database as? SQLDatabase {
+			_ = try await sql.raw(
+				#"UPDATE "fezposts" SET "image" = "images"[1] WHERE "images" IS NOT NULL AND cardinality("images") > 0"#
+			)
+			.all()
+		}
+		try await database.schema("fezposts")
+			.deleteField("images")
+			.update()
 	}
 }

--- a/Sources/swiftarr/Protocols/FezProtocol.swift
+++ b/Sources/swiftarr/Protocols/FezProtocol.swift
@@ -50,7 +50,7 @@ extension FezProtocol {
 		)
 
 		// Build the Post in the Fez.
-		let post = try FezPost(fez: fez, authorID: fromUserID, text: initialMessage, image: nil)
+		let post = try FezPost(fez: fez, authorID: fromUserID, text: initialMessage, images: nil)
 		try await post.save(on: req.db)
 
 		// Generate appropriate notifications.

--- a/Sources/swiftarr/Resources/Views/Fez/fezPost.html
+++ b/Sources/swiftarr/Resources/Views/Fez/fezPost.html
@@ -18,13 +18,15 @@
 						#formatFezText(fezPost.text)
 					</div>
 				</div>
-				#if(fezPost.image):
-					<div class="row align-items-center justify-content-start flex-nowrap gx-1">	
-						<div class="col col-auto flex-grow-0 flex-shrink-1">
-							<button type="button" class="btn p-0 border-0" data-bs-toggle="modal" data-bs-target="\#imageCarouselModal">
-								<img src="/api/v3/image/full/#(fezPost.image)" class="swiftarr-post-image" alt="Post Image">
-							</button>
-						</div>
+				#if(fezPost.images):
+					<div class="row">	
+						#for(image in fezPost.images):
+							<div class="col col-auto flex-grow-0 flex-shrink-1">
+								<button type="button" class="btn p-0 border-0" data-bs-toggle="modal" data-bs-target="\#imageCarouselModal">
+									<img src="/api/v3/image/full/#(image)" class="swiftarr-post-image" alt="Post Image">
+								</button>
+							</div>
+						#endfor
 					</div>
 				#endif
 				#if(fez.fezType != "closed"):

--- a/Sources/swiftarr/Resources/Views/Fez/singleFez.html
+++ b/Sources/swiftarr/Resources/Views/Fez/singleFez.html
@@ -177,35 +177,51 @@
 										</div>
 									</div>
 									<div class="alert alert-danger mt-3 #if(post.postErrorString == ""):d-none#endif" role="alert">#(post.postErrorString)</div>				
-									<div class="row mb-2 justify-content-between gx-1">
-										<div class="col col-6 col-md-4 col-lg-3">
-											<div class="card">
-												<h5 class="card-header">Photo</h5>
-												<div class="m-1 border img-for-upload-container">
-													<div class="ratio ratio-1x1">
-														<img class="img-for-upload" alt="">
-													</div>
-												</div>
-												<p class="text-center no-image-marker"><i>no photo selected</i></p>
-												<div class="container-fluid p-1">
-													<div class="row">
-														<div class="col">
-															<label class="btn btn-primary col-12 form-label">
-																<input class="image-upload-input d-none" type="file" accept="#(post.allowedImageTypes)" name="localPhoto1">
-																Choose Photo
-															</label>
-															<input type="hidden" class="current-server-photo" value="" name="serverPhoto1">
-														</div>
-													</div>
-													<div class="row justify-content-between m-0">
-														<div class="col col-auto p-0 m-0">
-															<button type="button" class="btn btn-primary btn-sm twitarr-image-remove">Remove</button>
-														</div>
-													</div>
-												</div>
+									#if(count(post.photoFilenames) > 0):
+										<div class="row mb-2">
+											<div class="col">
+												Add up to #count(post.photoFilenames) photos
 											</div>
 										</div>
-										<div class="col col-6 text-end">
+										<div class="row mb-2 gx-1">
+											#for(fn in post.photoFilenames):
+												<div class="col col-6 col-md-4 col-lg-3 mb-2">
+													<div class="card">
+														<h5 class="card-header">Photo #(index + 1)</h5>
+														<div class="m-1 border img-for-upload-container">
+															<div class="ratio ratio-1x1">
+																<img src="data:," class="img-for-upload" alt="">
+															</div>
+														</div>
+														<p class="text-center no-image-marker"><i>no photo selected</i></p>
+														<div class="container-fluid p-1">
+															<div class="row">
+																<div class="col">
+																	<label class="btn btn-primary col-12 form-label">
+																		<input class="image-upload-input d-none" type="file" accept="#(post.allowedImageTypes)" name="localPhoto#(index + 1)">
+																		Choose Photo
+																	</label>
+																	<input type="hidden" class="current-server-photo" value="#(fn)" name="serverPhoto#(index + 1)">
+																</div>
+															</div>
+															<div class="row justify-content-between m-0">
+																#if(index > 0):
+																	<div class="col col-auto p-0 m-0">
+																		<button type="button" class="btn btn-primary btn-sm twitarr-image-swap">&lt;&lt; Swap</button>
+																	</div>
+																#endif
+																<div class="col col-auto p-0 m-0">
+																	<button type="button" class="btn btn-primary btn-sm twitarr-image-remove">Remove</button>
+																</div>
+															</div>
+														</div>
+													</div>
+												</div>
+											#endfor
+										</div>
+									#endif
+									<div class="row mb-2 justify-content-end gx-1">
+										<div class="col col-auto text-end">
 											<button type="submit" class="btn btn-primary">Post<span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span></button><br>
 											<small>Please remember to abide by the <a href="/codeOfConduct">Code of Conduct</a></small>
 										</div>

--- a/Sources/swiftarr/Resources/Views/moderation/fezPostView.html
+++ b/Sources/swiftarr/Resources/Views/moderation/fezPostView.html
@@ -74,13 +74,15 @@
 												#formatPostText(modData.fezPost.text)
 											</div>
 										</div>
-										#if(modData.fezPost.image):
-											<div class="row align-items-center justify-content-start flex-nowrap gx-1">	
-												<div class="col col-auto flex-grow-0 flex-shrink-1">
-													<button type="button" class="btn p-0 border-0" data-bs-toggle="modal" data-bs-target="\#imageCarouselModal">
-														<img src="/api/v3/image/full/#(modData.fezPost.image)" class="swiftarr-post-image" alt="Post Image">
-													</button>
-												</div>
+										#if(modData.fezPost.images):
+											<div class="row">	
+												#for(image in modData.fezPost.images):
+													<div class="col col-auto flex-grow-0 flex-shrink-1">
+														<button type="button" class="btn p-0 border-0" data-bs-toggle="modal" data-bs-target="\#imageCarouselModal">
+															<img src="/api/v3/image/full/#(image)" class="swiftarr-post-image" alt="Post Image">
+														</button>
+													</div>
+												#endfor
 											</div>
 										#endif
 									</div>

--- a/Sources/swiftarr/Site/SiteChatController.swift
+++ b/Sources/swiftarr/Site/SiteChatController.swift
@@ -366,7 +366,7 @@ struct SiteFriendlyFezController: SiteControllerUtils {
 				oldPosts = []
 				newPosts = []
 				showDivider = false
-				post = .init(forType: .fezPost(fez))
+				post = .init(forType: .fezPost(fez), userRoles: cacheUser.userRoles)
 				paginator = PaginatorContext(
 					start: 0,
 					total: 40,

--- a/Sources/swiftarr/Site/SiteController.swift
+++ b/Sources/swiftarr/Site/SiteController.swift
@@ -321,7 +321,12 @@ struct MessagePostContext: Encodable {
 			formAction = "/lfg/\(forFez.fezID)/post"
 			postSuccessURL = "/lfg/\(forFez.fezID)"
 			messageTextPlaceholder = "Send a message"
-			photoFilenames = [""]
+			if forFez.fezType == .privateEvent {
+				photoFilenames = Array(repeating: "", count: maxImages)
+			}
+			else {
+				photoFilenames = [""]
+			}
 		// For creating an announcement
 		case .announcement:
 			formAction = "/admin/announcement/create"

--- a/Sources/swiftarr/configure.swift
+++ b/Sources/swiftarr/configure.swift
@@ -643,6 +643,7 @@ struct SwiftarrConfigurator {
 		app.migrations.add(UpdateEventFavoriteSchema_Photographer(), to: .psql)
 		app.migrations.add(UpdateUserDiscordHandleMigration(), to: .psql)
 		app.migrations.add(AddPerformerAlternativeNamesMigration(), to: .psql)
+		app.migrations.add(UpdateFezPostImagesMigration(), to: .psql)
 
 		// At this point the db *schema* should be set, and the rest of these migrations operate on the db's *data*.
 

--- a/Tests/AppTests/FezPostImageLimitTests.swift
+++ b/Tests/AppTests/FezPostImageLimitTests.swift
@@ -1,0 +1,220 @@
+import XCTVapor
+
+@testable import swiftarr
+
+// Private Event posts use the forum image limit (`maxForumPostImages`, 8 for Shutternauts).
+// LFG posts stay at one image. Seamail still cannot attach photos.
+class FezPostImageLimitTests: XCTestCase, SwiftarrBaseTest {
+
+	private struct Fixture {
+		let token: String
+		let fezID: UUID
+	}
+
+	private func makeUser(_ app: Application, username: String, shutternaut: Bool = false) async throws -> User {
+		let user = User(
+			username: username,
+			password: try Bcrypt.hash("password1"),
+			recoveryKey: try Bcrypt.hash("recovery key"),
+			accessLevel: .verified
+		)
+		try await user.save(on: app.db)
+		if shutternaut {
+			let role = UserRole(user: try user.requireID(), role: .shutternaut)
+			try await role.save(on: app.db)
+		}
+		return user
+	}
+
+	private func makeToken(_ app: Application, for user: User) async throws -> String {
+		let token = try Token.generate(for: user)
+		try await token.save(on: app.db)
+		return token.token
+	}
+
+	private func makeFez(
+		_ app: Application,
+		owner: User,
+		type: FezType,
+		title: String
+	) async throws -> FriendlyFez {
+		let ownerID = try owner.requireID()
+		let fez = FriendlyFez(
+			owner: ownerID,
+			fezType: type,
+			title: title,
+			info: "test fixture",
+			location: "Deck 9",
+			startTime: Date(),
+			endTime: Date().addingTimeInterval(3600)
+		)
+		fez.participantArray = [ownerID]
+		try await fez.save(on: app.db)
+		try await fez.$participants.attach(
+			[owner],
+			on: app.db,
+			{
+				$0.readCount = 0
+				$0.hiddenCount = 0
+			}
+		)
+		return fez
+	}
+
+	private func makeFixture(
+		_ app: Application,
+		suffix: String,
+		type: FezType,
+		shutternaut: Bool = false
+	) async throws -> Fixture {
+		let user = try await makeUser(app, username: "fezimg-\(suffix)", shutternaut: shutternaut)
+		let fez = try await makeFez(app, owner: user, type: type, title: "Event \(suffix)")
+		let token = try await makeToken(app, for: user)
+		try await app.asyncBoot()
+		try await app.initializeUserCache(app)
+		return Fixture(token: token, fezID: try fez.requireID())
+	}
+
+	private func bearer(_ token: String) -> HTTPHeaders {
+		var headers = HTTPHeaders()
+		headers.bearerAuthorization = BearerAuthorization(token: token)
+		return headers
+	}
+
+	private func namedImages(_ names: [String]) -> [ImageUploadData] {
+		names.map { ImageUploadData($0, nil) }
+	}
+
+	private func postImages(
+		_ app: Application,
+		fixture: Fixture,
+		names: [String],
+		text: String = "photo post"
+	) async throws -> (HTTPStatus, FezPostData?) {
+		var status: HTTPStatus = .internalServerError
+		var post: FezPostData?
+		try await app.test(
+			.POST,
+			"/api/v3/fez/\(fixture.fezID)/post",
+			headers: bearer(fixture.token),
+			beforeRequest: { req async throws in
+				try req.content.encode(PostContentData(text: text, images: namedImages(names)))
+			},
+			afterResponse: { res async throws in
+				status = res.status
+				if res.status == .ok {
+					post = try res.content.decode(FezPostData.self)
+				}
+			}
+		)
+		return (status, post)
+	}
+
+	func testPrivateEvent_RegularUser_CanPostUpToLimit() async throws {
+		try await withApp { app in
+			let fixture = try await makeFixture(
+				app,
+				suffix: UUID().uuidString.prefix(8).lowercased(),
+				type: .privateEvent
+			)
+			let names = (1...Settings.shared.maxForumPostImages).map { "pe-ok-\($0).jpg" }
+			let (status, post) = try await postImages(app, fixture: fixture, names: names)
+			XCTAssertEqual(status, .ok)
+			XCTAssertEqual(post?.images, names)
+			XCTAssertEqual(post?.image, names.first)
+		}
+	}
+
+	func testPrivateEvent_RegularUser_RejectedOverLimit() async throws {
+		try await withApp { app in
+			let fixture = try await makeFixture(
+				app,
+				suffix: UUID().uuidString.prefix(8).lowercased(),
+				type: .privateEvent
+			)
+			let over = Settings.shared.maxForumPostImages + 1
+			let names = (1...over).map { "pe-over-\($0).jpg" }
+			let (status, _) = try await postImages(app, fixture: fixture, names: names)
+			XCTAssertEqual(status, .badRequest)
+		}
+	}
+
+	func testPrivateEvent_Shutternaut_CanPostEight() async throws {
+		try await withApp { app in
+			let fixture = try await makeFixture(
+				app,
+				suffix: UUID().uuidString.prefix(8).lowercased(),
+				type: .privateEvent,
+				shutternaut: true
+			)
+			let names = (1...8).map { "pe-naut-\($0).jpg" }
+			let (status, post) = try await postImages(app, fixture: fixture, names: names)
+			XCTAssertEqual(status, .ok)
+			XCTAssertEqual(post?.images?.count, 8)
+			XCTAssertEqual(post?.image, names.first)
+		}
+	}
+
+	func testPrivateEvent_Shutternaut_RejectedOverEight() async throws {
+		try await withApp { app in
+			let fixture = try await makeFixture(
+				app,
+				suffix: UUID().uuidString.prefix(8).lowercased(),
+				type: .privateEvent,
+				shutternaut: true
+			)
+			let names = (1...9).map { "pe-naut-over-\($0).jpg" }
+			let (status, _) = try await postImages(app, fixture: fixture, names: names)
+			XCTAssertEqual(status, .badRequest)
+		}
+	}
+
+	func testLFG_StillLimitedToOne() async throws {
+		try await withApp { app in
+			let fixture = try await makeFixture(
+				app,
+				suffix: UUID().uuidString.prefix(8).lowercased(),
+				type: .activity,
+				shutternaut: true
+			)
+			let (oneStatus, _) = try await postImages(app, fixture: fixture, names: ["lfg-one.jpg"])
+			XCTAssertEqual(oneStatus, .ok)
+			let (twoStatus, _) = try await postImages(app, fixture: fixture, names: ["lfg-a.jpg", "lfg-b.jpg"])
+			XCTAssertEqual(twoStatus, .badRequest)
+		}
+	}
+
+	func testSeamail_StillRejectsPhotos() async throws {
+		try await withApp { app in
+			let fixture = try await makeFixture(
+				app,
+				suffix: UUID().uuidString.prefix(8).lowercased(),
+				type: .closed
+			)
+			let (status, _) = try await postImages(app, fixture: fixture, names: ["seamail.jpg"])
+			XCTAssertEqual(status, .badRequest)
+		}
+	}
+
+	func testFezPostData_KeepsImageForOlderClients() throws {
+		let author = UserHeader(
+			userID: UUID(),
+			username: "photo-user",
+			displayName: nil,
+			userImage: nil,
+			preferredPronoun: nil
+		)
+		let data = FezPostData(
+			postID: 7,
+			author: author,
+			text: "shots",
+			timestamp: Date(timeIntervalSince1970: 1_725_000_000),
+			image: "first.jpg",
+			images: ["first.jpg", "second.jpg"]
+		)
+		let encoded = try JSONEncoder().encode(data)
+		let json = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+		XCTAssertEqual(json?["image"] as? String, "first.jpg")
+		XCTAssertEqual(json?["images"] as? [String], ["first.jpg", "second.jpg"])
+	}
+}

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -229,3 +229,9 @@ associated AddedToChat field value increase.
 * `GET /api/v3/photostream` now supports a `byUser` UUID query parameter.
 * `POST /api/v3/photostream/upload` now returns the created
   `PhotostreamImageData` in its successful response body.
+
+## Aug 24, 2026
+* Private Event posts now allow multiple images, using the same `maxForumPostImages` limit as forum posts (8 for Shutternauts).
+* `FezPostData` and `SocketFezPostData` have a new `images` array. The existing `image` field remains and is the first attached image, for older clients.
+* LFG posts remain limited to one image. Seamail posts still cannot have images.
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/jocosocial/swiftarr/issues/521

Private event photos on the web were hardcoded to a single upload slot, and the API rejected anything beyond one image. This matches forum posts instead: the `maxForumPostImages` setting (default 4), with Shutternauts allowed up to 8.

**API**
- Private Event posts accept up to `maxForumPostImages` images, or 8 if the poster is a Shutternaut
- LFG posts stay limited to one image; seamail still cannot attach photos
- `FezPostData` and `SocketFezPostData` add an `images` array. The existing `image` field remains and is the first attached photo, so older clients keep working
- Database migration converts `fezposts.image` (string) to `fezposts.images` (string array)

**Web**
- The private event compose form shows one upload slot per allowed image, using the same slot count as forum posts (including the Shutternaut extra)
- Post and moderation views render every attached image

**Tests**
- Regular users can post up to the forum limit on a private event and are rejected over that limit
- Shutternauts can post 8 and are rejected at 9
- LFG remains one-image; seamail still rejects photos

![Regular user private event compose form with 4 photo slots](https://cursor.com/artifacts/c/art-1e7a2927-4c7d-43cb-b062-84a3912d8786)
![Private event post with two attached photos](https://cursor.com/artifacts/c/art-52fb9a92-bee4-4fbf-a16e-1b05534506ab)
![Shutternaut private event compose form with 8 photo slots](https://cursor.com/artifacts/c/art-4ec5b1c4-eb7a-4701-a567-1d608081ecc6)
![LFG compose form still limited to one photo](https://cursor.com/artifacts/c/art-814d9193-778a-44c5-a4ec-60a41f28b5eb)
<a href="https://cursor.com/agents/bc-33548cb1-0666-4a52-982e-087512cb3572/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprivate_event_two_photo_upload.mp4"><img src="https://cursor.com/artifacts/c/art-2d5eb3b3-af74-4668-b035-706f78c7080b" alt="private_event_two_photo_upload.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33548cb1-0666-4a52-982e-087512cb3572?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33548cb1-0666-4a52-982e-087512cb3572&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

