### PR TITLE
Add forgot-username lookup (#509)

### DIFF
--- a/Sources/swiftarr/Controllers/AuthController.swift
+++ b/Sources/swiftarr/Controllers/AuthController.swift
@@ -55,7 +55,7 @@ struct AuthController: APIRouteCollection {
 
 		// open access endpoints
 		authRoutes.post("recovery", use: recoveryHandler)
-		authRoutes.post("username", use: usernameHandler).setUsedForPreregistration()
+		authRoutes.post("username", use: usernameHandler)
 
 		// endpoints available only when not logged in
 		let basicAuthGroup = authRoutes.addBasicAuthRequirement()
@@ -203,14 +203,9 @@ struct AuthController: APIRouteCollection {
 	func usernameHandler(_ req: Request) async throws -> UserHeader {
 		// see `UserUsernameLookupData.validations()`
 		let data = try ValidatingJSONDecoder().decode(UserUsernameLookupData.self, fromBodyOf: req)
-		let normalizedCode = RegistrationCode.normalized(data.registrationCode)
+		let storedCodes = User.storedVerificationValues(for: data.registrationCode)
 
-		let users = try await User.query(on: req.db)
-			.group(.or) { group in
-				group.filter(\.$verification == normalizedCode)
-				group.filter(\.$verification == "*" + normalizedCode)
-			}
-			.all()
+		let users = try await User.query(on: req.db).filter(\.$verification ~~ storedCodes).all()
 
 		// Same generic failure for unknown codes and bad second factors so a valid
 		// registration code is not distinguishable from a made-up one.
@@ -252,11 +247,6 @@ struct AuthController: APIRouteCollection {
 				try await user.save(on: req.db)
 			}
 			throw noMatch
-		}
-
-		for user in users where user.recoveryAttempts != 0 {
-			user.recoveryAttempts = 0
-			try await user.save(on: req.db)
 		}
 
 		return try UserHeader(user: matched)

--- a/Sources/swiftarr/Controllers/AuthController.swift
+++ b/Sources/swiftarr/Controllers/AuthController.swift
@@ -229,10 +229,12 @@ struct AuthController: APIRouteCollection {
 		var passwordMatch: User?
 		var recoveryKeyMatch: User?
 		for user in orderedUsers {
+			// password is matched as typed
 			if try verifier.verify(data.recoveryKey, created: user.password) {
 				passwordMatch = user
 				break
 			}
+			// recoveryKey is hashed from the 3-word key with ASCII spaces removed
 			if recoveryKeyMatch == nil {
 				let normalizedRecoveryKey = data.recoveryKey.lowercased().replacingOccurrences(of: " ", with: "")
 				if try verifier.verify(normalizedRecoveryKey, created: user.recoveryKey) {
@@ -241,7 +243,9 @@ struct AuthController: APIRouteCollection {
 			}
 		}
 
+		// abort if no match
 		guard let matched = passwordMatch ?? recoveryKeyMatch else {
+			// track the attempt count on every account sharing this registration code
 			for user in users {
 				user.recoveryAttempts += 1
 				try await user.save(on: req.db)

--- a/Sources/swiftarr/Controllers/AuthController.swift
+++ b/Sources/swiftarr/Controllers/AuthController.swift
@@ -55,6 +55,7 @@ struct AuthController: APIRouteCollection {
 
 		// open access endpoints
 		authRoutes.post("recovery", use: recoveryHandler)
+		authRoutes.post("username", use: usernameHandler).setUsedForPreregistration()
 
 		// endpoints available only when not logged in
 		let basicAuthGroup = authRoutes.addBasicAuthRequirement()
@@ -173,6 +174,92 @@ struct AuthController: APIRouteCollection {
 			try await req.userCache.updateUser(user.requireID())
 			return try TokenStringData(user: user, token: token)
 		}
+	}
+
+	/// `POST /api/v3/auth/username`
+	///
+	/// Looks up a forgotten username from a registration code plus a second factor. The second
+	/// factor must be the account password or the recovery key generated at account creation.
+	/// A registration code is not accepted as the second factor — even the same code, and even
+	/// a different well-formed 6-character code.
+	///
+	/// The use case is a forgotten username during preregistration or later. The caller already
+	/// has a registration code (mailed before the cruise) and either the password they chose
+	/// or the recovery key shown when the account was created.
+	///
+	/// If the password matches a sub-account, that sub-account's `UserHeader` is returned. The
+	/// recovery key is shared across a primary account and its alts, so a recovery-key match
+	/// returns the primary account.
+	///
+	/// Username lookup does not spend the registration code and does not log the user in.
+	///
+	/// - Note: To prevent brute-force malicious attempts, there is a limit on successive
+	///   failed attempts, currently hard-coded to 5, shared with password recovery.
+	///
+	/// - Parameter requestBody: `UserUsernameLookupData`
+	/// - Throws: 400 error if the lookup fails or the second factor is a registration code.
+	///   403 error if the maximum number of successive failed recovery attempts has been reached.
+	/// - Returns: `UserHeader` for the matching account.
+	func usernameHandler(_ req: Request) async throws -> UserHeader {
+		// see `UserUsernameLookupData.validations()`
+		let data = try ValidatingJSONDecoder().decode(UserUsernameLookupData.self, fromBodyOf: req)
+		let normalizedCode = RegistrationCode.normalized(data.registrationCode)
+
+		let users = try await User.query(on: req.db)
+			.group(.or) { group in
+				group.filter(\.$verification == normalizedCode)
+				group.filter(\.$verification == "*" + normalizedCode)
+			}
+			.all()
+
+		// Same generic failure for unknown codes and bad second factors so a valid
+		// registration code is not distinguishable from a made-up one.
+		let noMatch = Abort(.badRequest, reason: "no match for supplied credentials")
+		guard !users.isEmpty else {
+			throw noMatch
+		}
+
+		// abort if account is seeing potential brute-force attack
+		guard users.allSatisfy({ $0.recoveryAttempts < 5 }) else {
+			throw Abort(.forbidden, reason: "please see a Twit-arr Team member for account recovery")
+		}
+
+		// Prefer a password match (identifies a specific primary or alt) over a recovery-key
+		// match (shared across the family). Walk primaries first so a recovery-key-only hit
+		// returns the account the registration code was originally assigned to.
+		let orderedUsers = users.sorted { lhs, rhs in
+			lhs.$parent.id == nil && rhs.$parent.id != nil
+		}
+		let verifier = BCryptDigest()
+		var passwordMatch: User?
+		var recoveryKeyMatch: User?
+		for user in orderedUsers {
+			if try verifier.verify(data.recoveryKey, created: user.password) {
+				passwordMatch = user
+				break
+			}
+			if recoveryKeyMatch == nil {
+				let normalizedRecoveryKey = data.recoveryKey.lowercased().replacingOccurrences(of: " ", with: "")
+				if try verifier.verify(normalizedRecoveryKey, created: user.recoveryKey) {
+					recoveryKeyMatch = user
+				}
+			}
+		}
+
+		guard let matched = passwordMatch ?? recoveryKeyMatch else {
+			for user in users {
+				user.recoveryAttempts += 1
+				try await user.save(on: req.db)
+			}
+			throw noMatch
+		}
+
+		for user in users where user.recoveryAttempts != 0 {
+			user.recoveryAttempts = 0
+			try await user.save(on: req.db)
+		}
+
+		return try UserHeader(user: matched)
 	}
 
 	// MARK: - basicAuthGroup Handlers (not logged in)

--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -2305,8 +2305,10 @@ extension UserCreateData: RCFValidatable {
 /// Returned by:
 /// * `GET /api/v3/users/ID/header`
 /// * `GET /api/v3/client/user/headers/since/DATE`
+/// * `POST /api/v3/auth/username`
 ///
-/// See `UsersController.headerHandler(_:)`, `ClientController.userHeadersHandler(_:)`.
+/// See `UsersController.headerHandler(_:)`, `ClientController.userHeadersHandler(_:)`,
+/// `AuthController.usernameHandler(_:)`.
 public struct UserHeader: Content, Sendable {
 	/// The user's ID.
 	var userID: UUID
@@ -2653,6 +2655,41 @@ extension UserRecoveryData: RCFValidatable {
 			}
 		tester.validate(newPassword.count >= 6, forKey: .newPassword, or: "password has a 6 character minimum length")
 		tester.validate(newPassword.count <= 50, forKey: .newPassword, or: "password has a 50 character limit")
+	}
+}
+
+/// Used to look up a forgotten username from a registration code plus a second factor.
+///
+/// Required by: `POST /api/v3/auth/username`
+///
+/// See `AuthController.usernameHandler(_:)`.
+public struct UserUsernameLookupData: Content {
+	/// The registration code associated with the account.
+	var registrationCode: String
+	/// The user's password or recovery key. Must not be a registration code.
+	var recoveryKey: String
+}
+
+extension UserUsernameLookupData: RCFValidatable {
+	func runValidations(using decoder: ValidatingDecoder) throws {
+		let tester = try decoder.validator(keyedBy: CodingKeys.self)
+		tester.validate(
+			RegistrationCode.isWellFormed(registrationCode),
+			forKey: .registrationCode,
+			or: "Malformed registration code. Registration code must be 6 alphanumeric letters; spaces optional"
+		)
+		tester.validate(
+			recoveryKey.count >= 6,
+			forKey: .recoveryKey,
+			or: "password/recovery code has a 6 character minimum"
+		)
+		// A 6-character alphanumeric value is a registration code. The second factor must be
+		// the account password or recovery key, never the registration code (even a different one).
+		tester.validate(
+			!RegistrationCode.isWellFormed(recoveryKey),
+			forKey: .recoveryKey,
+			or: "recovery key cannot be a registration code; provide your password or recovery key"
+		)
 	}
 }
 

--- a/Sources/swiftarr/Models/User.swift
+++ b/Sources/swiftarr/Models/User.swift
@@ -274,6 +274,12 @@ extension User {
 		guard !verificationUsed, let verification else { return }
 		self.verification = "*" + RegistrationCode.normalized(verification)
 	}
+
+	/// Both stored forms of a registration code (`code` and `*code`) for database lookup.
+	static func storedVerificationValues(for code: String) -> [String] {
+		let normalized = RegistrationCode.normalized(unspentVerification(code))
+		return [normalized, "*" + normalized]
+	}
 }
 
 /// Creates the `User` table in the database and specifies its fields.

--- a/Sources/swiftarr/Resources/Assets/js/swiftarr.js
+++ b/Sources/swiftarr/Resources/Assets/js/swiftarr.js
@@ -494,11 +494,26 @@ async function submitAJAXForm(formElement, event) {
 			// to avoid MultipartKit parsing issues with simple text/checkbox forms.
 			uploadBody = new URLSearchParams(uploadBody);
 		}
+		formElement.querySelector('.alert-danger')?.classList.add("d-none");
+		formElement.querySelector('.alert-success')?.classList.add("d-none");
 		let response = await fetch(formElement.action, { method: 'POST', body: uploadBody });
 		if (response.status < 300) {
 			let successURL = formElement.dataset.successurl;
 			if (!successURL) {
 				location.reload();
+				return;
+			}
+			if (successURL == "message") {
+				let data = await response.json();
+				let successAlert = formElement.querySelector('.alert-success');
+				let field = formElement.dataset.successfield;
+				let valueElem = successAlert?.querySelector("[data-success-value]");
+				if (successAlert && valueElem && field && data[field] != null) {
+					valueElem.textContent = data[field];
+					successAlert.classList.remove("d-none");
+				}
+				formElement.reset();
+				spinnerElem?.classList.add("d-none");
 				return;
 			}
 			formElement.reset();

--- a/Sources/swiftarr/Resources/Views/Login/createAccount.html
+++ b/Sources/swiftarr/Resources/Views/Login/createAccount.html
@@ -101,6 +101,9 @@
 					<a href="/resetPassword">I forgot my password!</a>
 				</div>
 				<div class="row mt-1">
+					<a href="/forgotUsername">I forgot my username!</a>
+				</div>
+				<div class="row mt-1">
 					<a href="/codeOfConduct">I want to read the Code of Conduct and Twit-arr Rules!</a>
 				</div>
 			</div>

--- a/Sources/swiftarr/Resources/Views/Login/forgotUsername.html
+++ b/Sources/swiftarr/Resources/Views/Login/forgotUsername.html
@@ -1,0 +1,71 @@
+#extend("trunk"):
+#export("body"):
+	<div class="container-fluid">
+	#if(trunk.userIsLoggedIn):
+		<div class="container-fluid mt-3">
+			<div class="row">
+				<h4>Forgot Username</h4>
+				<p>You're currently logged in as user "#(trunk.username)".</p>
+			</div>
+			<div class="row">
+				<form action="/logout" method="POST">
+					<button type="submit" class="btn btn-primary">Logout<span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span></button>
+				</form>
+			</div>
+		</div>
+	#else:
+		<div class="container-fluid mt-3">
+			<div class="row">
+				<div class="col">
+					<h5>Forgot Username</h5>
+					<p>If you've forgotten the username you registered with, you can look it up here.</p>
+					<p>You'll need your registration code, plus either your password or the recovery key shown when you created your account.</p>
+				</div>
+			</div>
+			<form class="ajax" action="/forgotUsername" method="POST" data-successurl="message" data-successfield="username">
+				<div class="row mb-2 mx-2">
+					<div class="col">
+						<label for="regCode" class="form-label" id="regcode-label">Registration Code</label>
+						<input type="text" class="form-control swiftarr-textfield" id="regCode" name="regCode"
+								spellcheck="false" autocapitalize="none" autocomplete="one-time-code"
+								aria-describedby="regcode-label regcode-help">
+						<div id="regcode-help" class="form-text">
+							Your Registration Code was mailed to you before the cruise.
+						</div>
+					</div>
+				</div>
+				<div class="row mb-3 mx-2">
+					<div class="col">
+						<label for="recoveryKey" class="form-label" id="recoverykey-label">Password OR Recovery Key</label>
+						<input type="text" class="form-control swiftarr-textfield" id="recoveryKey" name="recoveryKey"
+								aria-describedby="recoverykey-label recoverykey-help" autocomplete="off">
+						<div id="recoverykey-help" class="form-text">
+							Use the password you chose, or the Recovery Key shown when you created your account. A registration code will not work here.
+						</div>
+					</div>
+				</div>
+				<button type="submit" class="btn btn-primary">Look Up Username<span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span></button>
+				<div class="alert alert-success mt-3 d-none" role="alert">
+					<b>Success:</b> Your username is <strong data-success-value></strong>.
+				</div>
+				<div class="alert alert-danger mt-3 d-none" role="alert"></div>
+			</form>
+		</div>
+		<div class="container-fluid mt-3">
+			<div class="row nav-item">
+				<a class="nav-link" href="/createAccount">I want to create an account</a>
+			</div>
+			<div class="row nav-item">
+				<a class="nav-link" href="/login">Just let me log in</a>
+			</div>
+			<div class="row nav-item">
+				<a class="nav-link" href="/resetPassword">I forgot my password!</a>
+			</div>
+			<div class="row nav-item">
+				<a class="nav-link" href="/codeOfConduct">I want to read the Code of Conduct and Twit-arr Rules!</a>
+			</div>
+		</div>
+	#endif
+	</div>
+#endexport
+#endextend

--- a/Sources/swiftarr/Resources/Views/Login/loginPane.html
+++ b/Sources/swiftarr/Resources/Views/Login/loginPane.html
@@ -32,5 +32,8 @@
 	<a class="link-primary" href="/resetPassword">I forgot my password!</a>
 </div>
 <div class="row mt-1">
+	<a class="link-primary" href="/forgotUsername">I forgot my username!</a>
+</div>
+<div class="row mt-1">
 	<a class="link-primary" href="/codeOfConduct">I want to read the Code of Conduct and Twit-arr Rules!</a>
 </div>

--- a/Sources/swiftarr/Resources/Views/Login/resetPassword.html
+++ b/Sources/swiftarr/Resources/Views/Login/resetPassword.html
@@ -99,6 +99,9 @@
 				<a class="nav-link" href="/login">Just let me log in</a>
 			</div>
 			<div class="row nav-item">
+				<a class="nav-link" href="/forgotUsername">I forgot my username!</a>
+			</div>
+			<div class="row nav-item">
 				<a class="nav-link" href="/codeOfConduct">I want to read the Code of Conduct and Twit-arr Rules!</a>
 			</div>
 		</div>

--- a/Sources/swiftarr/Site/SiteLoginController.swift
+++ b/Sources/swiftarr/Site/SiteLoginController.swift
@@ -10,8 +10,8 @@ struct SiteLoginController: SiteControllerUtils {
 		openRoutes.get("login", use: loginPageViewHandler)
 		openRoutes.post("login", use: loginPagePostHandler)
 		openRoutes.post("recoverPassword", use: recoverPasswordPostHandler)  // Change pw while not logged in
-		openRoutes.get("forgotUsername", use: forgotUsernameViewHandler).setUsedForPreregistration()
-		openRoutes.post("forgotUsername", use: forgotUsernamePostHandler).setUsedForPreregistration()
+		openRoutes.get("forgotUsername", use: forgotUsernameViewHandler)
+		openRoutes.post("forgotUsername", use: forgotUsernamePostHandler)
 		openRoutes.get("codeOfConduct", use: codeOfConductViewHandler)
 		openRoutes.get("conductAgree", use: codeOfConductViewHandler)
 

--- a/Sources/swiftarr/Site/SiteLoginController.swift
+++ b/Sources/swiftarr/Site/SiteLoginController.swift
@@ -10,6 +10,8 @@ struct SiteLoginController: SiteControllerUtils {
 		openRoutes.get("login", use: loginPageViewHandler)
 		openRoutes.post("login", use: loginPagePostHandler)
 		openRoutes.post("recoverPassword", use: recoverPasswordPostHandler)  // Change pw while not logged in
+		openRoutes.get("forgotUsername", use: forgotUsernameViewHandler).setUsedForPreregistration()
+		openRoutes.post("forgotUsername", use: forgotUsernamePostHandler).setUsedForPreregistration()
 		openRoutes.get("codeOfConduct", use: codeOfConductViewHandler)
 		openRoutes.get("conductAgree", use: codeOfConductViewHandler)
 
@@ -375,6 +377,37 @@ struct SiteLoginController: SiteControllerUtils {
 			}
 			return try await req.view.render("Login/resetPassword", ctx)
 		}
+	}
+
+	/// `GET /forgotUsername`
+	///
+	/// Shows the Forgot Username page. Logged-in users already know their username, so this
+	/// shows the same login-status message as other Login pages.
+	func forgotUsernameViewHandler(_ req: Request) async throws -> View {
+		return try await req.view.render("Login/forgotUsername", LoginPageContext(req, title: "Forgot Username"))
+	}
+
+	/// `POST /forgotUsername`
+	///
+	/// Looks up a username from a registration code plus password or recovery key. Returns JSON
+	/// `UserHeader` so the form can AJAX the result onto the page.
+	func forgotUsernamePostHandler(_ req: Request) async throws -> UserHeader {
+		struct PostStruct: Codable {
+			var regCode: String
+			var recoveryKey: String
+		}
+		let postStruct = try req.content.decode(PostStruct.self)
+		let lookupData = UserUsernameLookupData(
+			registrationCode: postStruct.regCode,
+			recoveryKey: postStruct.recoveryKey
+		)
+		let apiResponse = try await apiQuery(
+			req,
+			endpoint: "/auth/username",
+			method: .POST,
+			encodeContent: lookupData
+		)
+		return try apiResponse.content.decode(UserHeader.self)
 	}
 
 	/// `GET /codeOfConduct`

--- a/Tests/AppTests/AuthControllerTests.swift
+++ b/Tests/AppTests/AuthControllerTests.swift
@@ -174,4 +174,263 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 			)
 		}
 	}
+
+	// MARK: - Username lookup
+
+	private func makeLookupUser(
+		_ app: Application,
+		username: String,
+		verification: String?,
+		password: String = "password1",
+		recoveryKey: String = "recoverykey",
+		parent: User? = nil
+	) async throws -> User {
+		let user = User(
+			username: username,
+			password: try Bcrypt.hash(password),
+			recoveryKey: try Bcrypt.hash(recoveryKey),
+			verification: verification,
+			parent: parent,
+			accessLevel: .verified
+		)
+		try await user.save(on: app.db)
+		return user
+	}
+
+	private func lookupBody(code: String, key: String) -> UserUsernameLookupData {
+		UserUsernameLookupData(registrationCode: code, recoveryKey: key)
+	}
+
+	func testUsernameLookup_PasswordMatch() async throws {
+		try await withApp { app in
+			let username = "lookup-pw-\(UUID().uuidString.prefix(8))"
+			let user = try await makeLookupUser(app, username: username, verification: "abc123")
+			defer { Task { try? await user.delete(on: app.db) } }
+
+			try await app.test(
+				.POST,
+				"/api/v3/auth/username",
+				beforeRequest: { req async throws in
+					try req.content.encode(lookupBody(code: "abc123", key: "password1"))
+				},
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .ok)
+					let header = try res.content.decode(UserHeader.self)
+					XCTAssertEqual(header.username, username)
+					XCTAssertEqual(header.userID, try user.requireID())
+				}
+			)
+
+			// Lookup must not spend the registration code.
+			let reloaded = try await User.find(user.requireID(), on: app.db)
+			XCTAssertEqual(reloaded?.verification, "abc123")
+		}
+	}
+
+	func testUsernameLookup_RecoveryKeyMatch() async throws {
+		try await withApp { app in
+			let username = "lookup-rk-\(UUID().uuidString.prefix(8))"
+			let user = try await makeLookupUser(app, username: username, verification: "def456")
+			defer { Task { try? await user.delete(on: app.db) } }
+
+			try await app.test(
+				.POST,
+				"/api/v3/auth/username",
+				beforeRequest: { req async throws in
+					try req.content.encode(lookupBody(code: "DEF 456", key: "recovery key"))
+				},
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .ok)
+					let header = try res.content.decode(UserHeader.self)
+					XCTAssertEqual(header.username, username)
+				}
+			)
+		}
+	}
+
+	func testUsernameLookup_SpentCodeStillWorks() async throws {
+		try await withApp { app in
+			let username = "lookup-spent-\(UUID().uuidString.prefix(8))"
+			let user = try await makeLookupUser(app, username: username, verification: "*abc123")
+			defer { Task { try? await user.delete(on: app.db) } }
+
+			try await app.test(
+				.POST,
+				"/api/v3/auth/username",
+				beforeRequest: { req async throws in
+					try req.content.encode(lookupBody(code: "abc123", key: "password1"))
+				},
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .ok, "a spent registration code must still look up the username")
+					let header = try res.content.decode(UserHeader.self)
+					XCTAssertEqual(header.username, username)
+				}
+			)
+
+			let reloaded = try await User.find(user.requireID(), on: app.db)
+			XCTAssertEqual(reloaded?.verification, "*abc123")
+		}
+	}
+
+	func testUsernameLookup_RegistrationCodeAsBothFactors_Rejected() async throws {
+		try await withApp { app in
+			let username = "lookup-both-\(UUID().uuidString.prefix(8))"
+			let user = try await makeLookupUser(app, username: username, verification: "abc123")
+			defer { Task { try? await user.delete(on: app.db) } }
+
+			try await app.test(
+				.POST,
+				"/api/v3/auth/username",
+				beforeRequest: { req async throws in
+					try req.content.encode(lookupBody(code: "abc123", key: "abc123"))
+				},
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .badRequest)
+					let error = try res.content.decode(ErrorResponse.self)
+					XCTAssertTrue(
+						error.reason.contains("cannot be a registration code"),
+						"reason=\(error.reason)"
+					)
+				}
+			)
+		}
+	}
+
+	func testUsernameLookup_WrongPassword_NotFound() async throws {
+		try await withApp { app in
+			let username = "lookup-wrong-\(UUID().uuidString.prefix(8))"
+			let user = try await makeLookupUser(app, username: username, verification: "abc123")
+			defer { Task { try? await user.delete(on: app.db) } }
+
+			try await app.test(
+				.POST,
+				"/api/v3/auth/username",
+				beforeRequest: { req async throws in
+					try req.content.encode(lookupBody(code: "abc123", key: "not-the-password"))
+				},
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .badRequest)
+					let error = try res.content.decode(ErrorResponse.self)
+					XCTAssertEqual(error.reason, "no match for supplied credentials")
+				}
+			)
+
+			let reloaded = try await User.find(user.requireID(), on: app.db)
+			XCTAssertEqual(reloaded?.recoveryAttempts, 1)
+		}
+	}
+
+	func testUsernameLookup_UnknownCode_NotFound() async throws {
+		try await withApp { app in
+			try await app.test(
+				.POST,
+				"/api/v3/auth/username",
+				beforeRequest: { req async throws in
+					try req.content.encode(lookupBody(code: "zzz999", key: "password1"))
+				},
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .badRequest)
+					let error = try res.content.decode(ErrorResponse.self)
+					XCTAssertEqual(error.reason, "no match for supplied credentials")
+				}
+			)
+		}
+	}
+
+	func testUsernameLookup_AltPasswordReturnsAlt() async throws {
+		try await withApp { app in
+			let suffix = UUID().uuidString.prefix(8)
+			let primary = try await makeLookupUser(
+				app,
+				username: "lookup-pri-\(suffix)",
+				verification: "abc123",
+				password: "primarypw"
+			)
+			let alt = try await makeLookupUser(
+				app,
+				username: "lookup-alt-\(suffix)",
+				verification: "abc123",
+				password: "altpasswd",
+				parent: primary
+			)
+			defer {
+				Task {
+					try? await alt.delete(on: app.db)
+					try? await primary.delete(on: app.db)
+				}
+			}
+
+			try await app.test(
+				.POST,
+				"/api/v3/auth/username",
+				beforeRequest: { req async throws in
+					try req.content.encode(lookupBody(code: "abc123", key: "altpasswd"))
+				},
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .ok)
+					let header = try res.content.decode(UserHeader.self)
+					XCTAssertEqual(header.username, alt.username)
+					XCTAssertEqual(header.userID, try alt.requireID())
+				}
+			)
+		}
+	}
+
+	func testUsernameLookup_RecoveryKeyReturnsPrimary() async throws {
+		try await withApp { app in
+			let suffix = UUID().uuidString.prefix(8)
+			let primary = try await makeLookupUser(
+				app,
+				username: "lookup-rkpri-\(suffix)",
+				verification: "abc123"
+			)
+			let alt = try await makeLookupUser(
+				app,
+				username: "lookup-rkalt-\(suffix)",
+				verification: "abc123",
+				password: "altpasswd",
+				parent: primary
+			)
+			defer {
+				Task {
+					try? await alt.delete(on: app.db)
+					try? await primary.delete(on: app.db)
+				}
+			}
+
+			try await app.test(
+				.POST,
+				"/api/v3/auth/username",
+				beforeRequest: { req async throws in
+					try req.content.encode(lookupBody(code: "abc123", key: "recovery key"))
+				},
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .ok)
+					let header = try res.content.decode(UserHeader.self)
+					XCTAssertEqual(header.username, primary.username)
+				}
+			)
+		}
+	}
+
+	func testUsernameLookup_LockoutAfterFiveFailures() async throws {
+		try await withApp { app in
+			let username = "lookup-lock-\(UUID().uuidString.prefix(8))"
+			let user = try await makeLookupUser(app, username: username, verification: "abc123")
+			user.recoveryAttempts = 5
+			try await user.save(on: app.db)
+			defer { Task { try? await user.delete(on: app.db) } }
+
+			try await app.test(
+				.POST,
+				"/api/v3/auth/username",
+				beforeRequest: { req async throws in
+					try req.content.encode(lookupBody(code: "abc123", key: "password1"))
+				},
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .forbidden)
+				}
+			)
+		}
+	}
 }

--- a/Tests/AppTests/AuthControllerTests.swift
+++ b/Tests/AppTests/AuthControllerTests.swift
@@ -177,22 +177,28 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 
 	// MARK: - Username lookup
 
+	private func uniqueRegCode() -> String {
+		String(UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(6)).lowercased()
+	}
+
 	private func makeLookupUser(
 		_ app: Application,
 		username: String,
 		verification: String?,
 		password: String = "password1",
 		recoveryKey: String = "recoverykey",
-		parent: User? = nil
+		parentID: UUID? = nil
 	) async throws -> User {
 		let user = User(
 			username: username,
 			password: try Bcrypt.hash(password),
 			recoveryKey: try Bcrypt.hash(recoveryKey),
 			verification: verification,
-			parent: parent,
 			accessLevel: .verified
 		)
+		if let parentID {
+			user.$parent.id = parentID
+		}
 		try await user.save(on: app.db)
 		return user
 	}
@@ -204,14 +210,14 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 	func testUsernameLookup_PasswordMatch() async throws {
 		try await withApp { app in
 			let username = "lookup-pw-\(UUID().uuidString.prefix(8))"
-			let user = try await makeLookupUser(app, username: username, verification: "abc123")
-			defer { Task { try? await user.delete(on: app.db) } }
+			let code = uniqueRegCode()
+			let user = try await makeLookupUser(app, username: username, verification: code)
 
 			try await app.test(
 				.POST,
 				"/api/v3/auth/username",
 				beforeRequest: { req async throws in
-					try req.content.encode(lookupBody(code: "abc123", key: "password1"))
+					try req.content.encode(lookupBody(code: code, key: "password1"))
 				},
 				afterResponse: { res async throws in
 					XCTAssertEqual(res.status, .ok)
@@ -223,21 +229,23 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 
 			// Lookup must not spend the registration code.
 			let reloaded = try await User.find(user.requireID(), on: app.db)
-			XCTAssertEqual(reloaded?.verification, "abc123")
+			XCTAssertEqual(reloaded?.verification, code)
+			try await user.delete(on: app.db)
 		}
 	}
 
 	func testUsernameLookup_RecoveryKeyMatch() async throws {
 		try await withApp { app in
 			let username = "lookup-rk-\(UUID().uuidString.prefix(8))"
-			let user = try await makeLookupUser(app, username: username, verification: "def456")
-			defer { Task { try? await user.delete(on: app.db) } }
+			let code = uniqueRegCode()
+			let user = try await makeLookupUser(app, username: username, verification: code)
+			let spaced = "\(code.prefix(3)) \(code.suffix(3))".uppercased()
 
 			try await app.test(
 				.POST,
 				"/api/v3/auth/username",
 				beforeRequest: { req async throws in
-					try req.content.encode(lookupBody(code: "DEF 456", key: "recovery key"))
+					try req.content.encode(lookupBody(code: spaced, key: "recovery key"))
 				},
 				afterResponse: { res async throws in
 					XCTAssertEqual(res.status, .ok)
@@ -245,20 +253,21 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 					XCTAssertEqual(header.username, username)
 				}
 			)
+			try await user.delete(on: app.db)
 		}
 	}
 
 	func testUsernameLookup_SpentCodeStillWorks() async throws {
 		try await withApp { app in
 			let username = "lookup-spent-\(UUID().uuidString.prefix(8))"
-			let user = try await makeLookupUser(app, username: username, verification: "*abc123")
-			defer { Task { try? await user.delete(on: app.db) } }
+			let code = uniqueRegCode()
+			let user = try await makeLookupUser(app, username: username, verification: "*" + code)
 
 			try await app.test(
 				.POST,
 				"/api/v3/auth/username",
 				beforeRequest: { req async throws in
-					try req.content.encode(lookupBody(code: "abc123", key: "password1"))
+					try req.content.encode(lookupBody(code: code, key: "password1"))
 				},
 				afterResponse: { res async throws in
 					XCTAssertEqual(res.status, .ok, "a spent registration code must still look up the username")
@@ -268,21 +277,22 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 			)
 
 			let reloaded = try await User.find(user.requireID(), on: app.db)
-			XCTAssertEqual(reloaded?.verification, "*abc123")
+			XCTAssertEqual(reloaded?.verification, "*" + code)
+			try await user.delete(on: app.db)
 		}
 	}
 
 	func testUsernameLookup_RegistrationCodeAsBothFactors_Rejected() async throws {
 		try await withApp { app in
 			let username = "lookup-both-\(UUID().uuidString.prefix(8))"
-			let user = try await makeLookupUser(app, username: username, verification: "abc123")
-			defer { Task { try? await user.delete(on: app.db) } }
+			let code = uniqueRegCode()
+			let user = try await makeLookupUser(app, username: username, verification: code)
 
 			try await app.test(
 				.POST,
 				"/api/v3/auth/username",
 				beforeRequest: { req async throws in
-					try req.content.encode(lookupBody(code: "abc123", key: "abc123"))
+					try req.content.encode(lookupBody(code: code, key: code))
 				},
 				afterResponse: { res async throws in
 					XCTAssertEqual(res.status, .badRequest)
@@ -293,20 +303,21 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 					)
 				}
 			)
+			try await user.delete(on: app.db)
 		}
 	}
 
 	func testUsernameLookup_WrongPassword_NotFound() async throws {
 		try await withApp { app in
 			let username = "lookup-wrong-\(UUID().uuidString.prefix(8))"
-			let user = try await makeLookupUser(app, username: username, verification: "abc123")
-			defer { Task { try? await user.delete(on: app.db) } }
+			let code = uniqueRegCode()
+			let user = try await makeLookupUser(app, username: username, verification: code)
 
 			try await app.test(
 				.POST,
 				"/api/v3/auth/username",
 				beforeRequest: { req async throws in
-					try req.content.encode(lookupBody(code: "abc123", key: "not-the-password"))
+					try req.content.encode(lookupBody(code: code, key: "not-the-password"))
 				},
 				afterResponse: { res async throws in
 					XCTAssertEqual(res.status, .badRequest)
@@ -317,6 +328,7 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 
 			let reloaded = try await User.find(user.requireID(), on: app.db)
 			XCTAssertEqual(reloaded?.recoveryAttempts, 1)
+			try await user.delete(on: app.db)
 		}
 	}
 
@@ -326,7 +338,7 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 				.POST,
 				"/api/v3/auth/username",
 				beforeRequest: { req async throws in
-					try req.content.encode(lookupBody(code: "zzz999", key: "password1"))
+					try req.content.encode(lookupBody(code: uniqueRegCode(), key: "password1"))
 				},
 				afterResponse: { res async throws in
 					XCTAssertEqual(res.status, .badRequest)
@@ -340,31 +352,26 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 	func testUsernameLookup_AltPasswordReturnsAlt() async throws {
 		try await withApp { app in
 			let suffix = UUID().uuidString.prefix(8)
+			let code = uniqueRegCode()
 			let primary = try await makeLookupUser(
 				app,
 				username: "lookup-pri-\(suffix)",
-				verification: "abc123",
+				verification: code,
 				password: "primarypw"
 			)
 			let alt = try await makeLookupUser(
 				app,
 				username: "lookup-alt-\(suffix)",
-				verification: "abc123",
+				verification: code,
 				password: "altpasswd",
-				parent: primary
+				parentID: try primary.requireID()
 			)
-			defer {
-				Task {
-					try? await alt.delete(on: app.db)
-					try? await primary.delete(on: app.db)
-				}
-			}
 
 			try await app.test(
 				.POST,
 				"/api/v3/auth/username",
 				beforeRequest: { req async throws in
-					try req.content.encode(lookupBody(code: "abc123", key: "altpasswd"))
+					try req.content.encode(lookupBody(code: code, key: "altpasswd"))
 				},
 				afterResponse: { res async throws in
 					XCTAssertEqual(res.status, .ok)
@@ -373,36 +380,33 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 					XCTAssertEqual(header.userID, try alt.requireID())
 				}
 			)
+			try await alt.delete(on: app.db)
+			try await primary.delete(on: app.db)
 		}
 	}
 
 	func testUsernameLookup_RecoveryKeyReturnsPrimary() async throws {
 		try await withApp { app in
 			let suffix = UUID().uuidString.prefix(8)
+			let code = uniqueRegCode()
 			let primary = try await makeLookupUser(
 				app,
 				username: "lookup-rkpri-\(suffix)",
-				verification: "abc123"
+				verification: code
 			)
 			let alt = try await makeLookupUser(
 				app,
 				username: "lookup-rkalt-\(suffix)",
-				verification: "abc123",
+				verification: code,
 				password: "altpasswd",
-				parent: primary
+				parentID: try primary.requireID()
 			)
-			defer {
-				Task {
-					try? await alt.delete(on: app.db)
-					try? await primary.delete(on: app.db)
-				}
-			}
 
 			try await app.test(
 				.POST,
 				"/api/v3/auth/username",
 				beforeRequest: { req async throws in
-					try req.content.encode(lookupBody(code: "abc123", key: "recovery key"))
+					try req.content.encode(lookupBody(code: code, key: "recovery key"))
 				},
 				afterResponse: { res async throws in
 					XCTAssertEqual(res.status, .ok)
@@ -410,27 +414,30 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 					XCTAssertEqual(header.username, primary.username)
 				}
 			)
+			try await alt.delete(on: app.db)
+			try await primary.delete(on: app.db)
 		}
 	}
 
 	func testUsernameLookup_LockoutAfterFiveFailures() async throws {
 		try await withApp { app in
 			let username = "lookup-lock-\(UUID().uuidString.prefix(8))"
-			let user = try await makeLookupUser(app, username: username, verification: "abc123")
+			let code = uniqueRegCode()
+			let user = try await makeLookupUser(app, username: username, verification: code)
 			user.recoveryAttempts = 5
 			try await user.save(on: app.db)
-			defer { Task { try? await user.delete(on: app.db) } }
 
 			try await app.test(
 				.POST,
 				"/api/v3/auth/username",
 				beforeRequest: { req async throws in
-					try req.content.encode(lookupBody(code: "abc123", key: "password1"))
+					try req.content.encode(lookupBody(code: code, key: "password1"))
 				},
 				afterResponse: { res async throws in
 					XCTAssertEqual(res.status, .forbidden)
 				}
 			)
+			try await user.delete(on: app.db)
 		}
 	}
 }

--- a/Tests/AppTests/AuthControllerTests.swift
+++ b/Tests/AppTests/AuthControllerTests.swift
@@ -419,6 +419,31 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 		}
 	}
 
+	func testUsernameLookup_SuccessfulLookupDoesNotResetAttempts() async throws {
+		try await withApp { app in
+			let username = "lookup-keep-\(UUID().uuidString.prefix(8))"
+			let code = uniqueRegCode()
+			let user = try await makeLookupUser(app, username: username, verification: code)
+			user.recoveryAttempts = 2
+			try await user.save(on: app.db)
+
+			try await app.test(
+				.POST,
+				"/api/v3/auth/username",
+				beforeRequest: { req async throws in
+					try req.content.encode(lookupBody(code: code, key: "password1"))
+				},
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .ok)
+				}
+			)
+
+			let reloaded = try await User.find(user.requireID(), on: app.db)
+			XCTAssertEqual(reloaded?.recoveryAttempts, 2)
+			try await user.delete(on: app.db)
+		}
+	}
+
 	func testUsernameLookup_LockoutAfterFiveFailures() async throws {
 		try await withApp { app in
 			let username = "lookup-lock-\(UUID().uuidString.prefix(8))"

--- a/Tests/AppTests/AuthControllerTests.swift
+++ b/Tests/AppTests/AuthControllerTests.swift
@@ -31,7 +31,6 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 		try await withApp { app in
 			let username = "recovery-marked-\(UUID().uuidString.prefix(8))"
 			let user = try await makeRecoveryUser(app, username: username, verification: "*abc123")
-			defer { Task { try? await user.delete(on: app.db) } }
 
 			try await app.test(
 				.POST,
@@ -43,6 +42,7 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 					XCTAssertEqual(res.status, .badRequest, "a spent registration code must not recover the account")
 				}
 			)
+			try await user.delete(on: app.db)
 		}
 	}
 
@@ -51,7 +51,6 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 		try await withApp { app in
 			let username = "recovery-bare-\(UUID().uuidString.prefix(8))"
 			let user = try await makeRecoveryUser(app, username: username, verification: "*abc123")
-			defer { Task { try? await user.delete(on: app.db) } }
 
 			try await app.test(
 				.POST,
@@ -63,6 +62,7 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 					XCTAssertEqual(res.status, .badRequest, "a spent registration code must not recover the account")
 				}
 			)
+			try await user.delete(on: app.db)
 		}
 	}
 
@@ -71,7 +71,6 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 		try await withApp { app in
 			let username = "recovery-unspent-\(UUID().uuidString.prefix(8))"
 			let user = try await makeRecoveryUser(app, username: username, verification: "abc123")
-			defer { Task { try? await user.delete(on: app.db) } }
 
 			try await app.test(
 				.POST,
@@ -87,6 +86,7 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 			// The code is spent by that recovery, so it is marked and cannot be replayed.
 			let reloaded = try await User.find(user.requireID(), on: app.db)
 			XCTAssertEqual(reloaded?.verification, "*abc123")
+			try await user.delete(on: app.db)
 		}
 	}
 
@@ -94,7 +94,6 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 		try await withApp { app in
 			let username = "recovery-spaced-\(UUID().uuidString.prefix(8))"
 			let user = try await makeRecoveryUser(app, username: username, verification: "abcabc")
-			defer { Task { try? await user.delete(on: app.db) } }
 
 			try await app.test(
 				.POST,
@@ -109,6 +108,7 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 
 			let reloaded = try await User.find(user.requireID(), on: app.db)
 			XCTAssertEqual(reloaded?.verification, "*abcabc")
+			try await user.delete(on: app.db)
 		}
 	}
 
@@ -116,7 +116,6 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 		try await withApp { app in
 			let username = "recovery-upper-\(UUID().uuidString.prefix(8))"
 			let user = try await makeRecoveryUser(app, username: username, verification: "abcabc")
-			defer { Task { try? await user.delete(on: app.db) } }
 
 			try await app.test(
 				.POST,
@@ -131,6 +130,7 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 
 			let reloaded = try await User.find(user.requireID(), on: app.db)
 			XCTAssertEqual(reloaded?.verification, "*abcabc")
+			try await user.delete(on: app.db)
 		}
 	}
 
@@ -138,7 +138,6 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 		try await withApp { app in
 			let username = "recovery-nbsp-\(UUID().uuidString.prefix(8))"
 			let user = try await makeRecoveryUser(app, username: username, verification: "abcabc")
-			defer { Task { try? await user.delete(on: app.db) } }
 
 			try await app.test(
 				.POST,
@@ -153,6 +152,7 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 
 			let reloaded = try await User.find(user.requireID(), on: app.db)
 			XCTAssertEqual(reloaded?.verification, "*abcabc")
+			try await user.delete(on: app.db)
 		}
 	}
 
@@ -160,7 +160,6 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 		try await withApp { app in
 			let username = "recovery-spaced-spent-\(UUID().uuidString.prefix(8))"
 			let user = try await makeRecoveryUser(app, username: username, verification: "*abcabc")
-			defer { Task { try? await user.delete(on: app.db) } }
 
 			try await app.test(
 				.POST,
@@ -172,6 +171,7 @@ class AuthControllerTests: XCTestCase, SwiftarrBaseTest {
 					XCTAssertEqual(res.status, .badRequest, "a spent spaced registration code must not recover the account")
 				}
 			)
+			try await user.delete(on: app.db)
 		}
 	}
 

--- a/Tests/AppTests/UserStructValidationTests.swift
+++ b/Tests/AppTests/UserStructValidationTests.swift
@@ -231,4 +231,11 @@ class UserStructValidationTests: XCTestCase {
 			"errs=\(errs)"
 		)
 	}
+
+	// MARK: - User.storedVerificationValues
+
+	func testStoredVerificationValues_IncludesSpentAndUnspentForms() {
+		XCTAssertEqual(User.storedVerificationValues(for: "AbC 123"), ["abc123", "*abc123"])
+		XCTAssertEqual(User.storedVerificationValues(for: "*abc123"), ["abc123", "*abc123"])
+	}
 }

--- a/Tests/AppTests/UserStructValidationTests.swift
+++ b/Tests/AppTests/UserStructValidationTests.swift
@@ -164,4 +164,71 @@ class UserStructValidationTests: XCTestCase {
 		let errs = try validationErrors(UserCreateData.self, json)
 		XCTAssertTrue(errs.contains(where: { $0.contains("Malformed registration code") }), "errs=\(errs)")
 	}
+
+	// MARK: - UserUsernameLookupData
+
+	private func usernameLookupJSON(registrationCode: String = "abc123", recoveryKey: String = "password1") -> String {
+		#"{"registrationCode":"\#(registrationCode)","recoveryKey":"\#(recoveryKey)"}"#
+	}
+
+	func testUsernameLookup_ValidPassword() throws {
+		XCTAssertEqual(try validationErrors(UserUsernameLookupData.self, usernameLookupJSON()), [])
+	}
+
+	func testUsernameLookup_ValidRecoveryKey() throws {
+		XCTAssertEqual(
+			try validationErrors(UserUsernameLookupData.self, usernameLookupJSON(recoveryKey: "word word word")),
+			[]
+		)
+	}
+
+	func testUsernameLookup_SpacedRegistrationCode_Accepted() throws {
+		XCTAssertEqual(
+			try validationErrors(UserUsernameLookupData.self, usernameLookupJSON(registrationCode: "abc 123")),
+			[]
+		)
+	}
+
+	func testUsernameLookup_MalformedRegistrationCode() throws {
+		let errs = try validationErrors(UserUsernameLookupData.self, usernameLookupJSON(registrationCode: "abc"))
+		XCTAssertTrue(errs.contains(where: { $0.contains("Malformed registration code") }), "errs=\(errs)")
+	}
+
+	func testUsernameLookup_RecoveryKeyTooShort() throws {
+		let errs = try validationErrors(UserUsernameLookupData.self, usernameLookupJSON(recoveryKey: "abcde"))
+		XCTAssertTrue(errs.contains("password/recovery code has a 6 character minimum"), "errs=\(errs)")
+	}
+
+	func testUsernameLookup_RegistrationCodeAsBothFactors_Rejected() throws {
+		let errs = try validationErrors(
+			UserUsernameLookupData.self,
+			usernameLookupJSON(registrationCode: "abc123", recoveryKey: "abc123")
+		)
+		XCTAssertTrue(
+			errs.contains("recovery key cannot be a registration code; provide your password or recovery key"),
+			"errs=\(errs)"
+		)
+	}
+
+	func testUsernameLookup_DifferentRegistrationCodeAsSecondFactor_Rejected() throws {
+		let errs = try validationErrors(
+			UserUsernameLookupData.self,
+			usernameLookupJSON(registrationCode: "abc123", recoveryKey: "xyz789")
+		)
+		XCTAssertTrue(
+			errs.contains("recovery key cannot be a registration code; provide your password or recovery key"),
+			"errs=\(errs)"
+		)
+	}
+
+	func testUsernameLookup_SpacedRegistrationCodeAsSecondFactor_Rejected() throws {
+		let errs = try validationErrors(
+			UserUsernameLookupData.self,
+			usernameLookupJSON(registrationCode: "abc123", recoveryKey: "ABC 123")
+		)
+		XCTAssertTrue(
+			errs.contains("recovery key cannot be a registration code; provide your password or recovery key"),
+			"errs=\(errs)"
+		)
+	}
 }

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -236,3 +236,6 @@ associated AddedToChat field value increase.
 * New endpoint `POST /api/v3/admin/regcodes/unlock/:userID` re-enables one-time registration-code password recovery (strips the spent `*` prefix on `User.verification` and clears `recoveryAttempts`). TwitarrTeam or `accountmanager` only.
 * Added `photostreamUploadRateLimit` (seconds between photostream uploads; `0` disables the limit) to `SettingsAdminData`, `SettingsUpdateData`, and `ClientSettingsData`.
 * `GET /api/v3/client/settings` now also includes `photostreamUploadRateLimit`.
+
+## Aug 26, 2026
+* New open-access endpoint `POST /api/v3/auth/username` looks up a forgotten username. Callers must supply a registration code plus a password or recovery key (`UserUsernameLookupData`); a registration code is not accepted as the second factor. Returns the matching `UserHeader`. Does not spend the registration code and does not log the user in.

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -238,4 +238,4 @@ associated AddedToChat field value increase.
 * `GET /api/v3/client/settings` now also includes `photostreamUploadRateLimit`.
 
 ## Aug 26, 2026
-* New open-access endpoint `POST /api/v3/auth/username` looks up a forgotten username. Callers must supply a registration code plus a password or recovery key (`UserUsernameLookupData`); a registration code is not accepted as the second factor. Returns the matching `UserHeader`. Does not spend the registration code and does not log the user in.
+* New endpoint `POST /api/v3/auth/username` returns a `UserHeader` given a registration code plus password or recovery key (`UserUsernameLookupData`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Resolves #509.

People who forget the username they registered with can look it up if they have their registration code **and** either their password or recovery key.

## API

`POST /api/v3/auth/username` (open access, same group as password recovery)

Request (`UserUsernameLookupData`):
- `registrationCode` — 6-character registration code (spaces optional)
- `recoveryKey` — password **or** recovery key; a registration code is rejected as this second factor

Response: the matching `UserHeader`.

A 6-character alphanumeric second factor is always treated as a registration code and rejected, so the same code cannot be supplied for both components. Lookup does not spend the registration code and does not log the user in. Failed attempts share the existing 5-try recovery lockout. Unknown codes and bad second factors return the same generic error so a valid registration code is not distinguishable from a made-up one.

If the password matches a sub-account, that alt's header is returned. The recovery key is shared across a family, so a recovery-key match returns the primary account.

## Site

- `GET`/`POST` `/forgotUsername`
- Linked from `/login`, create-account, and password-reset pages
- Form AJAXes the result onto the page as a green success with the username, or a red error/not-found

## Review follow-up

- Dropped `setUsedForPreregistration()` from the API and site routes (caller is not logged in)
- Query spent and unspent codes via `User.storedVerificationValues(for:)`
- Successful lookup no longer resets `recoveryAttempts`
- Recovery tests now await user deletes so Fluent can shut down without crashing CI
- Inline comments on password vs recovery-key matching and attempt tracking
- API changelog bullet shortened

Draft PR for review.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a69009f2-4094-486e-909c-5ba9e2bf9f61?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a69009f2-4094-486e-909c-5ba9e2bf9f61&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

