### PR TITLE
Expose added-to chat IDs in UserNotificationData (#467)

### DIFF
--- a/Sources/swiftarr/Controllers/AlertController.swift
+++ b/Sources/swiftarr/Controllers/AlertController.swift
@@ -87,9 +87,9 @@ struct AlertController: APIRouteCollection {
 		}
 		// Get the number of fezzes with unread messages
 		async let userHash = try req.redis.getUserHash(userID: user.userID)
-		async let seamailCounts = try req.redis.getChatUnreadCounts(userID: user.userID, inbox: .seamail)
-		async let lfgCounts = try req.redis.getChatUnreadCounts(userID: user.userID, inbox: .lfgMessages)
-		async let privateEventCounts = try req.redis.getChatUnreadCounts(userID: user.userID, inbox: .privateEvent)
+		async let seamailState = try req.redis.getChatUnreadState(userID: user.userID, inbox: .seamail)
+		async let lfgState = try req.redis.getChatUnreadState(userID: user.userID, inbox: .lfgMessages)
+		async let privateEventState = try req.redis.getChatUnreadState(userID: user.userID, inbox: .privateEvent)
 		async let actives = try getActiveAnnouncementIDs(on: req)
 		async let modData = try getModeratorNotifications(for: user, on: req)
 		let finishedSongCount = try await max(0, req.redis.getIntFromUserHash(userHash, field: .microKaraokeSongReady(0)) -
@@ -111,9 +111,9 @@ struct AlertController: APIRouteCollection {
 			nextLFG = try await storeNextJoinedAppointment(userID: user.userID, on: req)
 		}
 		var result = try await UserNotificationData(
-			seamailCounts: seamailCounts,
-			lfgCounts: lfgCounts,
-			privateEventCounts: privateEventCounts,
+			seamailState: seamailState,
+			lfgState: lfgState,
+			privateEventState: privateEventState,
 			activeAnnouncementIDs: actives,
 			newAnnouncementCount: newAnnouncements,
 			nextEventTime: nextEvent?.0,

--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -2629,6 +2629,13 @@ public struct UserNotificationData: Content {
 	/// If a chat the user was added to (but hasn't yet viewed) gets new messages, that chat is counted in this total and not in `newPrivateEventMessageCount`.
 	var addedToPrivateEventCount: Int
 
+	/// The IDs of the Seamail chats counted by `addedToSeamailCount`. Empty if not logged in. Order is not significant.
+	var addedToSeamailIDs: [UUID]
+	/// The IDs of the LFGs counted by `addedToLFGCount`. Empty if not logged in. Order is not significant.
+	var addedToLFGIDs: [UUID]
+	/// The IDs of the Private Events counted by `addedToPrivateEventCount`. Empty if not logged in. Order is not significant.
+	var addedToPrivateEventIDs: [UUID]
+
 	/// Count of # of Seamail threads with new messages. NOT total # of new messages-a single seamail thread with 10 new messages counts as 1. 0 if not logged in.
 	var newSeamailMessageCount: Int
 	/// Count of # of LFGs with new messages. 0 if not logged in.
@@ -2684,9 +2691,9 @@ public struct UserNotificationData: Content {
 
 extension UserNotificationData {
 	init(
-		seamailCounts: (Int, Int), 
-		lfgCounts: (Int, Int), 
-		privateEventCounts: (Int, Int),
+		seamailState: ChatUnreadState,
+		lfgState: ChatUnreadState,
+		privateEventState: ChatUnreadState,
 		activeAnnouncementIDs: [Int],
 		newAnnouncementCount: Int,
 		nextEventTime: Date?,
@@ -2707,12 +2714,15 @@ extension UserNotificationData {
 		self.newTwarrtMentionCount = 0
 		self.forumMentionCount = 0
 		self.newForumMentionCount = 0
-		self.addedToSeamailCount = seamailCounts.0
-		self.addedToLFGCount = lfgCounts.0
-		self.addedToPrivateEventCount = privateEventCounts.0
-		self.newSeamailMessageCount = seamailCounts.1
-		self.newFezMessageCount = lfgCounts.1
-		self.newPrivateEventMessageCount = privateEventCounts.1
+		self.addedToSeamailCount = seamailState.addedToChatCount
+		self.addedToLFGCount = lfgState.addedToChatCount
+		self.addedToPrivateEventCount = privateEventState.addedToChatCount
+		self.addedToSeamailIDs = seamailState.addedToChatIDs
+		self.addedToLFGIDs = lfgState.addedToChatIDs
+		self.addedToPrivateEventIDs = privateEventState.addedToChatIDs
+		self.newSeamailMessageCount = seamailState.unreadChatCount
+		self.newFezMessageCount = lfgState.unreadChatCount
+		self.newPrivateEventMessageCount = privateEventState.unreadChatCount
 		self.nextFollowedEventTime = nextEventTime
 		self.nextFollowedEventID = nextEvent
 		self.microKaraokeFinishedSongCount = microKaraokeFinishedSongCount
@@ -2737,6 +2747,9 @@ extension UserNotificationData {
 		self.addedToSeamailCount = 0
 		self.addedToLFGCount = 0
 		self.addedToPrivateEventCount = 0
+		self.addedToSeamailIDs = []
+		self.addedToLFGIDs = []
+		self.addedToPrivateEventIDs = []
 		self.newForumMentionCount = 0
 		self.newSeamailMessageCount = 0
 		self.newFezMessageCount = 0

--- a/Sources/swiftarr/Helpers/RedisWrapper.swift
+++ b/Sources/swiftarr/Helpers/RedisWrapper.swift
@@ -228,20 +228,11 @@ extension RedisClient {
 		_ = try await delete(Request.Redis.activeAnnouncementRedisKey).get()
 	}
 
-	// This returns a tuple where the first Int is the number of chats the user has been added to but not yet viewed,
-	// and the second Int is number of chats with unread messages (not the total number of unread messages).
-	func getChatUnreadCounts(userID: UUID, inbox: MailInbox) async throws -> (Int, Int) {
-		let hash = try await hvals(in: inbox.unreadMailRedisKey(userID), as: Int.self).get()
-		let counts = hash.reduce((0, 0)) {
-			if let hashVal = $1 {
-				if hashVal > 9000 {
-					return ($0.0 + 1, $0.1)
-				}
-				return ($0.0, $0.1 + 1)
-			}
-			return $0
-		}
-		return counts
+	// Returns the chats the user was added to but hasn't yet viewed, along with the number of chats that have
+	// unread messages. See `ChatUnreadState`.
+	func getChatUnreadState(userID: UUID, inbox: MailInbox) async throws -> ChatUnreadState {
+		let hash = try await hgetall(from: inbox.unreadMailRedisKey(userID), as: Int.self).get()
+		return ChatUnreadState(unreadMailHash: hash)
 	}
 
 	// Get the unread message count for a given chat in a mailinbox for a user.
@@ -342,5 +333,38 @@ extension RedisClient {
 	// for a given MailInbox for given user to a given value.
 	func setChatUnreadCount(_ value: Int, chatID: UUID, userID: UUID, inbox: MailInbox) async throws {
 		_ = try await hset(chatID.uuidString, to: value, in: inbox.unreadMailRedisKey(userID)).get()
+	}
+}
+
+/// Summarizes the unread state of a single `MailInbox` for a single user. Built from one read of that inbox's hash,
+/// so the chats the user was added to and the counts derived from them can never disagree with each other.
+struct ChatUnreadState {
+	/// The IDs of the chats the user has been added to but has not yet viewed, in no particular order.
+	var addedToChatIDs: [UUID] = []
+	/// The number of chats with unread messages. Not the total number of unread messages; a single chat with 10
+	/// unread messages counts as 1. Chats the user was added to and hasn't yet viewed aren't counted here.
+	var unreadChatCount: Int = 0
+
+	/// The number of chats the user has been added to but not yet viewed.
+	var addedToChatCount: Int { addedToChatIDs.count }
+
+	init() {}
+
+	/// Splits a raw "Unread<mailboxname>-<userID>" hash into the two buckets. Chats the user was added to are stored
+	/// with a value > 9000 (see `userAddedToChat`), so the value tells us which bucket a given chat belongs in.
+	init(unreadMailHash: [String: Int?]) {
+		for (field, value) in unreadMailHash {
+			guard let value else {
+				continue
+			}
+			if value > 9000 {
+				if let chatID = UUID(uuidString: field) {
+					addedToChatIDs.append(chatID)
+				}
+			}
+			else {
+				unreadChatCount += 1
+			}
+		}
 	}
 }

--- a/Tests/AppTests/ChatUnreadStateTests.swift
+++ b/Tests/AppTests/ChatUnreadStateTests.swift
@@ -1,0 +1,153 @@
+import Redis
+import XCTVapor
+
+@testable import swiftarr
+
+// Tests for splitting a raw "Unread<mailbox>-<userID>" Redis hash into added-to chat IDs vs. unread chat counts,
+// and for surfacing those IDs on UserNotificationData.
+class ChatUnreadStateTests: XCTestCase {
+
+	private let addedToValue = 10000
+
+	private func state(_ hash: [String: Int?]) -> ChatUnreadState {
+		return ChatUnreadState(unreadMailHash: hash)
+	}
+
+	// MARK: - ChatUnreadState
+
+	func testEmptyInboxHasNoAddedToChats() throws {
+		let result = state([:])
+		XCTAssertEqual(result.addedToChatIDs, [])
+		XCTAssertEqual(result.addedToChatCount, 0)
+		XCTAssertEqual(result.unreadChatCount, 0)
+	}
+
+	func testAddedToChatIsReportedByID() throws {
+		let chatID = UUID()
+		let result = state([chatID.uuidString: addedToValue])
+		XCTAssertEqual(result.addedToChatIDs, [chatID])
+		XCTAssertEqual(result.addedToChatCount, 1)
+		XCTAssertEqual(result.unreadChatCount, 0)
+	}
+
+	func testUnreadMessagesDoNotProduceAddedToIDs() throws {
+		let chatID = UUID()
+		let result = state([chatID.uuidString: 3])
+		XCTAssertEqual(result.addedToChatIDs, [])
+		XCTAssertEqual(result.unreadChatCount, 1)
+	}
+
+	// A chat the user was added to that then gets new messages stays above the added-to threshold, so it must
+	// keep being reported as an added-to chat and must not also be counted as an unread chat.
+	func testAddedToChatWithNewMessagesStaysAddedTo() throws {
+		let chatID = UUID()
+		let result = state([chatID.uuidString: addedToValue + 7])
+		XCTAssertEqual(result.addedToChatIDs, [chatID])
+		XCTAssertEqual(result.unreadChatCount, 0)
+	}
+
+	func testAddedToIDsAndUnreadCountsAreSeparated() throws {
+		let addedFirst = UUID()
+		let addedSecond = UUID()
+		let unread = UUID()
+		let result = state([
+			addedFirst.uuidString: addedToValue,
+			addedSecond.uuidString: addedToValue + 1,
+			unread.uuidString: 2,
+		])
+		XCTAssertEqual(Set(result.addedToChatIDs), Set([addedFirst, addedSecond]))
+		XCTAssertEqual(result.addedToChatCount, 2)
+		XCTAssertEqual(result.unreadChatCount, 1)
+	}
+
+	// addedToChatCount is derived from addedToChatIDs, so the count a client sees always matches the ID list.
+	func testAddedToCountMatchesIDCount() throws {
+		let hash = Dictionary(uniqueKeysWithValues: (0..<5).map { _ in (UUID().uuidString, Int?.some(addedToValue)) })
+		let result = state(hash)
+		XCTAssertEqual(result.addedToChatCount, result.addedToChatIDs.count)
+		XCTAssertEqual(result.addedToChatCount, 5)
+	}
+
+	// Redis returns nil for hash values that can't be coerced to Int; those entries shouldn't count as anything.
+	func testNilHashValuesAreIgnored() throws {
+		let chatID = UUID()
+		let result = state([chatID.uuidString: nil, UUID().uuidString: nil])
+		XCTAssertEqual(result.addedToChatIDs, [])
+		XCTAssertEqual(result.unreadChatCount, 0)
+	}
+
+	// Defensive: a malformed hash field can't be turned into a chat ID, but it shouldn't crash or be reported.
+	func testNonUUIDFieldIsNotReportedAsAddedTo() throws {
+		let result = state(["not-a-uuid": addedToValue])
+		XCTAssertEqual(result.addedToChatIDs, [])
+		XCTAssertEqual(result.addedToChatCount, 0)
+	}
+
+	// The threshold is "> 9000"; a chat with 9000 unread messages is still just an unread chat.
+	func testValueAtThresholdIsUnreadNotAddedTo() throws {
+		let chatID = UUID()
+		let result = state([chatID.uuidString: 9000])
+		XCTAssertEqual(result.addedToChatIDs, [])
+		XCTAssertEqual(result.unreadChatCount, 1)
+	}
+
+	// MARK: - UserNotificationData
+
+	func testNotificationDataCarriesAddedToIDsPerInbox() throws {
+		let seamailID = UUID()
+		let lfgID = UUID()
+		let privateEventID = UUID()
+		let data = UserNotificationData(
+			seamailState: state([seamailID.uuidString: addedToValue, UUID().uuidString: 1]),
+			lfgState: state([lfgID.uuidString: addedToValue]),
+			privateEventState: state([privateEventID.uuidString: addedToValue]),
+			activeAnnouncementIDs: [],
+			newAnnouncementCount: 0,
+			nextEventTime: nil,
+			nextEvent: nil,
+			nextLFGTime: nil,
+			nextLFG: nil,
+			microKaraokeFinishedSongCount: 0
+		)
+		XCTAssertEqual(data.addedToSeamailIDs, [seamailID])
+		XCTAssertEqual(data.addedToLFGIDs, [lfgID])
+		XCTAssertEqual(data.addedToPrivateEventIDs, [privateEventID])
+		XCTAssertEqual(data.addedToSeamailCount, 1)
+		XCTAssertEqual(data.addedToLFGCount, 1)
+		XCTAssertEqual(data.addedToPrivateEventCount, 1)
+		XCTAssertEqual(data.newSeamailMessageCount, 1)
+		XCTAssertEqual(data.newFezMessageCount, 0)
+		XCTAssertEqual(data.newPrivateEventMessageCount, 0)
+	}
+
+	// The logged-out struct must not leak any chat IDs.
+	func testLoggedOutNotificationDataHasEmptyAddedToIDs() throws {
+		let data = UserNotificationData()
+		XCTAssertEqual(data.addedToSeamailIDs, [])
+		XCTAssertEqual(data.addedToLFGIDs, [])
+		XCTAssertEqual(data.addedToPrivateEventIDs, [])
+	}
+
+	// The new fields are additive, so they must round-trip through the JSON clients actually receive.
+	func testAddedToIDsRoundTripThroughJSON() throws {
+		let lfgID = UUID()
+		let original = UserNotificationData(
+			seamailState: state([:]),
+			lfgState: state([lfgID.uuidString: addedToValue]),
+			privateEventState: state([:]),
+			activeAnnouncementIDs: [],
+			newAnnouncementCount: 0,
+			nextEventTime: nil,
+			nextEvent: nil,
+			nextLFGTime: nil,
+			nextLFG: nil,
+			microKaraokeFinishedSongCount: 0
+		)
+		let encoded = try JSONEncoder().encode(original)
+		let decoded = try JSONDecoder().decode(UserNotificationData.self, from: encoded)
+		XCTAssertEqual(decoded.addedToLFGIDs, [lfgID])
+		XCTAssertEqual(decoded.addedToSeamailIDs, [])
+		XCTAssertEqual(decoded.addedToPrivateEventIDs, [])
+		XCTAssertEqual(decoded.addedToLFGCount, 1)
+	}
+}

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -240,3 +240,10 @@ associated AddedToChat field value increase.
 ## Aug 26, 2026
 * New `QuartermasterController`, a "have/need" item board (see `/api/v3/quartermaster` endpoints for the full list).
 * New moderator endpoints for reviewing and setting the moderation state of Quartermaster items: `GET /api/v3/mod/quartermaster/ID`, `POST /api/v3/mod/quartermaster/ID/setstate/STRING`.
+
+## Aug 27, 2026
+* `UserNotificationData` has new `addedToSeamailIDs`, `addedToLFGIDs`, and `addedToPrivateEventIDs` fields. Each is an
+array of the chat IDs counted by the corresponding `addedTo<Seamail, LFG, PrivateEvent>Count` field, letting clients
+show *which* chats the user was added to rather than just how many. The arrays are empty when not logged in. Purely
+additive; the existing count fields are unchanged and are now derived from these arrays, so counts and IDs always agree.
+


### PR DESCRIPTION
Fixes #467.

### What was missing

`UserNotificationData` tells a client *how many* Seamails, LFGs, and Private Events it has been added to but not yet viewed, and nothing more. As #467 notes, the notification socket event carries the content ID but not the `UserNotificationData`, so a client that refreshes on that event still can't resolve which chats those counts refer to.

The IDs were already in Redis. Each `Unread<mailbox>-<userID>` hash is keyed by chat ID, and `userAddedToChat` stores `10000` against that key while `newUnreadMessage` increments from `0` — which is exactly what the existing `> 9000` test keys off. `getChatUnreadCounts` read the hash with `hvals`, so the field names (the chat IDs) were thrown away before the counts were computed.

### The change

- `getChatUnreadCounts` becomes `getChatUnreadState`, reading the same hash with `hgetall` and folding it into a new `ChatUnreadState` value that keeps the added-to chat IDs alongside the unread-chat count. Same one Redis round trip per inbox, same `> 9000` rule.
- `UserNotificationData` gains `addedToSeamailIDs`, `addedToLFGIDs`, and `addedToPrivateEventIDs`. The existing `addedTo*Count` fields are now derived from those arrays (`addedToChatCount` is `addedToChatIDs.count`), so a count can't disagree with its own ID list.
- Purely additive for clients: no field was removed, renamed, or changed type, and the empty (logged-out) initializer returns empty arrays. The site's cached-session decode at `SiteController.swift:92` is already a `try?` with a fallback, so an older cached blob just falls back once.
- API Changelist entry added.

### Tests

New `Tests/AppTests/ChatUnreadStateTests.swift`, 12 cases: the hash split (added-to vs. unread), the `> 9000` boundary (a chat with exactly 9000 unread messages is still just unread), an added-to chat that later receives messages staying added-to and not being double-counted, `nil` and non-UUID hash entries being ignored, the per-inbox mapping onto `UserNotificationData`, the logged-out struct staying empty, and a JSON round-trip of the new fields.

Verified they actually pin the behaviour: with the ID collection reverted so only a count is kept, 6 of the 12 fail (14 assertions); restored, 12/12 pass.

### Validation

```
swift build                                    # Build complete!
swift test --filter ChatUnreadStateTests       # Executed 12 tests, with 0 failures
swift format lint --configuration .swift-format <changed files>
```

`swift format lint` reports no new warnings on any changed file — `AlertController.swift` and `RedisWrapper.swift` are byte-for-byte the same warning set as master, and `ControllerStructs.swift` drops 2 (trailing whitespace on the old init signature). The new test file lints clean.

The full suite (`swift test --enable-test-discovery --skip SettingsTests` against Postgres/Redis on 5433/6380, after `swiftarr migrate --env testing --yes`) can't run on macOS: it dies in `ClientUsers.swift:70` looking for `swiftarr_swiftarr.bundle/seeds/test-registered-clients.txt` under `Xcode.app`. I confirmed that's pre-existing by running the identical command on unmodified `master`, which fails the same way. CI should cover it on Linux.
