### PR TITLE
fix: editing a forum post through the web drops its images (#526)

### DIFF
--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -1356,10 +1356,12 @@ struct ImageUploadData: Content, Sendable {
 
 extension ImageUploadData {
 	init(_ filename: String? = nil, _ image: Data? = nil) {
-		// An empty filename comes from unused photo-form slots; treat it as "no image" so it
-		// doesn't get stored as a bogus empty filename on the post.
+		// Both halves can arrive empty rather than absent: an unused photo-form slot submits an
+		// empty filename, and a file input the user never touched is still submitted, decoding to
+		// zero bytes rather than to nil. Both mean "no image here", and keeping either one costs a
+		// real photo, since processImages only consults filename when image is nil.
 		self.filename = filename?.isEmpty == true ? nil : filename
-		self.image = image
+		self.image = image?.isEmpty == true ? nil : image
 	}
 }
 

--- a/Sources/swiftarr/Protocols/ImageHandler.swift
+++ b/Sources/swiftarr/Protocols/ImageHandler.swift
@@ -140,10 +140,13 @@ extension APIRouteCollection {
 		}
 		var savedImageNames = [String?]()
 		for image in images {
-			if let imageData = image.image {
+			// An empty value on either half means the slot holds nothing, not that it holds something
+			// empty. A zero-byte image especially must not count as present, or it shadows the filename
+			// beside it and the caller loses a photo the content already had.
+			if let imageData = image.image, !imageData.isEmpty {
 				savedImageNames.append( try await processImage(data: imageData, usage: usage, on: req))
 			}
-			else if let filename = image.filename {
+			else if let filename = image.filename, !filename.isEmpty {
 				savedImageNames.append(filename)
 			}
 		}

--- a/Tests/AppTests/ForumPostImagePreservationTests.swift
+++ b/Tests/AppTests/ForumPostImagePreservationTests.swift
@@ -1,0 +1,125 @@
+import XCTVapor
+
+@testable import swiftarr
+
+// Tests that editing a forum post through the API keeps the photos the post already has, whatever
+// shape the client uses to refer to them.
+//
+// processImages picks between an entry's image bytes and its filename. An entry carrying an empty
+// value for either one is carrying nothing, and has to be read that way: a zero-byte image that
+// counts as present shadows the filename beside it, and the post loses a photo it already had (#526).
+class ForumPostImagePreservationTests: XCTestCase, SwiftarrBaseTest {
+
+	private let existingImage = "already-on-the-post.jpg"
+
+	private struct Fixture {
+		let token: String
+		let postID: Int
+	}
+
+	private func makeFixture(_ app: Application, suffix: String) async throws -> Fixture {
+		let author = User(
+			username: "author-\(suffix)",
+			password: try Bcrypt.hash("password1"),
+			recoveryKey: try Bcrypt.hash("recovery key"),
+			accessLevel: .verified
+		)
+		try await author.save(on: app.db)
+
+		let category = Category(title: "Image Fixture \(suffix)", purpose: "test fixture")
+		try await category.save(on: app.db)
+		let forum = try Forum(title: "Image Fixture \(suffix)", category: category, creatorID: author.requireID())
+		try await forum.save(on: app.db)
+		let post = try ForumPost(
+			forum: forum,
+			authorID: author.requireID(),
+			text: "original text",
+			images: [existingImage]
+		)
+		try await post.save(on: app.db)
+
+		let token = try Token.generate(for: author)
+		try await token.save(on: app.db)
+		// The cache is built from Redis, which is not reachable until the app has booted.
+		try await app.asyncBoot()
+		try await app.initializeUserCache(app)
+
+		return Fixture(token: token.token, postID: try post.requireID())
+	}
+
+	private func bearer(_ token: String) -> HTTPHeaders {
+		var headers = HTTPHeaders()
+		headers.bearerAuthorization = BearerAuthorization(token: token)
+		return headers
+	}
+
+	// Sends a raw body so a test can express an empty image or filename. Encoding an ImageUploadData
+	// would normalize those away, and they are the whole point here.
+	private func editPost(
+		_ app: Application,
+		_ fixture: Fixture,
+		imagesJSON: String,
+		verify: @escaping (PostData) throws -> Void
+	) async throws {
+		let body = """
+			{"text":"edited text","images":\(imagesJSON),"postAsModerator":false,"postAsTwitarrTeam":false}
+			"""
+		try await app.test(
+			.POST,
+			"/api/v3/forum/post/\(fixture.postID)/update",
+			headers: bearer(fixture.token),
+			beforeRequest: { req async throws in
+				req.headers.contentType = .json
+				req.body = ByteBuffer(string: body)
+			},
+			afterResponse: { res async throws in
+				XCTAssertEqual(res.status, .ok)
+				try verify(try res.content.decode(PostData.self))
+			}
+		)
+	}
+
+	private func suffix() -> String { UUID().uuidString.prefix(8).lowercased() }
+
+	// A client that fills in every field of ImageUploadData sends an empty image alongside the
+	// filename of a photo the post already has. The empty image must not discard that photo.
+	func testEditKeepsAPhotoSentWithAnEmptyImage() async throws {
+		try await withApp { app in
+			let fixture = try await makeFixture(app, suffix: suffix())
+			try await editPost(app, fixture, imagesJSON: #"[{"filename":"\#(existingImage)","image":""}]"#) { post in
+				XCTAssertEqual(post.images, [self.existingImage], "an empty image must not discard the filename beside it")
+			}
+		}
+	}
+
+	// The shape current clients send. Guards the fix against regressing the normal path.
+	func testEditKeepsAPhotoSentAsFilenameOnly() async throws {
+		try await withApp { app in
+			let fixture = try await makeFixture(app, suffix: suffix())
+			try await editPost(app, fixture, imagesJSON: #"[{"filename":"\#(existingImage)"}]"#) { post in
+				XCTAssertEqual(post.images, [self.existingImage])
+			}
+		}
+	}
+
+	// Empty on both sides means the slot holds nothing, so it must not be stored as an image whose
+	// filename is the empty string.
+	func testEditDropsASlotEmptyOnBothSides() async throws {
+		try await withApp { app in
+			let fixture = try await makeFixture(app, suffix: suffix())
+			try await editPost(app, fixture, imagesJSON: #"[{"filename":"","image":""}]"#) { post in
+				XCTAssertEqual(post.images ?? [], [], "an entry with nothing in it must not be stored")
+			}
+		}
+	}
+
+	// Removing a photo has to keep working: the client sends no entries at all.
+	func testEditWithNoImagesRemovesThePhoto() async throws {
+		try await withApp { app in
+			let fixture = try await makeFixture(app, suffix: suffix())
+			try await editPost(app, fixture, imagesJSON: "[]") { post in
+				XCTAssertEqual(post.images ?? [], [])
+			}
+		}
+	}
+}

--- a/Tests/AppTests/MessagePostFormTests.swift
+++ b/Tests/AppTests/MessagePostFormTests.swift
@@ -1,0 +1,84 @@
+import XCTVapor
+
+@testable import swiftarr
+
+// Tests the Site layer's post form -> PostContentData mapping, driven by multipart bodies shaped the
+// way a browser actually submits them. Pure Swift -- no DB or network required.
+class MessagePostFormTests: XCTestCase {
+
+	private typealias FormPart = (name: String, filename: String?, body: String)
+
+	// Assembles a multipart/form-data body. A part with a non-nil filename is a file input; a browser
+	// submits one of those even when the user picked nothing, as an empty filename and an empty body.
+	private func multipartBody(_ parts: [FormPart], boundary: String) -> String {
+		var body = ""
+		for part in parts {
+			body += "--\(boundary)\r\n"
+			if let filename = part.filename {
+				body += "Content-Disposition: form-data; name=\"\(part.name)\"; filename=\"\(filename)\"\r\n"
+				body += "Content-Type: application/octet-stream\r\n"
+			}
+			else {
+				body += "Content-Disposition: form-data; name=\"\(part.name)\"\r\n"
+			}
+			body += "\r\n\(part.body)\r\n"
+		}
+		return body + "--\(boundary)--\r\n"
+	}
+
+	private func decodeForm(_ parts: [FormPart]) throws -> MessagePostFormContent {
+		let boundary = "----WebKitFormBoundaryswiftarrTest"
+		return try FormDataDecoder().decode(
+			MessagePostFormContent.self,
+			from: multipartBody(parts, boundary: boundary),
+			boundary: boundary
+		)
+	}
+
+	// What the edit form submits for a post that already has one image: the stored filename rides
+	// along in the hidden serverPhoto1 field, and localPhoto1 is a file input the user never touched.
+	private let editFormWithOneExistingImage: [FormPart] = [
+		("postText", nil, "edited text"),
+		("localPhoto1", "", ""),
+		("serverPhoto1", nil, "existing.jpg"),
+		("localPhoto2", "", ""),
+		("serverPhoto2", nil, ""),
+	]
+
+	func testEditKeepsAnExistingImage() throws {
+		let content = try decodeForm(editFormWithOneExistingImage).buildPostContentData()
+		XCTAssertEqual(content.images.count, 1)
+		XCTAssertEqual(content.images.first?.filename, "existing.jpg")
+		// The image has to be nil, not merely empty. processImages checks `image` first and only
+		// falls back to `filename` when it is nil, so a zero-byte image here drops the photo.
+		XCTAssertNil(content.images.first?.image)
+	}
+
+	func testUntouchedFileInputDecodesAsEmptyData() throws {
+		// Pins the decoder behavior the test above guards against: the part is present in the body,
+		// so an optional Data decodes to empty Data rather than to nil.
+		let form = try decodeForm(editFormWithOneExistingImage)
+		XCTAssertEqual(form.localPhoto1, Data())
+	}
+
+	func testChoosingAPhotoUploadsIt() throws {
+		let content = try decodeForm([
+			("postText", nil, "first post"),
+			("localPhoto1", "photo.jpg", "JPEGBYTES"),
+			("serverPhoto1", nil, ""),
+		]).buildPostContentData()
+		XCTAssertEqual(content.images.count, 1)
+		XCTAssertEqual(content.images.first?.image, Data("JPEGBYTES".utf8))
+	}
+
+	func testUnusedPhotoSlotsAreDropped() throws {
+		let content = try decodeForm([
+			("postText", nil, "no photos here"),
+			("localPhoto1", "", ""),
+			("serverPhoto1", nil, ""),
+			("localPhoto2", "", ""),
+			("serverPhoto2", nil, ""),
+		]).buildPostContentData()
+		XCTAssertTrue(content.images.isEmpty, "got \(content.images)")
+	}
+}


### PR DESCRIPTION
This is the repro you posted on #526, and you were right that it is the site layer rather than the API. The mechanism sits one level below `SiteForumController`.

## What happens

An `<input type="file">` is submitted even when the user picks no file. The browser sends a part with an empty filename and an empty body. multipart-kit's `decodeNil(forKey:)` returns false unconditionally, so the optional `Data` fields on `MessagePostFormContent` decode to zero-byte `Data` rather than to nil.

`buildPostContentData` pairs that with the hidden `serverPhotoN` field, so the edit form produces an `ImageUploadData` holding both the existing filename and a zero-byte image. `processImages` checks `image` first and only falls back to `filename` when `image` is nil:

```swift
if let imageData = image.image {
    savedImageNames.append(try await processImage(data: imageData, usage: usage, on: req))
}
else if let filename = image.filename {
    savedImageNames.append(filename)
}
```

The zero-byte image takes the first branch, `processImage` returns nil for empty data, `compactMap` drops it, and the filename is never read. The photo is gone.

Tricordarr omits the `image` key entirely, so its value really is nil and the filename branch runs. That is the difference you were seeing between the two.

## The fix, in two parts

**Commit 1 fixes the reported bug.** `ImageUploadData`'s init now treats an empty image as absent, mirroring the empty-filename normalization already on the line above it. That stops the web form from ever producing the bad shape.

It also fixes something I did not expect to find. Every unused photo slot was reaching the API as `ImageUploadData(filename: nil, image: 0 bytes)`, so a post with one attachment has been sending four or eight image entries. They were discarded downstream, so nothing broke, but they should never have been sent.

**Commit 2 fixes the same defect at the layer that makes the decision.** The init above is a convenience used by the site form. A client posting the full `ImageUploadData` shape to the API skips it, because the synthesized `Codable` init does not normalize what it decodes, so `{"filename": "x.jpg", "image": ""}` still lost the photo. `processImages` now reads an empty value on either half as absent:

```swift
if let imageData = image.image, !imageData.isEmpty {
    savedImageNames.append(try await processImage(data: imageData, usage: usage, on: req))
}
else if let filename = image.filename, !filename.isEmpty {
    savedImageNames.append(filename)
}
```

The filename guard is needed on its own. Without it, an entry that is empty on both sides falls through to the filename branch and stores the empty string as one of the post's images. I checked all nine `processImages` call sites, covering daily themes, fezzes, forums and twarrts. None of them wants an empty entry kept.

The two commits are separable if you would rather take only the first.

## Testing

`MessagePostFormTests` covers the form layer, decoding multipart bodies shaped the way a browser submits them rather than building the struct by hand, since the decode step is where the bug lives.

- editing a post keeps its existing image
- an untouched file input decodes to empty Data, which pins the decoder behavior the first test depends on
- choosing a photo still uploads it
- unused photo slots are dropped

Three of those four fail against unfixed code, with the existing image arriving as `(filename: "existing.jpg", image: 0 bytes)`.

`ForumPostImagePreservationTests` covers the API, driving the real `POST /api/v3/forum/post/:postID/update` against Postgres and Redis. It sends raw JSON, because encoding an `ImageUploadData` would normalize away the shape being tested.

- an empty image does not discard the filename beside it
- a filename on its own still works, which is what current clients send
- an entry empty on both sides is dropped rather than stored as an empty filename
- sending no entries still removes the photo

One of those four fails against unfixed code, returning `[]` where the post's image should be. The other three pass before and after, so the coverage isolates the defect rather than masking it.

Full suite: 390 tests, 0 failures, with the test database migrated.
