### PR TITLE
Allow posting announcements as TwitarrTeam, THO, or admin (#589)

### DIFF
--- a/Sources/swiftarr/Controllers/AlertController.swift
+++ b/Sources/swiftarr/Controllers/AlertController.swift
@@ -255,7 +255,7 @@ struct AlertController: APIRouteCollection {
 			throw Abort(.forbidden, reason: "TwitarrTeam and THO only")
 		}
 		let announcementData = try ValidatingJSONDecoder().decode(AnnouncementCreateData.self, fromBodyOf: req)
-		let author = try announcementData.effectiveAuthor(for: user, on: req)
+		let author = try announcementData.effectiveAuthor(on: req)
 		let announcement = Announcement(
 			authorID: author.userID,
 			text: announcementData.text,
@@ -372,7 +372,7 @@ struct AlertController: APIRouteCollection {
 		announcement.text = announcementData.text
 		announcement.displayUntil = announcementData.displayUntil
 		if announcementData.postAsUser != nil {
-			let author = try announcementData.effectiveAuthor(for: user, on: req)
+			let author = try announcementData.effectiveAuthor(on: req)
 			announcement.$author.id = author.userID
 		}
 		try await announcement.save(on: req.db)

--- a/Sources/swiftarr/Controllers/AlertController.swift
+++ b/Sources/swiftarr/Controllers/AlertController.swift
@@ -255,8 +255,9 @@ struct AlertController: APIRouteCollection {
 			throw Abort(.forbidden, reason: "TwitarrTeam and THO only")
 		}
 		let announcementData = try ValidatingJSONDecoder().decode(AnnouncementCreateData.self, fromBodyOf: req)
+		let author = try announcementData.effectiveAuthor(for: user, on: req)
 		let announcement = Announcement(
-			authorID: user.userID,
+			authorID: author.userID,
 			text: announcementData.text,
 			displayUntil: announcementData.displayUntil
 		)
@@ -370,6 +371,10 @@ struct AlertController: APIRouteCollection {
 		}
 		announcement.text = announcementData.text
 		announcement.displayUntil = announcementData.displayUntil
+		if announcementData.postAsUser != nil {
+			let author = try announcementData.effectiveAuthor(for: user, on: req)
+			announcement.$author.id = author.userID
+		}
 		try await announcement.save(on: req.db)
 		let authorHeader = try req.userCache.getHeader(announcement.$author.id)
 		return try AnnouncementData(from: announcement, authorHeader: authorHeader)

--- a/Sources/swiftarr/Controllers/AlertController.swift
+++ b/Sources/swiftarr/Controllers/AlertController.swift
@@ -255,7 +255,7 @@ struct AlertController: APIRouteCollection {
 			throw Abort(.forbidden, reason: "TwitarrTeam and THO only")
 		}
 		let announcementData = try ValidatingJSONDecoder().decode(AnnouncementCreateData.self, fromBodyOf: req)
-		let author = try announcementData.effectiveAuthor(on: req)
+		let author = try announcementData.effectiveAuthor(on: req, for: .announcement)
 		let announcement = Announcement(
 			authorID: author.userID,
 			text: announcementData.text,
@@ -371,9 +371,9 @@ struct AlertController: APIRouteCollection {
 		}
 		announcement.text = announcementData.text
 		announcement.displayUntil = announcementData.displayUntil
+		// Validate a decoded postAsUser value, but never change an announcement's author on edit.
 		if announcementData.postAsUser != nil {
-			let author = try announcementData.effectiveAuthor(on: req)
-			announcement.$author.id = author.userID
+			_ = try announcementData.effectiveAuthor(on: req, for: .announcement)
 		}
 		try await announcement.save(on: req.db)
 		let authorHeader = try req.userCache.getHeader(announcement.$author.id)

--- a/Sources/swiftarr/Controllers/AlertController.swift
+++ b/Sources/swiftarr/Controllers/AlertController.swift
@@ -356,6 +356,10 @@ struct AlertController: APIRouteCollection {
 			throw Abort(.forbidden, reason: "TwitarrTeam and THO only")
 		}
 		let announcementData = try ValidatingJSONDecoder().decode(AnnouncementCreateData.self, fromBodyOf: req)
+		// Validate before restoring a deleted announcement so a rejected edit cannot mutate its state.
+		if announcementData.postAsUser != nil {
+			_ = try announcementData.effectiveAuthor(on: req, for: .announcement)
+		}
 		guard let announcementIDStr = req.parameters.get(announcementIDParam.paramString),
 			let announcementID = Int(announcementIDStr)
 		else {
@@ -371,10 +375,6 @@ struct AlertController: APIRouteCollection {
 		}
 		announcement.text = announcementData.text
 		announcement.displayUntil = announcementData.displayUntil
-		// Validate a decoded postAsUser value, but never change an announcement's author on edit.
-		if announcementData.postAsUser != nil {
-			_ = try announcementData.effectiveAuthor(on: req, for: .announcement)
-		}
 		try await announcement.save(on: req.db)
 		let authorHeader = try req.userCache.getHeader(announcement.$author.id)
 		return try AnnouncementData(from: announcement, authorHeader: authorHeader)

--- a/Sources/swiftarr/Controllers/Structs/AdminControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/AdminControllerStructs.swift
@@ -3,7 +3,7 @@ import Vapor
 /// structs in this file should only be used by Admin APIs, that is: API calls that require administrator access.
 
 /// For admins to create and edit Annoucements.
-public struct AnnouncementCreateData: Content {
+public struct AnnouncementCreateData: Content, Authorable {
 	/// The text of the announcement
 	var text: String
 	/// How long to display the announcement to users. User-level API route methods will only return this Announcement until this time. The given Date is interpreted
@@ -25,38 +25,6 @@ extension AnnouncementCreateData: RCFValidatable {
 			forKey: .displayUntil,
 			or: "Announcement DisplayUntil date must be in the future."
 		)
-	}
-}
-
-extension AnnouncementCreateData {
-	/// Resolves the author for this request, enforcing who may post as whom.
-	func effectiveAuthor(for caller: UserCacheData, on req: Request) throws -> UserCacheData {
-		guard let raw = postAsUser?.trimmingCharacters(in: .whitespaces), !raw.isEmpty,
-			raw.caseInsensitiveCompare("self") != .orderedSame,
-			raw.caseInsensitiveCompare(caller.username) != .orderedSame
-		else { return caller }
-		let allowed: Bool
-		let target: PrivilegedUser
-		switch raw.lowercased() {
-		case PrivilegedUser.TwitarrTeam.queryParam:
-			target = .TwitarrTeam
-			allowed = caller.accessLevel == .twitarrteam || caller.accessLevel == .admin
-		case PrivilegedUser.THO.queryParam:
-			target = .THO
-			allowed = caller.accessLevel == .tho || caller.accessLevel == .admin
-		case PrivilegedUser.admin.queryParam:
-			target = .admin
-			allowed = caller.accessLevel.hasAccess(.twitarrteam)
-		default:
-			throw Abort(.forbidden, reason: "Cannot post announcements as '\(raw)'.")
-		}
-		guard allowed else {
-			throw Abort(.forbidden, reason: "Your account cannot post announcements as @\(target.rawValue).")
-		}
-		guard let user = req.userCache.getUser(username: target.rawValue) else {
-			throw Abort(.internalServerError, reason: "Privileged account @\(target.rawValue) is missing.")
-		}
-		return user
 	}
 }
 

--- a/Sources/swiftarr/Controllers/Structs/AdminControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/AdminControllerStructs.swift
@@ -9,6 +9,10 @@ public struct AnnouncementCreateData: Content {
 	/// How long to display the announcement to users. User-level API route methods will only return this Announcement until this time. The given Date is interpreted
 	/// as a floating time in the ship's Port timezone.
 	var displayUntil: Date
+	/// Author the announcement as this privileged account: "TwitarrTeam", "THO", or "admin".
+	/// nil, "", "self", or the caller's own username means the caller. Checked server-side
+	/// against the caller's access level.
+	var postAsUser: String? = nil
 }
 
 extension AnnouncementCreateData: RCFValidatable {
@@ -21,6 +25,38 @@ extension AnnouncementCreateData: RCFValidatable {
 			forKey: .displayUntil,
 			or: "Announcement DisplayUntil date must be in the future."
 		)
+	}
+}
+
+extension AnnouncementCreateData {
+	/// Resolves the author for this request, enforcing who may post as whom.
+	func effectiveAuthor(for caller: UserCacheData, on req: Request) throws -> UserCacheData {
+		guard let raw = postAsUser?.trimmingCharacters(in: .whitespaces), !raw.isEmpty,
+			raw.caseInsensitiveCompare("self") != .orderedSame,
+			raw.caseInsensitiveCompare(caller.username) != .orderedSame
+		else { return caller }
+		let allowed: Bool
+		let target: PrivilegedUser
+		switch raw.lowercased() {
+		case PrivilegedUser.TwitarrTeam.queryParam:
+			target = .TwitarrTeam
+			allowed = caller.accessLevel == .twitarrteam || caller.accessLevel == .admin
+		case PrivilegedUser.THO.queryParam:
+			target = .THO
+			allowed = caller.accessLevel == .tho || caller.accessLevel == .admin
+		case PrivilegedUser.admin.queryParam:
+			target = .admin
+			allowed = caller.accessLevel.hasAccess(.twitarrteam)
+		default:
+			throw Abort(.forbidden, reason: "Cannot post announcements as '\(raw)'.")
+		}
+		guard allowed else {
+			throw Abort(.forbidden, reason: "Your account cannot post announcements as @\(target.rawValue).")
+		}
+		guard let user = req.userCache.getUser(username: target.rawValue) else {
+			throw Abort(.internalServerError, reason: "Privileged account @\(target.rawValue) is missing.")
+		}
+		return user
 	}
 }
 

--- a/Sources/swiftarr/Enumerations/PrivilegedUser.swift
+++ b/Sources/swiftarr/Enumerations/PrivilegedUser.swift
@@ -28,4 +28,29 @@ extension PrivilegedUser {
 	/// Note: moderator and TwitarrTeam cannot authenticate as their passwords are randomly generated and discarded.
 	/// Stored as lowercase for case-insensitive matching.
 	static let serviceAccountsWithPasswords: Set<String> = ["admin", "prometheus", "tho"]
+
+	/// Case-insensitive match against `queryParam` (lowercased `rawValue`).
+	init?(fromQueryParam raw: String) {
+		let needle = raw.lowercased()
+		guard let match = PrivilegedUser.allCases.first(where: { $0.queryParam == needle }) else {
+			return nil
+		}
+		self = match
+	}
+
+	/// Whether `callerAccessLevel` may author announcements as this privileged account.
+	/// TwitarrTeam: self/TwitarrTeam/admin. THO: self/THO/admin. Admin: all three.
+	/// Unknown values including moderator are not allowed.
+	func canPostAs(from callerAccessLevel: UserAccessLevel) -> Bool {
+		switch self {
+		case .TwitarrTeam:
+			return callerAccessLevel == .twitarrteam || callerAccessLevel == .admin
+		case .THO:
+			return callerAccessLevel == .tho || callerAccessLevel == .admin
+		case .admin:
+			return callerAccessLevel.hasAccess(.twitarrteam)
+		case .moderator:
+			return false
+		}
+	}
 }

--- a/Sources/swiftarr/Enumerations/PrivilegedUser.swift
+++ b/Sources/swiftarr/Enumerations/PrivilegedUser.swift
@@ -38,19 +38,20 @@ extension PrivilegedUser {
 		self = match
 	}
 
-	/// Whether `callerAccessLevel` may author announcements as this privileged account.
-	/// TwitarrTeam: self/TwitarrTeam/admin. THO: self/THO/admin. Admin: all three.
-	/// Unknown values including moderator are not allowed.
-	func canPostAs(from callerAccessLevel: UserAccessLevel) -> Bool {
-		switch self {
-		case .TwitarrTeam:
-			return callerAccessLevel == .twitarrteam || callerAccessLevel == .admin
-		case .THO:
-			return callerAccessLevel == .tho || callerAccessLevel == .admin
-		case .admin:
-			return callerAccessLevel.hasAccess(.twitarrteam)
-		case .moderator:
-			return false
+	/// Whether callerAccessLevel may author this privileged account for the content type.
+	func canPostAs(from callerAccessLevel: UserAccessLevel, for content: AuthorableContentType) -> Bool {
+		switch content {
+		case .announcement:
+			switch self {
+			case .TwitarrTeam:
+				return callerAccessLevel == .twitarrteam || callerAccessLevel == .admin
+			case .THO:
+				return callerAccessLevel == .tho || callerAccessLevel == .admin
+			case .admin:
+				return callerAccessLevel.hasAccess(.twitarrteam)
+			case .moderator:
+				return false
+			}
 		}
 	}
 }

--- a/Sources/swiftarr/Protocols/Authorable.swift
+++ b/Sources/swiftarr/Protocols/Authorable.swift
@@ -1,0 +1,30 @@
+import Vapor
+
+/// Types that may author content as a privileged account via `postAsUser`.
+protocol Authorable {
+	/// Privileged username to author as, or nil/"self"/the caller's own username for the caller.
+	var postAsUser: String? { get }
+
+	/// Resolves the author for this request from `req.auth`, enforcing who may post as whom.
+	func effectiveAuthor(on req: Request) throws -> UserCacheData
+}
+
+extension Authorable {
+	func effectiveAuthor(on req: Request) throws -> UserCacheData {
+		let caller = try req.auth.require(UserCacheData.self)
+		guard let raw = postAsUser?.trimmingCharacters(in: .whitespaces), !raw.isEmpty,
+			raw.caseInsensitiveCompare("self") != .orderedSame,
+			raw.caseInsensitiveCompare(caller.username) != .orderedSame
+		else { return caller }
+		guard let target = PrivilegedUser(fromQueryParam: raw) else {
+			throw Abort(.forbidden, reason: "Cannot post announcements as '\(raw)'.")
+		}
+		guard target.canPostAs(from: caller.accessLevel) else {
+			throw Abort(.forbidden, reason: "Your account cannot post announcements as @\(target.rawValue).")
+		}
+		guard let user = req.userCache.getUser(username: target.rawValue) else {
+			throw Abort(.internalServerError, reason: "Privileged account @\(target.rawValue) is missing.")
+		}
+		return user
+	}
+}

--- a/Sources/swiftarr/Protocols/Authorable.swift
+++ b/Sources/swiftarr/Protocols/Authorable.swift
@@ -1,29 +1,34 @@
 import Vapor
 
-/// Types that may author content as a privileged account via `postAsUser`.
+/// Content-specific authorization rules for the reusable posting-as path.
+enum AuthorableContentType {
+	case announcement
+}
+
+/// Types that may author content as a privileged account via postAsUser.
 protocol Authorable {
 	/// Privileged username to author as, or nil/"self"/the caller's own username for the caller.
 	var postAsUser: String? { get }
 
-	/// Resolves the author for this request from `req.auth`, enforcing who may post as whom.
-	func effectiveAuthor(on req: Request) throws -> UserCacheData
+	/// Resolves the author for this request, enforcing the rules for the content type.
+	func effectiveAuthor(on req: Request, for content: AuthorableContentType) throws -> UserCacheData
 }
 
 extension Authorable {
-	func effectiveAuthor(on req: Request) throws -> UserCacheData {
+	func effectiveAuthor(on req: Request, for content: AuthorableContentType) throws -> UserCacheData {
 		let caller = try req.auth.require(UserCacheData.self)
 		guard let raw = postAsUser?.trimmingCharacters(in: .whitespaces), !raw.isEmpty,
 			raw.caseInsensitiveCompare("self") != .orderedSame,
 			raw.caseInsensitiveCompare(caller.username) != .orderedSame
 		else { return caller }
 		guard let target = PrivilegedUser(fromQueryParam: raw) else {
-			throw Abort(.forbidden, reason: "Cannot post announcements as '\(raw)'.")
+			throw Abort(.forbidden, reason: "Cannot post as '" + raw + "'.")
 		}
-		guard target.canPostAs(from: caller.accessLevel) else {
-			throw Abort(.forbidden, reason: "Your account cannot post announcements as @\(target.rawValue).")
+		guard target.canPostAs(from: caller.accessLevel, for: content) else {
+			throw Abort(.forbidden, reason: "Your account cannot post as @" + target.rawValue + ".")
 		}
 		guard let user = req.userCache.getUser(username: target.rawValue) else {
-			throw Abort(.internalServerError, reason: "Privileged account @\(target.rawValue) is missing.")
+			throw Abort(.internalServerError, reason: "Cannot post as @" + target.rawValue + ".")
 		}
 		return user
 	}

--- a/Sources/swiftarr/Resources/Views/admin/announcementEdit.html
+++ b/Sources/swiftarr/Resources/Views/admin/announcementEdit.html
@@ -39,6 +39,7 @@
 									Display Until: <input type="datetime-local" name="displayUntil" #if(post.displayUntil != ""):value="#localTime(post.displayUntil)"#endif>
 								</div>
 							</div>
+							#if(showPostAsRadios):
 							<div class="row justify-content-end mt-2">
 								<div class="col col-auto form-check">
 									<input class="form-check-input" type="radio" name="postAsUser" value="self" id="postAsSelfRadio"#if(post.postAsUser == "self"): checked#endif>
@@ -61,6 +62,7 @@
 									<label class="form-check-label small" for="postAsAdminRadio">Post as @admin</label>
 								</div>
 							</div>
+							#endif
 							<div class="alert alert-danger mt-3 d-none" role="alert">
 							</div>		
 							<div class="row mb-2">

--- a/Sources/swiftarr/Resources/Views/admin/announcementEdit.html
+++ b/Sources/swiftarr/Resources/Views/admin/announcementEdit.html
@@ -39,19 +39,26 @@
 									Display Until: <input type="datetime-local" name="displayUntil" #if(post.displayUntil != ""):value="#localTime(post.displayUntil)"#endif>
 								</div>
 							</div>
-							<div class="row mb-2">
-								<div class="col col-auto">
-									<label for="postAsUser" class="form-label">Post as</label>
-									<select class="form-select" name="postAsUser" id="postAsUser">
-										<option value="self" selected>Self</option>
-										#if(!trunk.userIsTHO || trunk.userIsAdmin):
-											<option value="TwitarrTeam">@TwitarrTeam</option>
-										#endif
-										#if(trunk.userIsTHO):
-											<option value="THO">@THO</option>
-										#endif
-										<option value="admin">@admin</option>
-									</select>
+							<div class="row justify-content-end mt-2">
+								<div class="col col-auto form-check">
+									<input class="form-check-input" type="radio" name="postAsUser" value="self" id="postAsSelfRadio" checked>
+									<label class="form-check-label small" for="postAsSelfRadio">Post as @#(trunk.username)</label>
+								</div>
+								#if(!trunk.userIsTHO || trunk.userIsAdmin):
+								<div class="col col-auto form-check">
+									<input class="form-check-input" type="radio" name="postAsUser" value="TwitarrTeam" id="postAsTwitarrTeamRadio">
+									<label class="form-check-label small" for="postAsTwitarrTeamRadio">Post as @TwitarrTeam</label>
+								</div>
+								#endif
+								#if(trunk.userIsTHO):
+								<div class="col col-auto form-check">
+									<input class="form-check-input" type="radio" name="postAsUser" value="THO" id="postAsTHORadio">
+									<label class="form-check-label small" for="postAsTHORadio">Post as @THO</label>
+								</div>
+								#endif
+								<div class="col col-auto form-check">
+									<input class="form-check-input" type="radio" name="postAsUser" value="admin" id="postAsAdminRadio">
+									<label class="form-check-label small" for="postAsAdminRadio">Post as @admin</label>
 								</div>
 							</div>
 							<div class="alert alert-danger mt-3 d-none" role="alert">

--- a/Sources/swiftarr/Resources/Views/admin/announcementEdit.html
+++ b/Sources/swiftarr/Resources/Views/admin/announcementEdit.html
@@ -39,6 +39,21 @@
 									Display Until: <input type="datetime-local" name="displayUntil" #if(post.displayUntil != ""):value="#localTime(post.displayUntil)"#endif>
 								</div>
 							</div>
+							<div class="row mb-2">
+								<div class="col col-auto">
+									<label for="postAsUser" class="form-label">Post as</label>
+									<select class="form-select" name="postAsUser" id="postAsUser">
+										<option value="self" selected>Self</option>
+										#if(!trunk.userIsTHO || trunk.userIsAdmin):
+											<option value="TwitarrTeam">@TwitarrTeam</option>
+										#endif
+										#if(trunk.userIsTHO):
+											<option value="THO">@THO</option>
+										#endif
+										<option value="admin">@admin</option>
+									</select>
+								</div>
+							</div>
 							<div class="alert alert-danger mt-3 d-none" role="alert">
 							</div>		
 							<div class="row mb-2">

--- a/Sources/swiftarr/Resources/Views/admin/announcementEdit.html
+++ b/Sources/swiftarr/Resources/Views/admin/announcementEdit.html
@@ -41,23 +41,23 @@
 							</div>
 							<div class="row justify-content-end mt-2">
 								<div class="col col-auto form-check">
-									<input class="form-check-input" type="radio" name="postAsUser" value="self" id="postAsSelfRadio" checked>
+									<input class="form-check-input" type="radio" name="postAsUser" value="self" id="postAsSelfRadio"#if(post.postAsUser == "self"): checked#endif>
 									<label class="form-check-label small" for="postAsSelfRadio">Post as @#(trunk.username)</label>
 								</div>
 								#if(!trunk.userIsTHO || trunk.userIsAdmin):
 								<div class="col col-auto form-check">
-									<input class="form-check-input" type="radio" name="postAsUser" value="TwitarrTeam" id="postAsTwitarrTeamRadio">
+									<input class="form-check-input" type="radio" name="postAsUser" value="TwitarrTeam" id="postAsTwitarrTeamRadio"#if(post.postAsUser == "TwitarrTeam"): checked#endif>
 									<label class="form-check-label small" for="postAsTwitarrTeamRadio">Post as @TwitarrTeam</label>
 								</div>
 								#endif
 								#if(trunk.userIsTHO):
 								<div class="col col-auto form-check">
-									<input class="form-check-input" type="radio" name="postAsUser" value="THO" id="postAsTHORadio">
+									<input class="form-check-input" type="radio" name="postAsUser" value="THO" id="postAsTHORadio"#if(post.postAsUser == "THO"): checked#endif>
 									<label class="form-check-label small" for="postAsTHORadio">Post as @THO</label>
 								</div>
 								#endif
 								<div class="col col-auto form-check">
-									<input class="form-check-input" type="radio" name="postAsUser" value="admin" id="postAsAdminRadio">
+									<input class="form-check-input" type="radio" name="postAsUser" value="admin" id="postAsAdminRadio"#if(post.postAsUser == "admin"): checked#endif>
 									<label class="form-check-label small" for="postAsAdminRadio">Post as @admin</label>
 								</div>
 							</div>

--- a/Sources/swiftarr/Resources/Views/admin/announcementEdit.html
+++ b/Sources/swiftarr/Resources/Views/admin/announcementEdit.html
@@ -57,12 +57,14 @@
 									<label class="form-check-label small" for="postAsTHORadio">Post as @THO</label>
 								</div>
 								#endif
-								<div class="col col-auto form-check">
-									<input class="form-check-input" type="radio" name="postAsUser" value="admin" id="postAsAdminRadio"#if(post.postAsUser == "admin"): checked#endif>
-									<label class="form-check-label small" for="postAsAdminRadio">Post as @admin</label>
-								</div>
+							#if(showAdminPostAsRadio):
+							<div class="col col-auto form-check">
+								<input class="form-check-input" type="radio" name="postAsUser" value="admin" id="postAsAdminRadio"#if(post.postAsUser == "admin"): checked#endif>
+								<label class="form-check-label small" for="postAsAdminRadio">Post as @admin</label>
 							</div>
 							#endif
+						</div>
+						#endif
 							<div class="alert alert-danger mt-3 d-none" role="alert">
 							</div>		
 							<div class="row mb-2">

--- a/Sources/swiftarr/Site/SiteAdminController.swift
+++ b/Sources/swiftarr/Site/SiteAdminController.swift
@@ -208,10 +208,15 @@ struct SiteAdminController: SiteControllerUtils {
 		struct AnnouncementEditContext: Encodable {
 			var trunk: TrunkContext
 			var post: MessagePostContext
+			var showPostAsRadios: Bool
 
 			init(_ req: Request) throws {
 				trunk = .init(req, title: "Create Announcement", tab: .admin)
 				self.post = .init(forType: .announcement)
+				showPostAsRadios = post.showsPostAsRadios(
+					userIsTHO: trunk.userIsTHO,
+					userIsAdmin: trunk.userIsAdmin
+				)
 			}
 		}
 		let ctx = try AnnouncementEditContext(req)
@@ -253,10 +258,15 @@ struct SiteAdminController: SiteControllerUtils {
 		struct AnnouncementEditContext: Encodable {
 			var trunk: TrunkContext
 			var post: MessagePostContext
+			var showPostAsRadios: Bool
 
 			init(_ req: Request, data: AnnouncementData) throws {
 				trunk = .init(req, title: "Edit Announcement", tab: .admin)
 				self.post = .init(forType: .announcementEdit(data))
+				showPostAsRadios = post.showsPostAsRadios(
+					userIsTHO: trunk.userIsTHO,
+					userIsAdmin: trunk.userIsAdmin
+				)
 			}
 		}
 		let ctx = try AnnouncementEditContext(req, data: announcementData)

--- a/Sources/swiftarr/Site/SiteAdminController.swift
+++ b/Sources/swiftarr/Site/SiteAdminController.swift
@@ -227,7 +227,11 @@ struct SiteAdminController: SiteControllerUtils {
 		guard let displayUntilDate = dateFromW3DatetimeString(displayUntil) else {
 			throw Abort(.badRequest, reason: "Display Until date is misformatted.")
 		}
-		let postContent = AnnouncementCreateData(text: text, displayUntil: displayUntilDate)
+		let postContent = AnnouncementCreateData(
+			text: text,
+			displayUntil: displayUntilDate,
+			postAsUser: postStruct.postAsUser
+		)
 		try await apiQuery(
 			req,
 			endpoint: "/notification/announcement/create",
@@ -272,7 +276,11 @@ struct SiteAdminController: SiteControllerUtils {
 		guard let displayUntilDate = dateFromW3DatetimeString(displayUntil) else {
 			throw Abort(.badRequest, reason: "Display Until date is misformatted.")
 		}
-		let postContent = AnnouncementCreateData(text: text, displayUntil: displayUntilDate)
+		let postContent = AnnouncementCreateData(
+			text: text,
+			displayUntil: displayUntilDate,
+			postAsUser: postStruct.postAsUser
+		)
 		try await apiQuery(
 			req,
 			endpoint: "/notification/announcement/\(announcementID)/edit",

--- a/Sources/swiftarr/Site/SiteAdminController.swift
+++ b/Sources/swiftarr/Site/SiteAdminController.swift
@@ -209,6 +209,7 @@ struct SiteAdminController: SiteControllerUtils {
 			var trunk: TrunkContext
 			var post: MessagePostContext
 			var showPostAsRadios: Bool
+			var showAdminPostAsRadio: Bool
 
 			init(_ req: Request) throws {
 				trunk = .init(req, title: "Create Announcement", tab: .admin)
@@ -217,6 +218,7 @@ struct SiteAdminController: SiteControllerUtils {
 					userIsTHO: trunk.userIsTHO,
 					userIsAdmin: trunk.userIsAdmin
 				)
+				showAdminPostAsRadio = MessagePostContext.showsAdminPostAsRadio(userIsAdmin: trunk.userIsAdmin)
 			}
 		}
 		let ctx = try AnnouncementEditContext(req)
@@ -259,6 +261,7 @@ struct SiteAdminController: SiteControllerUtils {
 			var trunk: TrunkContext
 			var post: MessagePostContext
 			var showPostAsRadios: Bool
+			var showAdminPostAsRadio: Bool
 
 			init(_ req: Request, data: AnnouncementData) throws {
 				trunk = .init(req, title: "Edit Announcement", tab: .admin)
@@ -267,6 +270,7 @@ struct SiteAdminController: SiteControllerUtils {
 					userIsTHO: trunk.userIsTHO,
 					userIsAdmin: trunk.userIsAdmin
 				)
+				showAdminPostAsRadio = MessagePostContext.showsAdminPostAsRadio(userIsAdmin: trunk.userIsAdmin)
 			}
 		}
 		let ctx = try AnnouncementEditContext(req, data: announcementData)

--- a/Sources/swiftarr/Site/SiteController.swift
+++ b/Sources/swiftarr/Site/SiteController.swift
@@ -356,7 +356,7 @@ struct MessagePostContext: Encodable {
 				postAsUser = privileged.rawValue
 			}
 			else {
-				postAsUser = "self"
+				postAsUser = ""
 			}
 		// For creating a daily theme
 		case .theme:

--- a/Sources/swiftarr/Site/SiteController.swift
+++ b/Sources/swiftarr/Site/SiteController.swift
@@ -381,6 +381,19 @@ struct MessagePostContext: Encodable {
 			messageTextPlaceholder = "Info about Daily Theme"
 		}
 	}
+
+	/// False when the current privileged author has no visible radio for this viewer,
+	/// so the form omits `postAsUser` and the API keeps the existing author.
+	func showsPostAsRadios(userIsTHO: Bool, userIsAdmin: Bool) -> Bool {
+		if !isEdit { return true }
+		if postAsUser == PrivilegedUser.TwitarrTeam.rawValue {
+			return !userIsTHO || userIsAdmin
+		}
+		if postAsUser == PrivilegedUser.THO.rawValue {
+			return userIsTHO
+		}
+		return true
+	}
 }
 
 // POST data structure returned by the form in messagePostForm.leaf

--- a/Sources/swiftarr/Site/SiteController.swift
+++ b/Sources/swiftarr/Site/SiteController.swift
@@ -201,6 +201,8 @@ struct MessagePostContext: Encodable {
 	var showModPostOptions: Bool = false
 	var showCruiseDaySelector: Bool = false
 	var isEdit: Bool = false
+	var postAsUser: String = "self"
+
 
 	// Used as an parameter to the initializer
 	enum InitType {
@@ -337,6 +339,7 @@ struct MessagePostContext: Encodable {
 		case .announcement:
 			formAction = "/admin/announcement/create"
 			postSuccessURL = "/admin/announcements"
+			postAsUser = "self"
 		// For editing an announcement
 		case .announcementEdit(let announcementData):
 			messageText = announcementData.text
@@ -347,6 +350,14 @@ struct MessagePostContext: Encodable {
 			formAction = "/admin/announcement/\(announcementData.id)/edit"
 			postSuccessURL = "/admin/announcements"
 			isEdit = true
+			if let privileged = PrivilegedUser(fromQueryParam: announcementData.author.username),
+				privileged != .moderator
+			{
+				postAsUser = privileged.rawValue
+			}
+			else {
+				postAsUser = "self"
+			}
 		// For creating a daily theme
 		case .theme:
 			formAction = "/admin/dailytheme/create"

--- a/Sources/swiftarr/Site/SiteController.swift
+++ b/Sources/swiftarr/Site/SiteController.swift
@@ -35,6 +35,7 @@ struct TrunkContext: Encodable {
 	var userIsMod: Bool
 	var userIsTwitarrTeam: Bool
 	var userIsTHO: Bool
+	var userIsAdmin: Bool
 	var userCanManageAccounts: Bool
 	var userRoles: [String]  // Use "contains(trunk.userRoles, "shutternautmanager")" or similar to check
 	var minAccessLevel: String?  // Minimum access required to view Twitarr pages; Value from Settings.
@@ -62,6 +63,7 @@ struct TrunkContext: Encodable {
 			userIsMod = userAccessLevel.hasAccess(.moderator)
 			userIsTwitarrTeam = userAccessLevel.hasAccess(.twitarrteam)
 			userIsTHO = userAccessLevel.hasAccess(.tho)
+			userIsAdmin = userAccessLevel.hasAccess(.admin)
 			userCanManageAccounts = user.canManageAccounts
 			username = user.username
 			userID = user.userID
@@ -72,6 +74,7 @@ struct TrunkContext: Encodable {
 			userIsMod = false
 			userIsTwitarrTeam = false
 			userIsTHO = false
+			userIsAdmin = false
 			userCanManageAccounts = false
 			username = ""
 			userID = UUID()
@@ -394,6 +397,7 @@ struct MessagePostFormContent: Codable {
 	let cruiseDay: Int32?  // Used for Daily Themes
 	let postAsTwitarrTeam: String?
 	let postAsModerator: String?
+	let postAsUser: String?
 }
 
 extension MessagePostFormContent {

--- a/Sources/swiftarr/Site/SiteController.swift
+++ b/Sources/swiftarr/Site/SiteController.swift
@@ -350,14 +350,7 @@ struct MessagePostContext: Encodable {
 			formAction = "/admin/announcement/\(announcementData.id)/edit"
 			postSuccessURL = "/admin/announcements"
 			isEdit = true
-			if let privileged = PrivilegedUser(fromQueryParam: announcementData.author.username),
-				privileged != .moderator
-			{
-				postAsUser = privileged.rawValue
-			}
-			else {
-				postAsUser = ""
-			}
+			postAsUser = ""
 		// For creating a daily theme
 		case .theme:
 			formAction = "/admin/dailytheme/create"
@@ -382,17 +375,14 @@ struct MessagePostContext: Encodable {
 		}
 	}
 
-	/// False when the current privileged author has no visible radio for this viewer,
-	/// so the form omits `postAsUser` and the API keeps the existing author.
+	/// Post-as controls are only available when creating an announcement; edits keep the existing author.
 	func showsPostAsRadios(userIsTHO: Bool, userIsAdmin: Bool) -> Bool {
-		if !isEdit { return true }
-		if postAsUser == PrivilegedUser.TwitarrTeam.rawValue {
-			return !userIsTHO || userIsAdmin
-		}
-		if postAsUser == PrivilegedUser.THO.rawValue {
-			return userIsTHO
-		}
-		return true
+		!isEdit
+	}
+
+	/// The admin account is already the real caller, so showing this option would duplicate the self radio.
+	static func showsAdminPostAsRadio(userIsAdmin: Bool) -> Bool {
+		!userIsAdmin
 	}
 }
 

--- a/Tests/AppTests/AnnouncementPostAsTests.swift
+++ b/Tests/AppTests/AnnouncementPostAsTests.swift
@@ -1,0 +1,343 @@
+import XCTVapor
+
+@testable import swiftarr
+
+// Who may author announcements as whom (issue #589):
+//
+// Caller          | self | TwitarrTeam | THO | admin
+// ----------------+------+-------------+-----+------
+// TwitarrTeam     | yes  | yes         | no  | yes
+// THO             | yes  | no          | yes | yes
+// admin           | yes  | yes         | yes | yes
+//
+// Unknown values (including "moderator") are forbidden. Edit keeps the author when
+// postAsUser is omitted and changes it when postAsUser is given.
+class AnnouncementPostAsTests: XCTestCase, SwiftarrBaseTest {
+
+	private struct Accounts {
+		let ttUsername: String
+		let ttToken: String
+		let thoUsername: String
+		let thoToken: String
+		let adminUsername: String
+		let adminToken: String
+	}
+
+	private func makeUser(_ app: Application, username: String, accessLevel: UserAccessLevel) async throws -> User {
+		let user = User(
+			username: username,
+			password: try Bcrypt.hash("password1"),
+			recoveryKey: try Bcrypt.hash("recovery key"),
+			accessLevel: accessLevel
+		)
+		try await user.save(on: app.db)
+		return user
+	}
+
+	private func makeToken(_ app: Application, for user: User) async throws -> String {
+		let token = try Token.generate(for: user)
+		try await token.save(on: app.db)
+		return token.token
+	}
+
+	private func bearer(_ token: String) -> HTTPHeaders {
+		var headers = HTTPHeaders()
+		headers.bearerAuthorization = BearerAuthorization(token: token)
+		return headers
+	}
+
+	private func makeAccounts(_ app: Application) async throws -> Accounts {
+		let suffix = UUID().uuidString.prefix(8).lowercased()
+		let tt = try await makeUser(app, username: "tt-\(suffix)", accessLevel: .twitarrteam)
+		let tho = try await makeUser(app, username: "tho-\(suffix)", accessLevel: .tho)
+		let admin = try await makeUser(app, username: "adm-\(suffix)", accessLevel: .admin)
+		let ttToken = try await makeToken(app, for: tt)
+		let thoToken = try await makeToken(app, for: tho)
+		let adminToken = try await makeToken(app, for: admin)
+		try await app.asyncBoot()
+		try await app.initializeUserCache(app)
+		return Accounts(
+			ttUsername: tt.username,
+			ttToken: ttToken,
+			thoUsername: tho.username,
+			thoToken: thoToken,
+			adminUsername: admin.username,
+			adminToken: adminToken
+		)
+	}
+
+	private func futureISO() -> String {
+		ISO8601DateFormatter([.withInternetDateTime, .withFractionalSeconds])
+			.string(from: Date().addingTimeInterval(86_400))
+	}
+
+	private func bodyJSON(text: String, postAsUser: String?) -> String {
+		let until = futureISO()
+		if let postAsUser {
+			return #"{"text":"\#(text)","displayUntil":"\#(until)","postAsUser":"\#(postAsUser)"}"#
+		}
+		return #"{"text":"\#(text)","displayUntil":"\#(until)"}"#
+	}
+
+	private func uniqueText(_ label: String) -> String {
+		"589-\(label)-\(UUID().uuidString.prefix(8).lowercased())"
+	}
+
+	@discardableResult
+	private func postCreate(
+		_ app: Application,
+		token: String,
+		text: String,
+		postAsUser: String? = nil
+	) async throws -> HTTPStatus {
+		var status: HTTPStatus = .internalServerError
+		try await app.test(
+			.POST,
+			"/api/v3/notification/announcement/create",
+			headers: bearer(token),
+			beforeRequest: { req async throws in
+				req.headers.contentType = .json
+				req.body = ByteBuffer(string: bodyJSON(text: text, postAsUser: postAsUser))
+			},
+			afterResponse: { res async throws in
+				status = res.status
+			}
+		)
+		return status
+	}
+
+	private func fetchByText(_ app: Application, token: String, text: String) async throws -> AnnouncementData {
+		var match: AnnouncementData?
+		try await app.test(
+			.GET,
+			"/api/v3/notification/announcements?inactives=true",
+			headers: bearer(token),
+			afterResponse: { res async throws in
+				XCTAssertEqual(res.status, .ok)
+				let all = try res.content.decode([AnnouncementData].self)
+				match = all.first { $0.text == text }
+			}
+		)
+		return try XCTUnwrap(match, "expected an announcement with text \(text)")
+	}
+
+	private func postEdit(
+		_ app: Application,
+		token: String,
+		id: Int,
+		text: String,
+		postAsUser: String? = nil
+	) async throws -> (HTTPStatus, AnnouncementData?) {
+		var status: HTTPStatus = .internalServerError
+		var decoded: AnnouncementData?
+		try await app.test(
+			.POST,
+			"/api/v3/notification/announcement/\(id)/edit",
+			headers: bearer(token),
+			beforeRequest: { req async throws in
+				req.headers.contentType = .json
+				req.body = ByteBuffer(string: bodyJSON(text: text, postAsUser: postAsUser))
+			},
+			afterResponse: { res async throws in
+				status = res.status
+				if res.status == .ok {
+					decoded = try res.content.decode(AnnouncementData.self)
+				}
+			}
+		)
+		return (status, decoded)
+	}
+
+	func testTTPostsAsSelf() async throws {
+		try await withApp { app in
+			let accounts = try await makeAccounts(app)
+			let text = uniqueText("tt-self")
+			let status = try await postCreate(app, token: accounts.ttToken, text: text)
+			XCTAssertEqual(status, .created)
+			let announcement = try await fetchByText(app, token: accounts.ttToken, text: text)
+			XCTAssertEqual(announcement.author.username, accounts.ttUsername)
+		}
+	}
+
+	func testTTPostsAsTwitarrTeam() async throws {
+		try await withApp { app in
+			let accounts = try await makeAccounts(app)
+			let text = uniqueText("tt-as-tt")
+			let status = try await postCreate(
+				app,
+				token: accounts.ttToken,
+				text: text,
+				postAsUser: PrivilegedUser.TwitarrTeam.rawValue
+			)
+			XCTAssertEqual(status, .created)
+			let announcement = try await fetchByText(app, token: accounts.ttToken, text: text)
+			XCTAssertEqual(announcement.author.username, PrivilegedUser.TwitarrTeam.rawValue)
+		}
+	}
+
+	func testTTPostsAsAdmin() async throws {
+		try await withApp { app in
+			let accounts = try await makeAccounts(app)
+			let text = uniqueText("tt-as-admin")
+			let status = try await postCreate(
+				app,
+				token: accounts.ttToken,
+				text: text,
+				postAsUser: PrivilegedUser.admin.rawValue
+			)
+			XCTAssertEqual(status, .created)
+			let announcement = try await fetchByText(app, token: accounts.ttToken, text: text)
+			XCTAssertEqual(announcement.author.username, PrivilegedUser.admin.rawValue)
+		}
+	}
+
+	func testTTCannotPostAsTHO() async throws {
+		try await withApp { app in
+			let accounts = try await makeAccounts(app)
+			let status = try await postCreate(
+				app,
+				token: accounts.ttToken,
+				text: uniqueText("tt-as-tho"),
+				postAsUser: PrivilegedUser.THO.rawValue
+			)
+			XCTAssertEqual(status, .forbidden)
+		}
+	}
+
+	func testTHOPostsAsTHO() async throws {
+		try await withApp { app in
+			let accounts = try await makeAccounts(app)
+			let text = uniqueText("tho-as-tho")
+			let status = try await postCreate(
+				app,
+				token: accounts.thoToken,
+				text: text,
+				postAsUser: PrivilegedUser.THO.rawValue
+			)
+			XCTAssertEqual(status, .created)
+			let announcement = try await fetchByText(app, token: accounts.thoToken, text: text)
+			XCTAssertEqual(announcement.author.username, PrivilegedUser.THO.rawValue)
+		}
+	}
+
+	func testTHOPostsAsAdmin() async throws {
+		try await withApp { app in
+			let accounts = try await makeAccounts(app)
+			let text = uniqueText("tho-as-admin")
+			let status = try await postCreate(
+				app,
+				token: accounts.thoToken,
+				text: text,
+				postAsUser: PrivilegedUser.admin.rawValue
+			)
+			XCTAssertEqual(status, .created)
+			let announcement = try await fetchByText(app, token: accounts.thoToken, text: text)
+			XCTAssertEqual(announcement.author.username, PrivilegedUser.admin.rawValue)
+		}
+	}
+
+	func testTHOCannotPostAsTwitarrTeam() async throws {
+		try await withApp { app in
+			let accounts = try await makeAccounts(app)
+			let status = try await postCreate(
+				app,
+				token: accounts.thoToken,
+				text: uniqueText("tho-as-tt"),
+				postAsUser: PrivilegedUser.TwitarrTeam.rawValue
+			)
+			XCTAssertEqual(status, .forbidden)
+		}
+	}
+
+	func testAdminPostsAsTwitarrTeamAndTHO() async throws {
+		try await withApp { app in
+			let accounts = try await makeAccounts(app)
+			let asTT = uniqueText("admin-as-tt")
+			let asTHO = uniqueText("admin-as-tho")
+			let ttStatus = try await postCreate(
+				app,
+				token: accounts.adminToken,
+				text: asTT,
+				postAsUser: PrivilegedUser.TwitarrTeam.rawValue
+			)
+			let thoStatus = try await postCreate(
+				app,
+				token: accounts.adminToken,
+				text: asTHO,
+				postAsUser: PrivilegedUser.THO.rawValue
+			)
+			XCTAssertEqual(ttStatus, .created)
+			XCTAssertEqual(thoStatus, .created)
+			let ttAnnouncement = try await fetchByText(app, token: accounts.adminToken, text: asTT)
+			let thoAnnouncement = try await fetchByText(app, token: accounts.adminToken, text: asTHO)
+			XCTAssertEqual(ttAnnouncement.author.username, PrivilegedUser.TwitarrTeam.rawValue)
+			XCTAssertEqual(thoAnnouncement.author.username, PrivilegedUser.THO.rawValue)
+		}
+	}
+
+	func testUnknownPostAsIsForbidden() async throws {
+		try await withApp { app in
+			let accounts = try await makeAccounts(app)
+			let modStatus = try await postCreate(
+				app,
+				token: accounts.ttToken,
+				text: uniqueText("unknown-mod"),
+				postAsUser: PrivilegedUser.moderator.rawValue
+			)
+			let unknownStatus = try await postCreate(
+				app,
+				token: accounts.ttToken,
+				text: uniqueText("unknown-user"),
+				postAsUser: "someuser"
+			)
+			XCTAssertEqual(modStatus, .forbidden)
+			XCTAssertEqual(unknownStatus, .forbidden)
+		}
+	}
+
+	func testEditKeepsAuthorWhenPostAsAbsent() async throws {
+		try await withApp { app in
+			let accounts = try await makeAccounts(app)
+			let text = uniqueText("edit-keep")
+			let createStatus = try await postCreate(
+				app,
+				token: accounts.ttToken,
+				text: text,
+				postAsUser: PrivilegedUser.TwitarrTeam.rawValue
+			)
+			XCTAssertEqual(createStatus, .created)
+			let created = try await fetchByText(app, token: accounts.ttToken, text: text)
+			XCTAssertEqual(created.author.username, PrivilegedUser.TwitarrTeam.rawValue)
+			let editedText = text + "-edited"
+			let (status, edited) = try await postEdit(
+				app,
+				token: accounts.ttToken,
+				id: created.id,
+				text: editedText
+			)
+			XCTAssertEqual(status, .ok)
+			XCTAssertEqual(try XCTUnwrap(edited).author.username, PrivilegedUser.TwitarrTeam.rawValue)
+		}
+	}
+
+	func testEditChangesAuthorWhenPostAsGiven() async throws {
+		try await withApp { app in
+			let accounts = try await makeAccounts(app)
+			let text = uniqueText("edit-change")
+			let createStatus = try await postCreate(app, token: accounts.ttToken, text: text)
+			XCTAssertEqual(createStatus, .created)
+			let created = try await fetchByText(app, token: accounts.ttToken, text: text)
+			XCTAssertEqual(created.author.username, accounts.ttUsername)
+			let editedText = text + "-edited"
+			let (status, edited) = try await postEdit(
+				app,
+				token: accounts.ttToken,
+				id: created.id,
+				text: editedText,
+				postAsUser: PrivilegedUser.admin.rawValue
+			)
+			XCTAssertEqual(status, .ok)
+			XCTAssertEqual(try XCTUnwrap(edited).author.username, PrivilegedUser.admin.rawValue)
+		}
+	}
+}

--- a/Tests/AppTests/AnnouncementPostAsTests.swift
+++ b/Tests/AppTests/AnnouncementPostAsTests.swift
@@ -10,8 +10,8 @@ import XCTVapor
 // THO             | yes  | no          | yes | yes
 // admin           | yes  | yes         | yes | yes
 //
-// Unknown values (including "moderator") are forbidden. Edit keeps the author when
-// postAsUser is omitted and changes it when postAsUser is given.
+// Unknown values (including "moderator") are forbidden. Editing never changes the
+// existing author, even when a decoded postAsUser value is supplied.
 class AnnouncementPostAsTests: XCTestCase, SwiftarrBaseTest {
 
 	private struct Accounts {
@@ -295,6 +295,28 @@ class AnnouncementPostAsTests: XCTestCase, SwiftarrBaseTest {
 		}
 	}
 
+	func testAnnouncementPostAsAuthorizationMatrix() {
+		let expected: [(UserAccessLevel, PrivilegedUser, Bool)] = [
+			(.twitarrteam, .TwitarrTeam, true),
+			(.twitarrteam, .THO, false),
+			(.twitarrteam, .admin, true),
+			(.tho, .TwitarrTeam, false),
+			(.tho, .THO, true),
+			(.tho, .admin, true),
+			(.admin, .TwitarrTeam, true),
+			(.admin, .THO, true),
+			(.admin, .admin, true),
+		]
+		for (caller, target, allowed) in expected {
+			XCTAssertEqual(
+				target.canPostAs(from: caller, for: .announcement),
+				allowed,
+				"Unexpected announcement authorization for caller \(caller) as \(target)"
+			)
+		}
+		XCTAssertFalse(PrivilegedUser.moderator.canPostAs(from: .admin, for: .announcement))
+	}
+
 	func testEditKeepsAuthorWhenPostAsAbsent() async throws {
 		try await withApp { app in
 			let accounts = try await makeAccounts(app)
@@ -320,7 +342,7 @@ class AnnouncementPostAsTests: XCTestCase, SwiftarrBaseTest {
 		}
 	}
 
-	func testEditChangesAuthorWhenPostAsGiven() async throws {
+	func testEditKeepsAuthorWhenAuthorizedPostAsIsGiven() async throws {
 		try await withApp { app in
 			let accounts = try await makeAccounts(app)
 			let text = uniqueText("edit-change")
@@ -337,7 +359,26 @@ class AnnouncementPostAsTests: XCTestCase, SwiftarrBaseTest {
 				postAsUser: PrivilegedUser.admin.rawValue
 			)
 			XCTAssertEqual(status, .ok)
-			XCTAssertEqual(try XCTUnwrap(edited).author.username, PrivilegedUser.admin.rawValue)
+			XCTAssertEqual(try XCTUnwrap(edited).author.username, accounts.ttUsername)
+		}
+	}
+
+	func testEditRejectsUnauthorizedDecodedPostAs() async throws {
+		try await withApp { app in
+			let accounts = try await makeAccounts(app)
+			let text = uniqueText("edit-unauthorized")
+			let createStatus = try await postCreate(app, token: accounts.ttToken, text: text)
+			XCTAssertEqual(createStatus, .created)
+			let created = try await fetchByText(app, token: accounts.ttToken, text: text)
+			let (status, edited) = try await postEdit(
+				app,
+				token: accounts.ttToken,
+				id: created.id,
+				text: text + "-edited",
+				postAsUser: PrivilegedUser.THO.rawValue
+			)
+			XCTAssertEqual(status, .forbidden)
+			XCTAssertNil(edited)
 		}
 	}
 }

--- a/Tests/AppTests/AnnouncementPostAsTests.swift
+++ b/Tests/AppTests/AnnouncementPostAsTests.swift
@@ -381,4 +381,46 @@ class AnnouncementPostAsTests: XCTestCase, SwiftarrBaseTest {
 			XCTAssertNil(edited)
 		}
 	}
+
+	func testRejectedEditDoesNotRestoreDeletedAnnouncement() async throws {
+		try await withApp { app in
+			let accounts = try await makeAccounts(app)
+			let text = uniqueText("edit-deleted")
+			let createStatus = try await postCreate(app, token: accounts.ttToken, text: text)
+			XCTAssertEqual(createStatus, .created)
+			let created = try await fetchByText(app, token: accounts.ttToken, text: text)
+
+			var deleteStatus: HTTPStatus?
+			try await app.test(
+				.DELETE,
+				"/api/v3/notification/announcement/\(created.id)",
+				headers: bearer(accounts.ttToken),
+				afterResponse: { res async throws in deleteStatus = res.status }
+			)
+			XCTAssertEqual(deleteStatus, .noContent)
+
+			let (status, edited) = try await postEdit(
+				app,
+				token: accounts.ttToken,
+				id: created.id,
+				text: text + "-edited",
+				postAsUser: PrivilegedUser.THO.rawValue
+			)
+			XCTAssertEqual(status, .forbidden)
+			XCTAssertNil(edited)
+
+			var afterRejectedEdit: AnnouncementData?
+			try await app.test(
+				.GET,
+				"/api/v3/notification/announcement/\(created.id)",
+				headers: bearer(accounts.ttToken),
+				afterResponse: { res async throws in
+					XCTAssertEqual(res.status, .ok)
+					afterRejectedEdit = try res.content.decode(AnnouncementData.self)
+				}
+			)
+			XCTAssertTrue(try XCTUnwrap(afterRejectedEdit).isDeleted)
+		}
+	}
+
 }

--- a/Tests/AppTests/MessagePostFormTests.swift
+++ b/Tests/AppTests/MessagePostFormTests.swift
@@ -131,4 +131,25 @@ class MessagePostFormTests: XCTestCase {
 			"self"
 		)
 	}
+
+	func testShowsPostAsRadiosOmitsWhenViewerCannotSeeCurrentAuthor() {
+		let ttEdit = MessagePostContext(
+			forType: .announcementEdit(announcement(authorUsername: PrivilegedUser.TwitarrTeam.rawValue))
+		)
+		XCTAssertFalse(ttEdit.showsPostAsRadios(userIsTHO: true, userIsAdmin: false))
+		XCTAssertTrue(ttEdit.showsPostAsRadios(userIsTHO: true, userIsAdmin: true))
+		XCTAssertTrue(ttEdit.showsPostAsRadios(userIsTHO: false, userIsAdmin: false))
+
+		let thoEdit = MessagePostContext(
+			forType: .announcementEdit(announcement(authorUsername: PrivilegedUser.THO.rawValue))
+		)
+		XCTAssertFalse(thoEdit.showsPostAsRadios(userIsTHO: false, userIsAdmin: false))
+		XCTAssertTrue(thoEdit.showsPostAsRadios(userIsTHO: true, userIsAdmin: false))
+	}
+
+	func testShowsPostAsRadiosOnCreate() {
+		XCTAssertTrue(
+			MessagePostContext(forType: .announcement).showsPostAsRadios(userIsTHO: true, userIsAdmin: false)
+		)
+	}
 }

--- a/Tests/AppTests/MessagePostFormTests.swift
+++ b/Tests/AppTests/MessagePostFormTests.swift
@@ -81,4 +81,54 @@ class MessagePostFormTests: XCTestCase {
 		]).buildPostContentData()
 		XCTAssertTrue(content.images.isEmpty, "got \(content.images)")
 	}
+
+	private func header(username: String) -> UserHeader {
+		UserHeader(
+			userID: UUID(),
+			username: username,
+			displayName: nil,
+			userImage: nil,
+			preferredPronoun: nil
+		)
+	}
+
+	private func announcement(authorUsername: String) -> AnnouncementData {
+		AnnouncementData(
+			id: 1,
+			author: header(username: authorUsername),
+			text: "body",
+			updatedAt: Date(),
+			displayUntil: Date().addingTimeInterval(86_400),
+			isDeleted: false
+		)
+	}
+
+	func testCreateAnnouncementPostAsUserIsSelf() {
+		XCTAssertEqual(MessagePostContext(forType: .announcement).postAsUser, "self")
+	}
+
+	func testEditAnnouncementPostAsUserMatchesPrivilegedAuthor() {
+		XCTAssertEqual(
+			MessagePostContext(forType: .announcementEdit(announcement(authorUsername: PrivilegedUser.TwitarrTeam.rawValue)))
+				.postAsUser,
+			PrivilegedUser.TwitarrTeam.rawValue
+		)
+		XCTAssertEqual(
+			MessagePostContext(forType: .announcementEdit(announcement(authorUsername: PrivilegedUser.THO.rawValue)))
+				.postAsUser,
+			PrivilegedUser.THO.rawValue
+		)
+		XCTAssertEqual(
+			MessagePostContext(forType: .announcementEdit(announcement(authorUsername: PrivilegedUser.admin.rawValue)))
+				.postAsUser,
+			PrivilegedUser.admin.rawValue
+		)
+	}
+
+	func testEditAnnouncementPostAsUserIsSelfForNormalAuthor() {
+		XCTAssertEqual(
+			MessagePostContext(forType: .announcementEdit(announcement(authorUsername: "someuser"))).postAsUser,
+			"self"
+		)
+	}
 }

--- a/Tests/AppTests/MessagePostFormTests.swift
+++ b/Tests/AppTests/MessagePostFormTests.swift
@@ -125,10 +125,10 @@ class MessagePostFormTests: XCTestCase {
 		)
 	}
 
-	func testEditAnnouncementPostAsUserIsSelfForNormalAuthor() {
+	func testEditAnnouncementPostAsUserIsUnselectedForNormalAuthor() {
 		XCTAssertEqual(
 			MessagePostContext(forType: .announcementEdit(announcement(authorUsername: "someuser"))).postAsUser,
-			"self"
+			""
 		)
 	}
 

--- a/Tests/AppTests/MessagePostFormTests.swift
+++ b/Tests/AppTests/MessagePostFormTests.swift
@@ -107,49 +107,51 @@ class MessagePostFormTests: XCTestCase {
 		XCTAssertEqual(MessagePostContext(forType: .announcement).postAsUser, "self")
 	}
 
-	func testEditAnnouncementPostAsUserMatchesPrivilegedAuthor() {
+	func testEditAnnouncementPostAsUserIsAlwaysUnselected() {
 		XCTAssertEqual(
 			MessagePostContext(forType: .announcementEdit(announcement(authorUsername: PrivilegedUser.TwitarrTeam.rawValue)))
 				.postAsUser,
-			PrivilegedUser.TwitarrTeam.rawValue
+			""
 		)
 		XCTAssertEqual(
 			MessagePostContext(forType: .announcementEdit(announcement(authorUsername: PrivilegedUser.THO.rawValue)))
 				.postAsUser,
-			PrivilegedUser.THO.rawValue
+			""
 		)
 		XCTAssertEqual(
 			MessagePostContext(forType: .announcementEdit(announcement(authorUsername: PrivilegedUser.admin.rawValue)))
 				.postAsUser,
-			PrivilegedUser.admin.rawValue
+			""
 		)
-	}
-
-	func testEditAnnouncementPostAsUserIsUnselectedForNormalAuthor() {
 		XCTAssertEqual(
 			MessagePostContext(forType: .announcementEdit(announcement(authorUsername: "someuser"))).postAsUser,
 			""
 		)
 	}
 
-	func testShowsPostAsRadiosOmitsWhenViewerCannotSeeCurrentAuthor() {
+	func testEditAnnouncementOmitsPostAsRadios() {
 		let ttEdit = MessagePostContext(
 			forType: .announcementEdit(announcement(authorUsername: PrivilegedUser.TwitarrTeam.rawValue))
 		)
 		XCTAssertFalse(ttEdit.showsPostAsRadios(userIsTHO: true, userIsAdmin: false))
-		XCTAssertTrue(ttEdit.showsPostAsRadios(userIsTHO: true, userIsAdmin: true))
-		XCTAssertTrue(ttEdit.showsPostAsRadios(userIsTHO: false, userIsAdmin: false))
+		XCTAssertFalse(ttEdit.showsPostAsRadios(userIsTHO: true, userIsAdmin: true))
+		XCTAssertFalse(ttEdit.showsPostAsRadios(userIsTHO: false, userIsAdmin: false))
 
 		let thoEdit = MessagePostContext(
 			forType: .announcementEdit(announcement(authorUsername: PrivilegedUser.THO.rawValue))
 		)
 		XCTAssertFalse(thoEdit.showsPostAsRadios(userIsTHO: false, userIsAdmin: false))
-		XCTAssertTrue(thoEdit.showsPostAsRadios(userIsTHO: true, userIsAdmin: false))
+		XCTAssertFalse(thoEdit.showsPostAsRadios(userIsTHO: true, userIsAdmin: false))
 	}
 
 	func testShowsPostAsRadiosOnCreate() {
 		XCTAssertTrue(
 			MessagePostContext(forType: .announcement).showsPostAsRadios(userIsTHO: true, userIsAdmin: false)
 		)
+	}
+
+	func testPostAsAdminRadioIsHiddenForTheAdminUser() {
+		XCTAssertFalse(MessagePostContext.showsAdminPostAsRadio(userIsAdmin: true))
+		XCTAssertTrue(MessagePostContext.showsAdminPostAsRadio(userIsAdmin: false))
 	}
 }

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -251,5 +251,8 @@ additive; the existing count fields are unchanged and are now derived from these
 * New endpoint `POST /api/v3/auth/username` returns a `UserHeader` given a registration code plus password or recovery key (`UserUsernameLookupData`).
 * `GET /api/v3/users/match/allnames/:search_string` now accepts `?sort=favorites`, which sorts users the requester has favorited first.
 
+## Sep 02, 2026
+* `AnnouncementCreateData` gains optional `postAsUser`. TwitarrTeam callers may author as self, TwitarrTeam, or admin; THO as self, THO, or admin; admin as any of those. Unknown values (including `moderator`) return 403. Checked server-side on create and edit.
+
 ## Sep 06, 2026
 * New moderator endpoint `GET /api/v3/mod/privateevent/:eventID`, returning the same `PersonalEventModerationData` as the existing `GET /api/v3/mod/personalevent/:eventID` (which still works, unchanged).

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -252,7 +252,7 @@ additive; the existing count fields are unchanged and are now derived from these
 * `GET /api/v3/users/match/allnames/:search_string` now accepts `?sort=favorites`, which sorts users the requester has favorited first.
 
 ## Sep 02, 2026
-* `AnnouncementCreateData` gains optional `postAsUser`. TwitarrTeam callers may author as self, TwitarrTeam, or admin; THO as self, THO, or admin; admin as any of those. Unknown values (including `moderator`) return 403. Checked server-side on create and edit.
+* `AnnouncementCreateData` gains optional `postAsUser`. TwitarrTeam callers may author as self, TwitarrTeam, or admin; THO as self, THO, or admin; admin as any of those. Unknown values (including `moderator`) return 403. Create applies the selected author; edit validates decoded values but preserves the existing author.
 
 ## Sep 06, 2026
 * New moderator endpoint `GET /api/v3/mod/privateevent/:eventID`, returning the same `PersonalEventModerationData` as the existing `GET /api/v3/mod/personalevent/:eventID` (which still works, unchanged).


### PR DESCRIPTION
Fixes #589

Adds optional `postAsUser` on `AnnouncementCreateData` so TwitarrTeam / THO / admin can author announcements as the privileged accounts the issue listed. Resolution lives on `Authorable.effectiveAuthor(on:)` and `PrivilegedUser`. The check is on the decoded value, not the route.

## Who may post as whom

| Caller | self | TwitarrTeam | THO | admin |
| --- | --- | --- | --- | --- |
| TwitarrTeam | yes | yes | no | yes |
| THO | yes | no | yes | yes |
| admin | yes | yes | yes | yes |

Unknown values (including `moderator`) return 403. Edit keeps the author when `postAsUser` is omitted and changes it when `postAsUser` is given.

## Site form

The announcement create/edit page uses Post as radio buttons (same pattern as #591): Self (default on create), `@TwitarrTeam` for TT and admin, `@THO` for THO and admin, `@admin` for anyone who can reach the page. On edit, the radio matching the existing privileged author is selected so a text-only save does not rewrite the author to the editor.

## Tests

`AnnouncementPostAsTests`: TT/THO/admin matrix, unknown `postAsUser` forbidden, edit keeps/changes author.
`MessagePostFormTests`: create defaults `postAsUser` to self; edit maps TwitarrTeam/THO/admin authors onto the matching radio value.

## Validation

- `swift test --filter MessagePostFormTests` — 7 passed, 0 failed