### PR TITLE
fix moderator visibility and labeling for fezzes

### DIFF
--- a/Sources/swiftarr/Controllers/ModerationController.swift
+++ b/Sources/swiftarr/Controllers/ModerationController.swift
@@ -461,7 +461,7 @@ struct ModerationController: APIRouteCollection {
 			.sort(\.$createdAt, .descending).all()
 		let edits = try await lfg.$edits.query(on: req.db).sort(\.$createdAt, .ascending).all()
 		let ownerHeader = try req.userCache.getHeader(lfg.$owner.id)
-		let fezData = try FezData(fez: lfg, owner: ownerHeader)
+		let fezData = try FezData(fez: lfg, owner: ownerHeader, overrideQuarantine: true)
 		let editData: [FezEditLogData] = try edits.map {
 			return try FezEditLogData($0, on: req)
 		}

--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -730,17 +730,19 @@ public struct FezData: Content, ResponseEncodable {
 }
 
 extension FezData {
-	init(fez: FriendlyFez, owner: UserHeader) throws {
+	init(fez: FriendlyFez, owner: UserHeader, overrideQuarantine: Bool = false) throws {
 		self.fezID = try fez.requireID()
 		self.owner = owner
 		self.fezType = fez.fezType
-		self.title = fez.moderationStatus.showsContent() ? fez.title : "Fez Title is under moderator review"
-		self.info = fez.moderationStatus.showsContent() ? fez.info : "Fez Information field is under moderator review"
+		let showContent = fez.moderationStatus.showsContent() || overrideQuarantine
+		let underReviewText = "\(fez.fezType.lfgLabel) is under moderator review"
+		self.title = showContent ? fez.title : underReviewText
+		self.info = showContent ? fez.info : underReviewText
 		self.startTime = fez.startTime == nil ? nil : Settings.shared.timeZoneChanges.portTimeToDisplayTime(fez.startTime)
 		self.endTime = fez.endTime == nil ? nil : Settings.shared.timeZoneChanges.portTimeToDisplayTime(fez.endTime)
 		self.timeZone = self.startTime == nil ? nil : Settings.shared.timeZoneChanges.abbrevAtTime(self.startTime)
 		self.timeZoneID = self.startTime == nil ? nil : Settings.shared.timeZoneChanges.tzAtTime(self.startTime).identifier
-		self.location = fez.moderationStatus.showsContent() ? fez.location : "Fez Location field is under moderator review"
+		self.location = showContent ? fez.location : underReviewText
 		self.lastModificationTime = fez.updatedAt ?? Date()
 		self.participantCount = fez.participantArray.count
 		self.minParticipants = fez.minCapacity

--- a/Sources/swiftarr/Controllers/Structs/ModeratorControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ModeratorControllerStructs.swift
@@ -46,6 +46,7 @@ extension FezEditLogData {
 ///
 /// See `ModerationController.fezModerationHandler(_:)`
 public struct FezModerationData: Content {
+	/// The fez in question, with quarantine masking overridden so moderators see the real text.
 	var fez: FezData
 	var isDeleted: Bool
 	var moderationStatus: ContentModerationStatus

--- a/Sources/swiftarr/Enumerations/ReportType.swift
+++ b/Sources/swiftarr/Enumerations/ReportType.swift
@@ -25,6 +25,25 @@ enum ReportType: String, Codable {
 	case personalEvent
 	/// a `QuartermasterItem`
 	case quartermasterItem
+
+	/// A consumer-friendly label for this report type, for use in UI contexts (e.g. the moderator reports page).
+	/// `.fez` and `.fezPost` cover LFGs, Seamails, and Private Events (they're all backed by `FriendlyFez`), so
+	/// the label can't be more specific without also knowing the underlying `FezType`.
+	var label: String {
+		switch self {
+		case .forum: return "Forum"
+		case .forumPost: return "Forum Post"
+		case .twarrt: return "Twarrt"
+		case .userProfile: return "User Profile"
+		case .fez: return "LFG/Private Event"
+		case .fezPost: return "LFG/Seamail/Private Event Post"
+		case .mkSong: return "Microkaraoke Song"
+		case .mkSongSnippet: return "Microkaraoke Snippet"
+		case .streamPhoto: return "Photostream Photo"
+		case .personalEvent: return "Personal Event"
+		case .quartermasterItem: return "Quartermaster Item"
+		}
+	}
 }
 
 /// Moderation status of a piece of reportable content.

--- a/Sources/swiftarr/Resources/Views/moderation/fezView.html
+++ b/Sources/swiftarr/Resources/Views/moderation/fezView.html
@@ -3,11 +3,11 @@
     	<div class="container-md ms-0 mt-2">
     		<div class="row align-items-end">
     			<div class="col col-auto">
-			    	<h6><b>Moderate Fez \##(modData.fez.fezID)</br>Titled: #(modData.fez.title)</b></h6>
+			    	<h6><b>Moderate #(typeLabel) \##(modData.fez.fezID)</br>Titled: #(modData.fez.title)</b></h6>
 				</div>
 			</div>
 			<div class="row justify-content-between mb-3">
-				<div class="col" data-reportabletype="fez" data-reportableid="#(modData.fez.fezID)" data-postid="#(modData.fez.fezID)">
+				<div class="col" data-reportabletype="lfg" data-reportableid="#(modData.fez.fezID)" data-postid="#(modData.fez.fezID)">
 					#if(!modData.isDeleted):
 						<a class="btn btn-outline-primary btn-sm" href="/lfg/#(modData.fez.fezID)/edit">Edit</a>
 						<button type="button" class="btn btn-outline-primary btn-sm" data-bs-toggle="modal" data-bs-target="\#deleteFezModal">Delete</button>
@@ -36,7 +36,7 @@
 			</div>
     		<div class="row mt-2">
     			#if(modData.isDeleted):
-					<h6><b>Fez has been Deleted.<br>Prior to delete, it looked like this:</b></h6>
+					<h6><b>#(typeLabel) has been Deleted.<br>Prior to delete, it looked like this:</b></h6>
     			#else:
 					<h6><b>As it currently exists:</b></h6>
 				#endif
@@ -78,7 +78,7 @@
 			#if(count(modData.edits) == 0):
 				<div class="row mb-3">
 					<div class="col">
-						<h6><b>No previous edits to this fez.</b></h6>
+						<h6><b>No previous edits to this #(typeLabel).</b></h6>
 					</div>
 				</div>
 			#else:
@@ -119,10 +119,10 @@
 			#endif
 			
 			#if(count(modData.reports) == 0):
-				<h6><b>No reports on this fez.</b></h6>
-			#else:				
+				<h6><b>No reports on this #(typeLabel).</b></h6>
+			#else:
 				<div class="row mt-3">
-					<h6><b>#count(modData.reports) reports on this fez:</b></h6>
+					<h6><b>#count(modData.reports) reports on this #(typeLabel):</b></h6>
 				</div>
 				<div class="row mb-3">
 					<div class="col">
@@ -146,7 +146,7 @@
 						<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
 					</div>
 					<div class="modal-body">
-						Are you sure you want to delete this fez?
+						Are you sure you want to delete this #(typeLabel)?
 					</div>
 					<div class="modal-footer">
 						<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
@@ -161,7 +161,7 @@
 						</label>
 					</div>
 					<div class="mx-3 pb-1 text-end text-danger error-display d-none" id="fezDialog_errorDisplay">
-						<b>Error attempting to delete fez:</b> <span class="errortext"></span>
+						<b>Error attempting to delete #(typeLabel):</b> <span class="errortext"></span>
 					</div>
 				</div>
 			</div>

--- a/Sources/swiftarr/Resources/Views/moderation/reports.html
+++ b/Sources/swiftarr/Resources/Views/moderation/reports.html
@@ -22,7 +22,7 @@
 					<div class="container-fluid">
 						<div class="row">
 							<div class="col">
-								@#(report.reportedUser.username)'s #(report.reportType)
+								@#(report.reportedUser.username)'s #(report.reportTypeLabel)
 							</div>
 							<div class="col col-auto">
 								<span title="#localTime(report.firstReport.creationTime)">reported #relativeTime(report.firstReport.creationTime)</span>

--- a/Sources/swiftarr/Resources/Views/moderation/userView.html
+++ b/Sources/swiftarr/Resources/Views/moderation/userView.html
@@ -70,7 +70,7 @@
 						<li class="list-group-item has-action-bar" href="#reportGroup.contentURL">
 							<div class="row">
 								<div class="col">
-									@#(reportGroup.firstReport.reportedUser.username)'s #(reportGroup.reportType)
+									@#(reportGroup.firstReport.reportedUser.username)'s #(reportGroup.reportTypeLabel)
 								</div>
 								<div class="col col-auto">
 									<span title="#localTime(reportGroup.firstReport.creationTime)">#relativeTime(reportGroup.firstReport.creationTime)</span>

--- a/Sources/swiftarr/Site/SiteModController.swift
+++ b/Sources/swiftarr/Site/SiteModController.swift
@@ -4,6 +4,7 @@ import Vapor
 // A set of reports that are all reporting on the same piece of content
 struct ReportContentGroup: Codable {
 	var reportType: ReportType
+	var reportTypeLabel: String
 	var reportedID: String
 	var reportedUser: UserHeader
 	var firstReport: ReportModerationData
@@ -536,10 +537,12 @@ struct SiteModController: SiteControllerUtils {
 			var modData: FezModerationData
 			var firstReport: ReportModerationData?
 			var finalEditAuthor: UserHeader?
+			var typeLabel: String
 
 			init(_ req: Request, modData: FezModerationData) throws {
 				trunk = .init(req, title: "LFG Moderation", tab: .moderator)
 				self.modData = modData
+				typeLabel = modData.fez.fezType.lfgLabel
 				firstReport = modData.reports.count > 0 ? modData.reports[0] : nil
 				finalEditAuthor = modData.edits.last?.author
 				if self.modData.edits.count > 1 {
@@ -1038,6 +1041,7 @@ func generateContentGroups(from reports: [ReportModerationData]) -> [ReportConte
 		}
 		var newGroup = ReportContentGroup(
 			reportType: report.type,
+			reportTypeLabel: report.type.label,
 			reportedID: report.reportedID,
 			reportedUser: report.reportedUser,
 			firstReport: report,


### PR DESCRIPTION
1) Mods kept seeing the hidden view in the mod UI.
2) All fezzes were "fez" not LFG/Seamail/Private Event.