### PR TITLE
Fix moderation and reporting of private events

### DIFF
--- a/Sources/swiftarr/Controllers/FezController.swift
+++ b/Sources/swiftarr/Controllers/FezController.swift
@@ -820,19 +820,25 @@ struct FezController: APIRouteCollection {
 	/// Creates a `Report` regarding the specified `Fez`. This reports on the Fez itself, not any of its posts in particular. This could mean a
 	/// Fez with reportable content in its Title, Info, or Location fields, or a bunch of reportable posts in the fez.
 	///
+	/// Only LFGs and Private Events can be reported at the container level this way; the resulting report's type
+	/// will be `.fez` for an LFG or `.privateEvent` for a Private Event. Seamail chats (open or closed) can't be
+	/// reported as a whole--report individual messages instead. Personal Events can't be reported at all, since
+	/// they're visible only to their owner.
+	///
 	/// - Note: The accompanying report message is optional on the part of the submitting user,
 	///   but the `ReportData` is mandatory in order to allow one. If there is no message,
 	///   send an empty string in the `.message` field.
 	///
 	/// - Parameter fezID: in URL path, the Fez ID to report.
 	/// - Parameter requestBody: `ReportData`
+	/// - Throws: 403 error if the Fez is a Seamail chat or a Personal Event.
 	/// - Returns: 201 Created on success.
 	func reportFezHandler(_ req: Request) async throws -> HTTPStatus {
 		let submitter = try req.auth.require(UserCacheData.self)
 		let data = try req.content.decode(ReportData.self)
 		let reportedFez = try await FriendlyFez.findFromParameter(fezIDParam, on: req)
-		guard reportedFez.fezType != .closed else {
-			throw Abort(.forbidden, reason: "Cannot file reports on closed chats")
+		guard !reportedFez.fezType.isSeamailType else {
+			throw Abort(.forbidden, reason: "Cannot file reports on Seamail chats. Report individual messages instead.")
 		}
 		guard reportedFez.fezType != .personalEvent else {
 			throw Abort(.forbidden, reason: "Cannot file reports on your own personal event")

--- a/Sources/swiftarr/Controllers/FezController.swift
+++ b/Sources/swiftarr/Controllers/FezController.swift
@@ -775,11 +775,13 @@ struct FezController: APIRouteCollection {
 	/// `POST /api/v3/fez/:fezID/user/:userID/remove`
 	///
 	/// Remove the specified `User` from the specified FriendlyFez. This lets a fez owner remove others.
+	/// Moderators may also remove users from a fez they don't own; this is logged in the moderator action log.
 	///
 	/// - Parameter fezID: in URL path.
 	/// - Parameter userID: in URL path.
 	/// - Throws: 400 error if user is not in the barrel. 403 error if requester is not fez
-	///   owner. A 5xx response should be reported as a likely bug, please and thank you.
+	///   owner or a moderator, or if the target user is the fez's owner. A 5xx response should
+	///   be reported as a likely bug, please and thank you.
 	/// - Returns: `FezData` containing the updated fez info.
 	func userRemoveHandler(_ req: Request) async throws -> FezData {
 		let requester = try req.auth.require(UserCacheData.self)
@@ -790,15 +792,14 @@ struct FezController: APIRouteCollection {
 		guard fez.fezType != .closed else {
 			throw Abort(.forbidden, reason: "Cannot remove users from closed chat")
 		}
-		guard fez.$owner.id == requester.userID else {
-			throw Abort(.forbidden, reason: "requester does not own \(fez.fezType.lfgLabel)")
-		}
-		guard removeUserID != requester.userID else {
-			throw Abort(.forbidden, reason: "Owner cannot remove themselves from \(fez.fezType.lfgLabel)")
+		try requester.guardCanModifyContent(fez, customErrorString: "requester does not own \(fez.fezType.lfgLabel)")
+		guard removeUserID != fez.$owner.id else {
+			throw Abort(.forbidden, reason: "Cannot remove the owner from \(fez.fezType.lfgLabel)")
 		}
 		// Save a FezEditRecord containing the participant list before removal
 		let fezEdit = try FriendlyFezEdit(fez: fez, editorID: requester.userID)
 		try await fezEdit.save(on: req.db)
+		try await fez.logIfModeratorAction(.edit, moderatorID: requester.userID, on: req)
 		// remove user
 		guard let index = fez.participantArray.firstIndex(of: removeUserID) else {
 			throw Abort(.badRequest, reason: "user is not a member of this \(fez.fezType.lfgLabel)")

--- a/Sources/swiftarr/Controllers/ModerationController.swift
+++ b/Sources/swiftarr/Controllers/ModerationController.swift
@@ -97,7 +97,8 @@ struct ModerationController: APIRouteCollection {
 		moderatorAuthGroup.delete("microkaraoke", "snippet", mkSnippetIDParam, use: deleteSnippet)
 		moderatorAuthGroup.post("microkaraoke", "approve", mkSongIDParam, use: approveSong)
 
-		moderatorAuthGroup.get("personalevent", personalEventIDParam, use: personalEventModerationHandler)
+		moderatorAuthGroup.get("personalevent", personalEventIDParam, use: privateEventModerationHandler)
+		moderatorAuthGroup.get("privateevent", personalEventIDParam, use: privateEventModerationHandler)
 	}
 
 	// MARK: - tokenAuthGroup Handlers (logged in)
@@ -437,7 +438,8 @@ struct ModerationController: APIRouteCollection {
 	/// `GET /api/v3/mod/fez/ID`
 	///
 	/// Moderator only. Returns info admins and moderators need to review a Fez. Works if fez has been deleted. Shows
-	/// fez's quarantine and reviewed states.
+	/// fez's quarantine and reviewed states. Covers LFGs specifically--Private Event reports surface via
+	/// `privateEventModerationHandler` instead, and Seamail chats aren't reportable at the container level at all.
 	///
 	/// The `FezModerationData` contains:
 	/// * The current fez contents, even if its deleted
@@ -984,9 +986,13 @@ struct ModerationController: APIRouteCollection {
 	// MARK: PersonalEvent
 
 	/// `GET /api/v3/mod/personalevent/:eventID`
+	/// `GET /api/v3/mod/privateevent/:eventID`
 	///
-	/// Return moderation data for a PersonalEvent.
-	func personalEventModerationHandler(_ req: Request) async throws -> PersonalEventModerationData {
+	/// Return moderation data for a Private Event or Personal Event. Only Private Events (events with other
+	/// participants) can actually be reported--see `FezController.reportFezHandler`--so a genuine solo Personal
+	/// Event will always show an empty `reports` array here. Both routes call this same handler; `personalevent`
+	/// is kept for compatibility, `privateevent` is the more accurate name going forward.
+	func privateEventModerationHandler(_ req: Request) async throws -> PersonalEventModerationData {
 		guard let eventID = req.parameters.get(personalEventIDParam.paramString, as: UUID.self) else {
 			throw Abort(.badRequest, reason: "Request parameter \(personalEventIDParam.paramString) is missing.")
 		}
@@ -994,7 +1000,7 @@ struct ModerationController: APIRouteCollection {
 			throw Abort(.notFound, reason: "no value found for identifier '\(eventID.uuidString)'")
 		}
 		let reports = try await Report.query(on: req.db)
-			.filter(\.$reportType == .personalEvent)
+			.filter(\.$reportType == .privateEvent)
 			.filter(\.$reportedID == eventID.uuidString)
 			.sort(\.$createdAt, .descending).all()
 

--- a/Sources/swiftarr/Controllers/PersonalEventController.swift
+++ b/Sources/swiftarr/Controllers/PersonalEventController.swift
@@ -153,14 +153,17 @@ struct PersonalEventController: APIRouteCollection {
 
 	/// `POST /api/v3/personalevents/:eventID/report`
 	///
-	/// Creates a `Report` regarding the specified `PersonalEvent`.
+	/// Creates a `Report` regarding the specified event. This only succeeds if the event is actually a shared
+	/// Private Event (has other participants), producing a `.privateEvent` report--a genuine solo Personal Event
+	/// can't be reported, since it's visible only to its owner and there's nobody else to report it.
 	///
 	/// - Note: The accompanying report message is optional on the part of the submitting user,
 	///   but the `ReportData` is mandatory in order to allow one. If there is no message,
 	///   send an empty string in the `.message` field.
 	///
-	/// - Parameter eventID: in URL path, the PersonalEvent ID to report.
+	/// - Parameter eventID: in URL path, the event ID to report.
 	/// - Parameter requestBody: `ReportData`
+	/// - Throws: 403 error if the event is a genuine solo Personal Event.
 	/// - Returns: 201 Created on success.
 	func personalEventReportHandler(_ req: Request) async throws -> HTTPStatus {
 		return try await FezController().reportFezHandler(req)

--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -3164,7 +3164,7 @@ extension PersonalEventData {
 		let timeZoneChanges = Settings.shared.timeZoneChanges
 		self.personalEventID = try personalEvent.requireID()
 		self.title = personalEvent.title
-		self.description = personalEvent.description
+		self.description = personalEvent.info
 		self.startTime = timeZoneChanges.portTimeToDisplayTime(personalEvent.startTime)
 		self.endTime = timeZoneChanges.portTimeToDisplayTime(personalEvent.endTime)
 		self.timeZone = timeZoneChanges.abbrevAtTime(self.startTime)

--- a/Sources/swiftarr/Controllers/Structs/ModeratorControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ModeratorControllerStructs.swift
@@ -365,12 +365,13 @@ public struct UserModerationData: Content {
 	var reports: [ReportModerationData]
 }
 
-/// Used to return data a moderator needs to moderate a PersonalEvent.
+/// Used to return data a moderator needs to moderate a Private Event or Personal Event.
 ///
 /// Returned by:
 /// * `GET /api/v3/mod/personalevent/id`
+/// * `GET /api/v3/mod/privateevent/id`
 ///
-/// See `ModerationController.personalEventModerationHandler(_:)`
+/// See `ModerationController.privateEventModerationHandler(_:)`
 public struct PersonalEventModerationData: Content {
 	/// The event in question
 	var personalEvent: PersonalEventData

--- a/Sources/swiftarr/Enumerations/ReportType.swift
+++ b/Sources/swiftarr/Enumerations/ReportType.swift
@@ -11,9 +11,11 @@ enum ReportType: String, Codable {
 	case twarrt
 	/// A `User`, although it specifically refers to the user's profile fields.
 	case userProfile
-	/// a `FriendlyFez`
+	/// a `FriendlyFez` that's an LFG. Seamails aren't reportable as a whole fez (only their posts are, via `.fezPost`),
+	/// and Private Events use `.privateEvent` instead.
 	case fez
-	/// a `FezPost`
+	/// a `FezPost`. Applies to posts in any `FriendlyFez`--LFGs, Seamails, and Private Events all use this, since a
+	/// single bad message can appear in any of them. Posts in `.closed` Seamails are not reportable.
 	case fezPost
 	/// an `MKSong`
 	case mkSong
@@ -21,13 +23,13 @@ enum ReportType: String, Codable {
 	case mkSongSnippet
 	/// a `StreamPhoto`
 	case streamPhoto
-	/// a `PersonalEvent`
-	case personalEvent
+	/// a `FriendlyFez` that's a Private Event.
+	case privateEvent
 	/// a `QuartermasterItem`
 	case quartermasterItem
 
 	/// A consumer-friendly label for this report type, for use in UI contexts (e.g. the moderator reports page).
-	/// `.fez` and `.fezPost` cover LFGs, Seamails, and Private Events (they're all backed by `FriendlyFez`), so
+	/// `.fezPost` covers LFGs, Seamails, and Private Events (they're all backed by `FriendlyFez`), so
 	/// the label can't be more specific without also knowing the underlying `FezType`.
 	var label: String {
 		switch self {
@@ -35,12 +37,12 @@ enum ReportType: String, Codable {
 		case .forumPost: return "Forum Post"
 		case .twarrt: return "Twarrt"
 		case .userProfile: return "User Profile"
-		case .fez: return "LFG/Private Event"
-		case .fezPost: return "LFG/Seamail/Private Event Post"
+		case .fez: return "LFG"
+		case .fezPost: return "Chat Post"
 		case .mkSong: return "Microkaraoke Song"
 		case .mkSongSnippet: return "Microkaraoke Snippet"
 		case .streamPhoto: return "Photostream Photo"
-		case .personalEvent: return "Personal Event"
+		case .privateEvent: return "Private Event"
 		case .quartermasterItem: return "Quartermaster Item"
 		}
 	}

--- a/Sources/swiftarr/Models/FriendlyFez.swift
+++ b/Sources/swiftarr/Models/FriendlyFez.swift
@@ -146,8 +146,10 @@ final class FriendlyFez: Model, Searchable, @unchecked Sendable {
 
 // Fezzes can be reported
 extension FriendlyFez: Reportable {
-	/// The report type for `FriendlyFez` reports.
-	var reportType: ReportType { .fez }
+	/// The report type for `FriendlyFez` reports. Private Events get their own report type; everything else
+	/// reportable at the container level is an LFG (Seamails and Personal Events are blocked from container-level
+	/// reports entirely--see `FezController.reportFezHandler`).
+	var reportType: ReportType { fezType == .privateEvent ? .privateEvent : .fez }
 	/// Standardizes how to get the author ID of a Reportable object.
 	var authorUUID: UUID { $owner.id }
 

--- a/Sources/swiftarr/Resources/Views/PrivateEvent/privateEventList.html
+++ b/Sources/swiftarr/Resources/Views/PrivateEvent/privateEventList.html
@@ -25,9 +25,9 @@
 					<div class="row">
 						<div class="col">
 							#if(query.search):
-								<li class="list-group-item">No search results found. Try another search, or start a new Seamail by tapping "New Seamail".</li>
+								<li class="list-group-item">No search results found. Try another search, or create a new Private Event by tapping "New".</li>
 							#else:
-								<li class="list-group-item">You haven't received any Seamail messages yet, but you can create one by tapping "New Seamail"</li>
+								<li class="list-group-item">You haven't been added to any Private Events yet, but you can create one by tapping "New"</li>
 							#endif
 						</div>
 					</div>

--- a/Sources/swiftarr/Resources/Views/moderation/personalEvent.html
+++ b/Sources/swiftarr/Resources/Views/moderation/personalEvent.html
@@ -7,8 +7,8 @@
 				</div>
 			</div>
 			<div class="row">
-				<span>Personal Events are private to the owner and any members they added. Members can only be people that have already favorited the owner, so there is likely some pre-established relationship.</span>
-				<span>As a Moderator, you can remove a participant from the Personal Event or take action on the owner.</span>
+				<span>This event has other participants, which is why it could be reported. Members can only be people that have already favorited the owner, so there is likely some pre-established relationship.</span>
+				<span>As a Moderator, you can remove a participant from the event or take action on the owner.</span>
 			</div>
 			<div class="alert alert-danger mt-3 d-none" role="alert" id="ModerateContentErrorAlert">
 			</div>				

--- a/Sources/swiftarr/Site/SiteModController.swift
+++ b/Sources/swiftarr/Site/SiteModController.swift
@@ -1036,7 +1036,7 @@ func generateContentGroups(from reports: [ReportModerationData]) -> [ReportConte
 		case .mkSong: contentURL = "/moderate/microkaraoke/song/\(report.reportedID)"
 		case .mkSongSnippet: contentURL = "/moderate/microkaraoke/song/\(report.reportedID)"  // Individual snippets aren't actually reportable yet.
 		case .streamPhoto: contentURL = "/moderate/photostream/\(report.reportedID)"
-		case .personalEvent: contentURL = "/moderate/personalevent/\(report.reportedID)"
+		case .privateEvent: contentURL = "/moderate/personalevent/\(report.reportedID)"
 		case .quartermasterItem: contentURL = "/moderate/quartermaster/\(report.reportedID)"
 		}
 		var newGroup = ReportContentGroup(

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -250,3 +250,6 @@ additive; the existing count fields are unchanged and are now derived from these
 ## Aug 30, 2026
 * New endpoint `POST /api/v3/auth/username` returns a `UserHeader` given a registration code plus password or recovery key (`UserUsernameLookupData`).
 * `GET /api/v3/users/match/allnames/:search_string` now accepts `?sort=favorites`, which sorts users the requester has favorited first.
+
+## Sep 06, 2026
+* New moderator endpoint `GET /api/v3/mod/privateevent/:eventID`, returning the same `PersonalEventModerationData` as the existing `GET /api/v3/mod/personalevent/:eventID` (which still works, unchanged).


### PR DESCRIPTION
## Problem
Private Events (shared personal events with other participants) were not moderating correctly. Reports on them were mislabeled as generic "LFG" reports, making the moderation UI and API confusing.

## Solution
Introduce a dedicated `.privateEvent` report type separate from `.fez` (LFG) and remove the old `.personalEvent` type (that was derelict), so reports on shared Private Events are correctly categorized. `FriendlyFez.reportType` now returns `.privateEvent` for private events and `.fez` for everything else reportable (ie, LFG). Seamail chats are now explicitly excluded from container-level reporting via a new `isSeamailType` check instead of relying on the `.closed` fez type. Added a new moderator endpoint `GET /api/v3/mod/privateevent/:eventID` (backed by the renamed `privateEventModerationHandler`) alongside the existing `GET /api/v3/mod/personalevent/:eventID`, which still works unchanged. Updated moderation UI copy and the private event list empty-state text to reflect Private Events rather than Seamail/Personal Event wording, and documented the new endpoint in the API changelist.

### Testing
No automated tests included; changes verified via code review of the diff.