### PR TITLE
Allow Fez create to include initial post

### DIFF
--- a/Sources/swiftarr/Controllers/FezController.swift
+++ b/Sources/swiftarr/Controllers/FezController.swift
@@ -62,7 +62,7 @@ struct FezController: APIRouteCollection {
 		tokenAuthGroup.get("joined", use: joinedHandler)
 		tokenAuthGroup.get("owner", use: ownerHandler)
 		tokenAuthGroup.get(fezIDParam, use: fezHandler)
-		tokenAuthGroup.post("create", use: createHandler)
+		tokenAuthGroup.on(.POST, "create", body: .collect(maxSize: ByteCount(value: Settings.shared.imageMaxBodySize)), use: createHandler)
 		tokenAuthGroup.on(.POST, fezIDParam, "post", body: .collect(maxSize: ByteCount(value: Settings.shared.imageMaxBodySize)), use: postAddHandler)
 		tokenAuthGroup.webSocket(fezIDParam, "socket", onUpgrade: createFezSocket)
 		tokenAuthGroup.post(fezIDParam, "cancel", use: cancelHandler)
@@ -473,12 +473,6 @@ struct FezController: APIRouteCollection {
 		guard fez.fezType != .personalEvent else {
 			throw Abort(.badRequest, reason: "Personal Events don't have posts.")
 		}
-		guard ![.closed, .open].contains(fez.fezType) || data.images.count == 0 else {
-			throw Abort(.badRequest, reason: "Private conversations can't contain photos.")
-		}
-		guard data.images.count <= 1 else {
-			throw Abort(.badRequest, reason: "posts may only have one image")
-		}
 		guard fez.participantArray.contains(cacheUser.userID) || cacheUser.accessLevel.hasAccess(.moderator) else {
 			throw Abort(.forbidden, reason: "user is not member of \(fez.fezType.lfgLabel); cannot post")
 		}
@@ -488,6 +482,19 @@ struct FezController: APIRouteCollection {
 		guard fez.moderationStatus != .locked else {
 			// Note: Users should still be able to post in a quarantined LFG so they can figure out what (else) to do.
 			throw Abort(.badRequest, reason: "\(fez.fezType.lfgLabel) is locked; cannot post.")
+		}
+		return try await addFezPost(to: fez, data: data, cacheUser: cacheUser, on: req)
+	}
+
+	// This is the bulk of postAddHandler, pulled out into a separate fn so createChat can use it to create
+	// a Fez's optional initial post using the same rules (image limits, notifications, hidden-post bookkeeping)
+	// as posting to an existing Fez. Callers are responsible for any membership/lock/personalEvent guards.
+	func addFezPost(to fez: FriendlyFez, data: PostContentData, cacheUser: UserCacheData, on req: Request) async throws -> FezPostData {
+		guard ![.closed, .open].contains(fez.fezType) || data.images.count == 0 else {
+			throw Abort(.badRequest, reason: "Private conversations can't contain photos.")
+		}
+		guard data.images.count <= 1 else {
+			throw Abort(.badRequest, reason: "posts may only have one image")
 		}
 		// process image
 		let filenames = try await processImages(data.images, usage: .fezPost, on: req)
@@ -632,6 +639,14 @@ struct FezController: APIRouteCollection {
 	///
 	/// A value of 0 in either the `.minCapacity` or `.maxCapacity` fields indicates an undefined
 	/// limit: "there is no minimum", "there is no maximum".
+	///
+	/// `FezContentData` may optionally include a `firstPost`, which creates the fez's opening post
+	/// in the same call--similar to how `POST /api/v3/forum/categories/ID/create` takes a `firstPost`.
+	/// This is ignored for `.personalEvent` fez types, which don't support posts. The same image-count
+	/// rules that apply to `POST /api/v3/fez/ID/post` apply here (0 images for Seamail types, 1 image
+	/// otherwise). `firstPost`'s own `postAsModerator`/`postAsTwitarrTeam` flags govern the post's
+	/// author independently of this call's `createdByModerator`/`createdByTwitarrTeam` flags; set both
+	/// if the fez owner and post author should match.
 	///
 	/// - Parameter requestBody: `FezContentData` payload in the HTTP body.
 	/// - Throws: 400 error if the supplied data does not validate.
@@ -1167,8 +1182,15 @@ extension FezController {
 		let addedInitialUsers = Set(initialUsers).subtracting([user.userID, creator.userID])
 		// Notify users who were added (does not include the creator)
 		try await notifyAddedToFez(fez, for: Array(addedInitialUsers), by: creator, on: req)
+		var posts: [FezPostData] = []
+		if let firstPost = data.firstPost {
+			guard fez.fezType != .personalEvent else {
+				throw Abort(.badRequest, reason: "Personal Events don't have posts.")
+			}
+			posts = [try await addFezPost(to: fez, data: firstPost, cacheUser: user, on: req)]
+		}
 		let creatorPivot = try await fez.$participants.$pivots.query(on: req.db).filter(\.$user.$id == creator.userID).first()
-		let fezData = try buildFezData(from: fez, with: creatorPivot, posts: [], for: user, on: req)
+		let fezData = try buildFezData(from: fez, with: creatorPivot, posts: posts, for: user, on: req)
 		return fezData
 	}
 	

--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -634,6 +634,8 @@ public struct FezContentData: Content {
 	var createdByModerator: Bool?
 	/// If TRUE, the Fez will be created by user @TwitarrTeam instead of the current user. Current user must be a TT member.
 	var createdByTwitarrTeam: Bool?
+	/// If set, creates the fez's opening post at creation time instead of requiring a separate call.
+	var firstPost: PostContentData?
 }
 
 extension FezContentData {
@@ -649,6 +651,7 @@ extension FezContentData {
 		self.maxCapacity = 0
 		self.createdByModerator = false
 		self.createdByTwitarrTeam = false
+		self.firstPost = nil
 	}
 }
 

--- a/Tests/AppTests/FezAndEventValidationTests.swift
+++ b/Tests/AppTests/FezAndEventValidationTests.swift
@@ -101,6 +101,35 @@ class FezAndEventValidationTests: XCTestCase {
 		XCTAssertEqual(try validationErrors(FezContentData.self, json), [])
 	}
 
+	// MARK: - FezContentData — optional firstPost (nested PostContentData validation)
+
+	private func fezJSONWithFirstPost(firstPostText: String, images: String = "[]") -> String {
+		let base = fezJSON()
+		// Splice a "firstPost" field into the base fixture's object.
+		let firstPostJSON = #""firstPost":{"text":"\#(firstPostText)","images":\#(images)}"#
+		return String(base.dropLast()) + "," + firstPostJSON + "}"
+	}
+
+	func testFez_NoFirstPost_HappyPath() throws {
+		// Regression check: omitting firstPost entirely still validates cleanly.
+		XCTAssertEqual(try validationErrors(FezContentData.self, fezJSON()), [])
+	}
+
+	func testFez_FirstPost_HappyPath() throws {
+		XCTAssertEqual(try validationErrors(FezContentData.self, fezJSONWithFirstPost(firstPostText: "Hello there!")), [])
+	}
+
+	func testFez_FirstPost_EmptyText_PropagatesPostContentDataValidation() throws {
+		let errs = try validationErrors(FezContentData.self, fezJSONWithFirstPost(firstPostText: ""))
+		XCTAssertTrue(errs.contains("post text cannot be empty."), "errs=\(errs)")
+	}
+
+	func testFez_FirstPost_TextTooLong_PropagatesPostContentDataValidation() throws {
+		let text = String(repeating: "a", count: 2048)
+		let errs = try validationErrors(FezContentData.self, fezJSONWithFirstPost(firstPostText: text))
+		XCTAssertTrue(errs.contains("post length of \(text.count) is over the 2048 character limit"), "errs=\(errs)")
+	}
+
 	// MARK: - PersonalEventContentData
 
 	private func eventJSON(

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -296,3 +296,7 @@ additive; the existing count fields are unchanged and are now derived from these
 - New endpoint `GET /api/v3/users/:user_id/vcard` returns a downloadable vCard (`.vcf`) of a user's land-based contact fields. The HTML profile page has a Save vCard button.
 - New endpoint `GET /api/v3/events/photographerreport` returns a paginated photography-coverage report (`Paginated<ShutternautScheduleReportData>`) of events flagged as needing a photographer and/or assigned a Shutternaut.
 - New endpoint `GET /api/v3/events/photographerreport/download` returns the same report as a CSV of all matching rows.
+
+## Sep 08, 2026
+
+- `FezContentData` gains an optional `firstPost` (`PostContentData`), letting `POST /api/v3/fez/create` create the intial post in the same call.


### PR DESCRIPTION
## Problem
Creating a Fez (LFG/Seamail) and adding its first post required two separate API calls, unlike forum threads which let you create the thread and its first post together.

## Solution
`FezContentData` now accepts an optional `firstPost` (`PostContentData`). When provided, `POST /api/v3/fez/create` creates the fez and its opening post in a single call, mirroring `POST /api/v3/forum/categories/ID/create`.

Details:
- Extracted the shared posting logic from `postAddHandler` into `addFezPost(to:data:cacheUser:on:)` so both the initial post and subsequent posts share the same image-count validation, notification, and bookkeeping rules.
- `firstPost` is rejected for `.personalEvent` fez types, which don't support posts.
- `firstPost`'s own `postAsModerator`/`postAsTwitarrTeam` flags independently control the post's author from the fez's `createdByModerator`/`createdByTwitarrTeam` flags.
- Updated the `create` route to collect request bodies up to the image max size, since `firstPost` may include an image.
- Added validation tests covering the happy path, omitted `firstPost`, and propagation of `PostContentData` validation errors (empty text, text too long).
- Updated the API changelist.

Fixes #519