### PR TITLE
Add ability to favorite fezzes (Seamail, LFG, Private Events)

### DIFF
--- a/Sources/swiftarr/Controllers/FezController.swift
+++ b/Sources/swiftarr/Controllers/FezController.swift
@@ -16,6 +16,7 @@ struct FezController: APIRouteCollection {
 		var excludetype: [String] = []
 		var lfgtypes: Bool?
 		var onlynew: Bool?
+		var favorite: Bool?
 		var start: Int?
 		var limit: Int?
 		var cruiseday: Int?
@@ -81,6 +82,9 @@ struct FezController: APIRouteCollection {
 		tokenAuthGroup.post(fezIDParam, "mute", use: muteAddHandler)
 		tokenAuthGroup.delete(fezIDParam, "mute", use: muteRemoveHandler)
 		tokenAuthGroup.post(fezIDParam, "mute", "remove", use: muteRemoveHandler)
+		tokenAuthGroup.post(fezIDParam, "favorite", use: favoriteAddHandler)
+		tokenAuthGroup.delete(fezIDParam, "favorite", use: favoriteRemoveHandler)
+		tokenAuthGroup.post(fezIDParam, "favorite", "remove", use: favoriteRemoveHandler)
 	}
 
 	// MARK: - tokenAuthGroup Handlers (logged in)
@@ -174,6 +178,7 @@ struct FezController: APIRouteCollection {
 	/// - `?type=STRING` - Only return fezzes of the given fezType. See `FezType` for a list.
 	/// - `?excludetype=STRING` - Don't return fezzes of the given type. See `FezType` for a list.
 	/// - `?onlynew=TRUE` - Only return fezzes with unread messages.
+	/// - `?favorite=TRUE` - Only return fezzes the user has favorited.
 	/// - `?start=INT` - The offset to the first result to return in the filtered + sorted array of results.
 	/// - `?limit=INT` - The maximum number of fezzes to return; defaults to 50.
 	/// - `?search=STRING` - Only show fezzes whose title, info, or any post contains the given string.
@@ -211,6 +216,7 @@ struct FezController: APIRouteCollection {
 	/// * `?limit=INT` - The maximum number of fezzes to return; defaults to 50.
 	/// - `?hidepast=BOOLEAN` - Hide fezzes that started more than one hour in the past. For this endpoint, this defaults to FALSE.
 	/// - `?lfgtypes=BOOLEAN` - Shorthand to include/exliude all the LFG types (Activity, Gaming, Dining, etc.) Acts the same as using multiple `type=` or `exludetype=` params.
+	/// - `?favorite=TRUE` - Only return fezzes the user has favorited.
 	///
 	/// - Throws: A 5xx response should be reported as a likely bug, please and thank you.
 	/// - Returns: An array of `FezData` containing all the fezzes created by the user.
@@ -226,6 +232,9 @@ struct FezController: APIRouteCollection {
 		}
 		else if let excludeTypes = try urlQuery.getExcludeTypes() {
 			query.filter(\.$fezType !~ excludeTypes)
+		}
+		if urlQuery.favorite == true {
+			query.filter(FezParticipant.self, \.$isFavorite == true)
 		}
 
 		if let dayFilter = req.query[Int.self, at: "cruiseday"] {
@@ -947,20 +956,10 @@ struct FezController: APIRouteCollection {
 	func muteAddHandler(_ req: Request) async throws -> HTTPStatus {
 		let cacheUser = try req.auth.require(UserCacheData.self)
 		let fez = try await FriendlyFez.findFromParameter(fezIDParam, on: req)
-		let effectiveUser = getEffectiveUser(user: cacheUser, req: req, fez: fez)
 		guard !cacheUser.getBlocks().contains(fez.$owner.id) else {
 			throw Abort(.notFound, reason: "this \(fez.fezType.lfgLabel) is not available")
 		}
-		// Without this check Moderator A could mute a chat for all Moderators which
-		// doesn't feel super good. It's also a confusing UX and would require Help
-		// signage to work around. So we're just going to the option to do that.
-		guard effectiveUser.userID == cacheUser.userID else {
-			throw Abort(.badRequest, reason: "Privileged mailbox chats cannot be muted")
-		}
-		guard let fezParticipant = try await fez.$participants.$pivots.query(on: req.db)
-				.filter(\.$user.$id == effectiveUser.userID).first() else {
-			throw Abort(.forbidden, reason: "user is not a member of this fez")
-		}
+		let fezParticipant = try await getOwnFezParticipant(fez: fez, cacheUser: cacheUser, req: req)
 
 		if fezParticipant.isMuted == true {
 			return .ok
@@ -982,14 +981,10 @@ struct FezController: APIRouteCollection {
 	func muteRemoveHandler(_ req: Request) async throws -> HTTPStatus {
 		let cacheUser = try req.auth.require(UserCacheData.self)
 		let fez = try await FriendlyFez.findFromParameter(fezIDParam, on: req)
-		let effectiveUser = getEffectiveUser(user: cacheUser, req: req, fez: fez)
 		guard !cacheUser.getBlocks().contains(fez.$owner.id) else {
 			throw Abort(.notFound, reason: "this \(fez.fezType.lfgLabel) is not available")
 		}
-		guard let fezParticipant = try await fez.$participants.$pivots.query(on: req.db)
-				.filter(\.$user.$id == effectiveUser.userID).first() else {
-			throw Abort(.forbidden, reason: "user is not a member of this fez")
-		}
+		let fezParticipant = try await getOwnFezParticipant(fez: fez, cacheUser: cacheUser, req: req)
 
 		if fezParticipant.isMuted != true {
 			return .ok
@@ -997,6 +992,58 @@ struct FezController: APIRouteCollection {
 		fezParticipant.isMuted = nil
 		try await fezParticipant.save(on: req.db)
 		_ = try await storeNextJoinedAppointment(userID: cacheUser.userID, on: req)
+		return .noContent
+	}
+
+	/// `POST /api/v3/fez/:fez_ID/favorite`
+	///
+	/// Favorite the specified `Fez` for the current user. Lets the user flag a chat (Seamail, LFG, or
+	/// Private Event) they intend to come back to later; offers a filter criteria similar to `onlynew`.
+	/// Only members of the fez may favorite it. Unjoining a fez implies unfavoriting it, as the favorite
+	/// flag is stored on the per-user membership pivot, which is deleted on unjoin.
+	///
+	/// For privileged mailboxes (the shared `@moderator`/`@TwitarrTeam` seamail), favoriting uses the
+	/// requesting user's own `FezParticipant` pivot, not a pivot shared by the whole team, so favoriting
+	/// a privileged-mailbox chat only affects the user who favorited it.
+	///
+	/// - Parameter fez_ID: In the URL path.
+	/// - Returns: 201 Created on success; 200 OK if already favorited.
+	func favoriteAddHandler(_ req: Request) async throws -> HTTPStatus {
+		let cacheUser = try req.auth.require(UserCacheData.self)
+		let fez = try await FriendlyFez.findFromParameter(fezIDParam, on: req)
+		guard !cacheUser.getBlocks().contains(fez.$owner.id) else {
+			throw Abort(.notFound, reason: "this \(fez.fezType.lfgLabel) is not available")
+		}
+		let fezParticipant = try await getOwnFezParticipant(fez: fez, cacheUser: cacheUser, req: req)
+
+		if fezParticipant.isFavorite {
+			return .ok
+		}
+		fezParticipant.isFavorite = true
+		try await fezParticipant.save(on: req.db)
+		return .created
+	}
+
+	/// `POST /api/v3/fez/:fez_ID/favorite/remove`
+	/// `DELETE /api/v3/fez/:fez_ID/favorite`
+	///
+	/// Unfavorite the specified `Fez` for the current user.
+	///
+	/// - Parameter fez_ID: In the URL path.
+	/// - Returns: 204 No Content on success; 200 OK if already not favorited.
+	func favoriteRemoveHandler(_ req: Request) async throws -> HTTPStatus {
+		let cacheUser = try req.auth.require(UserCacheData.self)
+		let fez = try await FriendlyFez.findFromParameter(fezIDParam, on: req)
+		guard !cacheUser.getBlocks().contains(fez.$owner.id) else {
+			throw Abort(.notFound, reason: "this \(fez.fezType.lfgLabel) is not available")
+		}
+		let fezParticipant = try await getOwnFezParticipant(fez: fez, cacheUser: cacheUser, req: req)
+
+		if !fezParticipant.isFavorite {
+			return .ok
+		}
+		fezParticipant.isFavorite = false
+		try await fezParticipant.save(on: req.db)
 		return .noContent
 	}
 }
@@ -1088,6 +1135,9 @@ extension FezController {
 				)
 				query.filter(FezParticipant.self, \.$addedTo == false)
 			}
+		}
+		if urlQuery.favorite == true {
+			query.filter(FezParticipant.self, \.$isFavorite == true)
 		}
 		if var searchStr = urlQuery.search {
 			searchStr = searchStr.escapedForSQLWildcards()
@@ -1259,7 +1309,8 @@ extension FezController {
 			// appears with unread messages that cannot be cleared.
 			let postCount = fez.postCount - (pivot?.hiddenCount ?? 0)
 			fezData.members = FezData.MembersOnlyData(participants: participants, waitingList: waitingList, postCount: postCount,
-					readCount: pivot?.readCount ?? postCount, posts: posts, isMuted: pivot?.isMuted ?? false)
+					readCount: pivot?.readCount ?? postCount, posts: posts, isMuted: pivot?.isMuted ?? false,
+					isFavorite: pivot?.isFavorite ?? false)
 		} else if fez.fezType.isPrivateEventType {
 			// We need to let non-members see private events they're not currently a member of (so they can report them), but
 			// they should only see a minimum amount of info on the event they're not in.
@@ -1332,6 +1383,32 @@ extension FezController {
 			return result
 		}
 		return try FezParticipant(userID, lfg)
+	}
+
+	/// Resolves the `FezParticipant` pivot to use for per-user chat settings (mute, favorite) actions.
+	/// These settings are always tracked per actual user, even when the fez is a privileged mailbox chat
+	/// (`@moderator`/`@TwitarrTeam` seamail) that multiple real users share access to--each real user gets
+	/// their own pivot for it (see `ensureFezParticipantForUser`), so muting/favoriting a privileged-mailbox
+	/// chat only affects the user who did it. We don't want `getEffectiveUser(user:req:fez:)`'s persona
+	/// substitution here, only its "is this a privileged mailbox chat" signal, to decide whether to
+	/// auto-create the calling user's own pivot if they haven't got one yet.
+	///
+	/// - Parameters:
+	///   - fez: The FriendlyFez being muted/favorited.
+	///   - cacheUser: The actual requesting user (never a moderator/TwitarrTeam persona).
+	///   - req: The Request for database access.
+	/// - Throws: 403 error if the fez isn't a privileged mailbox chat and the user has no existing pivot (isn't a member).
+	/// - Returns: The requesting user's own `FezParticipant` pivot for this fez.
+	func getOwnFezParticipant(fez: FriendlyFez, cacheUser: UserCacheData, req: Request) async throws -> FezParticipant {
+		let effectiveUser = getEffectiveUser(user: cacheUser, req: req, fez: fez)
+		if effectiveUser.userID != cacheUser.userID {
+			return try await ensureFezParticipantForUser(fez: fez, user: cacheUser, on: req, isPrivilegedMailbox: true)
+		}
+		guard let pivot = try await fez.$participants.$pivots.query(on: req.db)
+				.filter(\.$user.$id == cacheUser.userID).first() else {
+			throw Abort(.forbidden, reason: "user is not a member of this fez")
+		}
+		return pivot
 	}
 
 	/// Ensures a FezParticipant exists for the given user and fez, creating and initializing it if needed.

--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -765,6 +765,8 @@ public struct FezData: Content, ResponseEncodable {
 		var posts: [FezPostData]?
 		/// Whether user has muted the fez.
 		var isMuted: Bool
+		/// Whether user has favorited the fez.
+		var isFavorite: Bool
 	}
 
 	/// Will be nil if user is not a member of the fez (in the participant or waiting lists).

--- a/Sources/swiftarr/Pivots/FezParticipant.swift
+++ b/Sources/swiftarr/Pivots/FezParticipant.swift
@@ -21,6 +21,9 @@ final class FezParticipant: Model, @unchecked Sendable {
 	/// Otherwise this field should be NIL or FALSE.
 	@Field(key: "mute") var isMuted: Bool?
 
+	/// True if the user has favorited this Fez. Lets the user flag a chat to come back to later.
+	@Field(key: "favorite") var isFavorite: Bool
+
 	/// True if the user was recently added to this Fez by another user.
 	/// Set to true when an .addedToChat notification is generated, cleared when the user views the fez.
 	/// Otherwise this field should be FALSE.
@@ -52,6 +55,7 @@ final class FezParticipant: Model, @unchecked Sendable {
 		self.readCount = 0
 		self.hiddenCount = 0
 		self.isMuted = nil
+		self.isFavorite = false
 		self.addedTo = false
 	}
 }
@@ -111,6 +115,20 @@ struct AddAddedToFieldToFezParticipantSchema: AsyncMigration {
 	func revert(on database: Database) async throws {
 		try await database.schema("fez+participants")
 			.deleteField("added_to")
+			.update()
+	}
+}
+
+struct AddFavoriteFieldToFezParticipantSchema: AsyncMigration {
+	func prepare(on database: Database) async throws {
+		try await database.schema("fez+participants")
+			.field("favorite", .bool, .required, .sql(.default(false)))
+			.update()
+	}
+
+	func revert(on database: Database) async throws {
+		try await database.schema("fez+participants")
+			.deleteField("favorite")
 			.update()
 	}
 }

--- a/Sources/swiftarr/Resources/Views/Fez/fezListItem.html
+++ b/Sources/swiftarr/Resources/Views/Fez/fezListItem.html
@@ -7,7 +7,7 @@
 	<a href="/seamail/#(fez.fezID)#if(effectiveUser != nil):?foruser=#(effectiveUser)#endif" class="list-group-item list-group-item-action">		
 		<div class="row">
 			<div class="col #if(fez.members && fez.members.isMuted):text-muted#endif">
-				#if(fez.members && fez.members.isMuted):🔇#endif <b>#(fez.title)</b>
+				#if(fez.members && fez.members.isMuted):🔇#elseif(fez.members && fez.members.isFavorite):⭐#endif <b>#(fez.title)</b>
 			</div>
 			<div class="col col-auto">
 				<span title="#localTime(fez.lastModificationTime)" class="text-muted">#relativeTime(fez.lastModificationTime)</span>
@@ -47,7 +47,7 @@
 	<a class="list-group-item list-group-item-action" href="/privateevent/#(fez.fezID)">		
 		<div class="row">
 			<div class="col">
-				#if(fez.cancelled):<span class="text-danger"><b>Cancelled</b></span>#endif <b>#(fez.title)</b>
+				#if(fez.cancelled):<span class="text-danger"><b>Cancelled</b></span>#endif #if(fez.members && fez.members.isFavorite):⭐#endif <b>#(fez.title)</b>
 			</div>
 			<div class="col col-auto">
 				#if(fez.startTime != nil && fez.endTime != nil):
@@ -108,7 +108,7 @@
 	<a class="list-group-item list-group-item-action" href="/lfg/#(fez.fezID)">		
 		<div class="row">
 			<div class="col">
-				#if(fez.cancelled):<span class="text-danger"><b>Cancelled</b></span>#endif <b>#(fez.title)</b>
+				#if(fez.cancelled):<span class="text-danger"><b>Cancelled</b></span>#endif #if(fez.members && fez.members.isFavorite):⭐#endif <b>#(fez.title)</b>
 			</div>
 			<div class="col col-auto">
 				#if(fez.startTime != nil && fez.endTime != nil):

--- a/Sources/swiftarr/Resources/Views/Fez/seamailThread.html
+++ b/Sources/swiftarr/Resources/Views/Fez/seamailThread.html
@@ -24,7 +24,18 @@
 					#if(canEditTitle):
 						<a class="btn btn-outline-primary" href="/seamail/#(fez.fezID)/edit">Edit</a>
 					#endif
-					<input type="checkbox" class="btn-check" autocomplete="off" data-action="muteSeamail" 
+					<input type="checkbox" class="btn-check" autocomplete="off" data-action="favorite"
+								data-actionpath="/seamail/#(fez.fezID)/favorite"
+								data-istoggle="true"
+								data-errordiv="favorite_errorDisplay"
+								id="#(fez.fezID)_favorite"
+							#if(fez.members.isFavorite):checked#endif>
+					<label class="btn btn-outline-primary" for="#(fez.fezID)_favorite">
+						Favorite<span class="laughtext"></span>
+						<span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
+						<span class="visually-hidden">Loading...</span>
+					</label>
+					<input type="checkbox" class="btn-check" autocomplete="off" data-action="muteSeamail"
 								data-actionpath="/seamail/#(fez.fezID)/mute"
 								data-istoggle="true"
 								data-errordiv="mute_errorDisplay"
@@ -38,6 +49,9 @@
 				</div>
 			</div>
 			<div class="row">
+				<div class="col text-end text-danger d-none" id="favorite_errorDisplay">
+					Error favoriting chat: <span class="errortext"></span>
+				</div>
 				<div class="col text-end text-danger d-none" id="mute_errorDisplay">
 					Error muting chat: <span class="errortext"></span>
 			</div>

--- a/Sources/swiftarr/Resources/Views/Fez/seamails.html
+++ b/Sources/swiftarr/Resources/Views/Fez/seamails.html
@@ -8,10 +8,16 @@
 					</div>
 				</div>
     			<div class="col col-auto align-self-end">
-					#if(filterEnable):
-			    	<a class="btn btn-outline-secondary btn-sm #if(filterActive):active#endif" role="button" 
-			    			href="#(filterURL)" autocomplete="off" #if(filterActive):aria-pressed="true"#endif>
+					#if(unreadFilterURL):
+			    	<a class="btn btn-outline-secondary btn-sm #if(unreadFilterActive):active#endif" role="button"
+			    			href="#(unreadFilterURL)" autocomplete="off" #if(unreadFilterActive):aria-pressed="true"#endif>
 			    		Filter: New Msgs
+					</a>
+					#endif
+					#if(favoriteFilterURL):
+			    	<a class="btn btn-outline-secondary btn-sm #if(favoriteFilterActive):active#endif" role="button"
+			    			href="#(favoriteFilterURL)" autocomplete="off" #if(favoriteFilterActive):aria-pressed="true"#endif>
+			    		Filter: Favorites
 					</a>
 					#endif
 			    	<a class="btn btn-primary btn-sm" role="button" href="/seamail/create">New Seamail</a>

--- a/Sources/swiftarr/Resources/Views/Fez/singleFez.html
+++ b/Sources/swiftarr/Resources/Views/Fez/singleFez.html
@@ -62,6 +62,17 @@
 						#if(trunk.userIsMod):
 							<a class="btn btn-outline-primary" href="/moderate/lfg/#(fez.fezID)">Mod</a>
 						#endif
+						<input type="checkbox" class="btn-check" autocomplete="off" data-action="favorite"
+									data-actionpath="/lfg/#(fez.fezID)/favorite"
+									data-istoggle="true"
+									data-errordiv="favorite_errorDisplay"
+									id="#(fez.fezID)_favorite"
+								#if(fez.members.isFavorite):checked#endif>
+						<label class="btn btn-outline-primary" for="#(fez.fezID)_favorite">
+							Favorite<span class="laughtext"></span>
+							<span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
+							<span class="visually-hidden">Loading...</span>
+						</label>
 						#if(fez.owner.userID == trunk.userID):
 							#if(fez.fezType != "personalEvent"):
 								<a class="btn btn-outline-primary" href="/lfg/#(fez.fezID)/members">Manage Members</a>
@@ -98,7 +109,10 @@
 				<div class="col text-end text-danger d-none" id="fezActions_errorDisplay">
 					Could not join #(typeName): <span class="errortext"></span>
 				</div>
-			</div>	
+				<div class="col text-end text-danger d-none" id="favorite_errorDisplay">
+					Could not add/remove favorite: <span class="errortext"></span>
+				</div>
+			</div>
 			
 			#if(fez.members):
 				#if(fez.fezType != "personalEvent"):

--- a/Sources/swiftarr/Site/SiteChatController.swift
+++ b/Sources/swiftarr/Site/SiteChatController.swift
@@ -197,6 +197,8 @@ struct SiteFriendlyFezController: SiteControllerUtils {
 
 		privateRoutes.post(fezIDParam, "join", use: fezJoinPostHandler)
 		privateRoutes.post(fezIDParam, "leave", use: fezLeavePostHandler)
+		privateRoutes.post(fezIDParam, "favorite", use: fezAddFavoritePostHandler)
+		privateRoutes.delete(fezIDParam, "favorite", use: fezRemoveFavoritePostHandler)
 		privateRoutes.post(fezIDParam, "post", use: fezThreadPostHandler)
 		privateRoutes.post("post", postIDParam, "delete", use: fezPostDeleteHandler)
 		privateRoutes.delete("post", postIDParam, use: fezPostDeleteHandler)
@@ -485,6 +487,28 @@ struct SiteFriendlyFezController: SiteControllerUtils {
 		}
 		try await apiQuery(req, endpoint: "/fez/\(fezID)/unjoin", method: .POST)
 		return .created
+	}
+
+	// POST /lfg/ID/favorite
+	//
+	// Favorites a fez.
+	func fezAddFavoritePostHandler(_ req: Request) async throws -> HTTPStatus {
+		guard let fezID = req.parameters.get(fezIDParam.paramString)?.percentEncodeFilePathEntry() else {
+			throw Abort(.badRequest, reason: "Missing fez_id")
+		}
+		try await apiQuery(req, endpoint: "/fez/\(fezID)/favorite", method: .POST)
+		return .created
+	}
+
+	// DELETE /lfg/ID/favorite
+	//
+	// Unfavorites a fez.
+	func fezRemoveFavoritePostHandler(_ req: Request) async throws -> HTTPStatus {
+		guard let fezID = req.parameters.get(fezIDParam.paramString)?.percentEncodeFilePathEntry() else {
+			throw Abort(.badRequest, reason: "Missing fez_id")
+		}
+		try await apiQuery(req, endpoint: "/fez/\(fezID)/favorite/remove", method: .POST)
+		return .noContent
 	}
 
 	// POST /lfg/ID/cancel

--- a/Sources/swiftarr/Site/SiteSeamailController.swift
+++ b/Sources/swiftarr/Site/SiteSeamailController.swift
@@ -11,6 +11,10 @@ struct SiteSeamailController: SiteControllerUtils {
 		var paginator: PaginatorContext
 		var query: SeamailQueryOptions
 		var queryDescription: String
+		var unreadFilterURL: String?
+		var unreadFilterActive: Bool
+		var favoriteFilterURL: String?
+		var favoriteFilterActive: Bool
 
 		init(_ req: Request, fezList: FezListData, fezzes: [FezData]) throws {
 			effectiveUser = req.query[String.self, at: "foruser"]
@@ -22,6 +26,10 @@ struct SiteSeamailController: SiteControllerUtils {
 			let searchQuery = try req.query.decode(SeamailQueryOptions.self)
 			query = searchQuery
 			queryDescription = query.describeQuery()
+			unreadFilterActive = searchQuery.onlynew == true
+			favoriteFilterActive = searchQuery.favorite == true
+			unreadFilterURL = searchQuery.toggling(onlynew: true, baseURL: "/seamail")
+			favoriteFilterURL = searchQuery.toggling(favorite: true, baseURL: "/seamail")
 			if query.search != nil {
 				paginator = .init(fezList.paginator) { pageIndex in
 					// "/seamail/search?start=\(pageIndex * limit)&limit=\(limit)"
@@ -41,9 +49,10 @@ struct SiteSeamailController: SiteControllerUtils {
 		var start: Int?
 		var limit: Int?
 		var onlynew: Bool?
-		
+		var favorite: Bool?
+
 		func describeQuery() -> String {
-			return "\(onlynew == true ? "New " : "")Seamail\(search != nil ? " containing \"\(search!)\"" : "")"
+			return "\(onlynew == true ? "New " : "")\(favorite == true ? "Favorite " : "")Seamail\(search != nil ? " containing \"\(search!)\"" : "")"
 		}
 
 		// Builds a new URL given the saved query options plus the given baseURL and startOffset. Used
@@ -60,9 +69,20 @@ struct SiteSeamailController: SiteControllerUtils {
 			if newOffset != 0 { elements.append(URLQueryItem(name: "start", value: String(newOffset))) }
 			if let limit = limit { elements.append(URLQueryItem(name: "limit", value: String(limit))) }
 			if let onlynew = onlynew { elements.append(URLQueryItem(name: "onlynew", value: String(onlynew))) }
+			if let favorite = favorite { elements.append(URLQueryItem(name: "favorite", value: String(favorite))) }
 
 			components.queryItems = elements
 			return components.string
+		}
+
+		// Builds the URL for a filter toggle button: flips the given flag (onlynew/favorite) while
+		// preserving the other query options, and clears pagination since the result set changes.
+		func toggling(onlynew toggleOnlynew: Bool = false, favorite toggleFavorite: Bool = false, baseURL: String) -> String? {
+			var newOptions = self
+			newOptions.start = 0
+			if toggleOnlynew { newOptions.onlynew = (onlynew == true) ? nil : true }
+			if toggleFavorite { newOptions.favorite = (favorite == true) ? nil : true }
+			return newOptions.buildQuery(baseURL: baseURL, startOffset: 0)
 		}
 	}
 
@@ -93,6 +113,8 @@ struct SiteSeamailController: SiteControllerUtils {
 		privateRoutes.post("seamail", fezIDParam, "post", use: seamailThreadPostHandler)
 		privateRoutes.post("seamail", fezIDParam, "mute", use: seamailAddMutePostHandler)
 		privateRoutes.delete("seamail", fezIDParam, "mute", use: seamailRemoveMutePostHandler)
+		privateRoutes.post("seamail", fezIDParam, "favorite", use: seamailAddFavoritePostHandler)
+		privateRoutes.delete("seamail", fezIDParam, "favorite", use: seamailRemoveFavoritePostHandler)
 		privateRoutes.get("seamail", fezIDParam, "edit", use: seamailEditViewHandler)
 		privateRoutes.post("seamail", fezIDParam, "edit", use: seamailEditHandler)
 		privateRoutes.webSocket("seamail", fezIDParam, "socket", shouldUpgrade: shouldCreateMsgSocket, onUpgrade: createMsgSocket)
@@ -418,6 +440,28 @@ struct SiteSeamailController: SiteControllerUtils {
 			throw Abort(.badRequest, reason: "Missing fez_id parameter.")
 		}
 		try await apiQuery(req, endpoint: "/fez/\(fezID)/mute/remove", method: .POST)
+		return .noContent
+	}
+
+	// POST /seamail/:seamail_ID/favorite
+	//
+	// Adds a seamail to the user's favorites list.
+	func seamailAddFavoritePostHandler(_ req: Request) async throws -> HTTPStatus {
+		guard let fezID = req.parameters.get(fezIDParam.paramString)?.percentEncodeFilePathEntry() else {
+			throw Abort(.badRequest, reason: "Missing fez_id parameter.")
+		}
+		try await apiQuery(req, endpoint: "/fez/\(fezID)/favorite", method: .POST)
+		return .created
+	}
+
+	// DELETE /seamail/:seamail_ID/favorite
+	//
+	// Removes a seamail from the user's favorites list.
+	func seamailRemoveFavoritePostHandler(_ req: Request) async throws -> HTTPStatus {
+		guard let fezID = req.parameters.get(fezIDParam.paramString)?.percentEncodeFilePathEntry() else {
+			throw Abort(.badRequest, reason: "Missing fez_id parameter.")
+		}
+		try await apiQuery(req, endpoint: "/fez/\(fezID)/favorite/remove", method: .POST)
 		return .noContent
 	}
 

--- a/Sources/swiftarr/configure.swift
+++ b/Sources/swiftarr/configure.swift
@@ -647,6 +647,7 @@ struct SwiftarrConfigurator {
 		app.migrations.add(UpdateEventFavoriteSchema_Photographer(), to: .psql)
 		app.migrations.add(UpdateUserDiscordHandleMigration(), to: .psql)
 		app.migrations.add(AddPerformerAlternativeNamesMigration(), to: .psql)
+		app.migrations.add(AddFavoriteFieldToFezParticipantSchema(), to: .psql)
 
 		// At this point the db *schema* should be set, and the rest of these migrations operate on the db's *data*.
 

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -296,3 +296,11 @@ additive; the existing count fields are unchanged and are now derived from these
 - New endpoint `GET /api/v3/users/:user_id/vcard` returns a downloadable vCard (`.vcf`) of a user's land-based contact fields. The HTML profile page has a Save vCard button.
 - New endpoint `GET /api/v3/events/photographerreport` returns a paginated photography-coverage report (`Paginated<ShutternautScheduleReportData>`) of events flagged as needing a photographer and/or assigned a Shutternaut.
 - New endpoint `GET /api/v3/events/photographerreport/download` returns the same report as a CSV of all matching rows.
+
+## Sep 08, 2026
+
+- Fezzes (LFG, Seamail, Private Event) can be favorited by members.
+  - New endpoints `POST/DELETE /api/v3/fez/:fez_ID/favorite` and `POST /api/v3/fez/:fez_ID/favorite/remove`.
+  - `FezData.MembersOnlyData` has a new `isFavorite` field. 
+  - `GET /api/v3/fez/joined` and `GET /api/v3/fez/owner` now support a `?favorite=true` filter.
+- `POST/DELETE /api/v3/fez/:fez_ID/mute` is no longer rejected for privileged mailboxes (`@moderator`/`@TwitarrTeam`).


### PR DESCRIPTION
## Problem
When catching up on a busy conversation, there was no way to flag a chat to come back to later — the only tracking was mute and unread state, with no way to bookmark something for later attention (#513).

## Solution
Adds a per-user "favorite" flag on fez (Seamail/LFG/Private Event) memberships, similar in spirit to the existing mute flag, so users can star a conversation and filter their lists down to just their starred ones.

### Details
- New `isFavorite` field on the `FezParticipant` pivot, with a migration (`AddFavoriteFieldToFezParticipantSchema`) adding the `favorite` column.
- New endpoints: `POST/DELETE /api/v3/fez/:fez_ID/favorite` and `POST /api/v3/fez/:fez_ID/favorite/remove`.
- `GET /api/v3/fez/joined` and `GET /api/v3/fez/owner` now support a `?favorite=true` filter, mirroring the existing `?onlynew=true` filter.
- `FezData.MembersOnlyData` now includes `isFavorite`.
- Site UI: Favorite toggle button on Seamail and LFG detail pages, a favorite star indicator in list items, and a "Filter: Favorites" button on the Seamail list page.
- Refactored mute add/remove handlers to share a new `getOwnFezParticipant` helper (also used by the new favorite handlers), which correctly resolves the calling user's own participant pivot even for privileged mailboxes (`@moderator`/`@TwitarrTeam` seamail) rather than rejecting those chats outright — so muting/favoriting a privileged mailbox chat now only affects the user who took the action.
- Updated API Changelist.

Fixes #513 