### PR TITLE
Add unlisted visibility for Private Events

### DIFF
--- a/Sources/swiftarr/Controllers/FezController.swift
+++ b/Sources/swiftarr/Controllers/FezController.swift
@@ -362,7 +362,7 @@ struct FezController: APIRouteCollection {
 		let pivots = try await query.copy().sort(FriendlyFez.self, \.$createdAt, .descending).range(pagination.range).all()
 		let fezDataArray = try pivots.map { pivot -> FezData in
 			let fez = try pivot.joined(FriendlyFez.self)
-			return try buildFezData(from: fez, with: nil, for: effectiveUser, on: req)
+			return try buildFezData(from: fez, with: nil, for: effectiveUser, on: req, formerMember: true)
 		}
 		return FezListData(
 			paginator: Paginator(total: fezCount, start: pagination.start, limit: pagination.limit),
@@ -394,7 +394,10 @@ struct FezController: APIRouteCollection {
 			case .closed: throw Abort(.badRequest, reason: "Cannot add members to a closed chat")
 			case .open: throw Abort(.badRequest, reason: "Cannot add yourself to a Seamail chat. Ask the chat creator to add you.")
 			case .personalEvent: throw Abort(.badRequest, reason: "Cannot add members to a personal event")
-			case .privateEvent: throw Abort(.badRequest, reason: "Cannot add yourself to a Private Event. Ask the event creator to add you.")
+			case .privateEvent:
+				guard fez.visibility == .unlisted else {
+					throw Abort(.badRequest, reason: "Cannot add yourself to a Private Event. Ask the event creator to add you.")
+				}
 			default: break
 		}
 		guard !fez.participantArray.contains(cacheUser.userID) else {
@@ -457,7 +460,7 @@ struct FezController: APIRouteCollection {
 		try await deleteFezNotifications(userIDs: [cacheUser.userID], fez: fez, on: req)
 		try await forwardMembershipChangeToSockets(fez, participantID: cacheUser.userID, joined: false, on: req)
 		_ = try await storeNextJoinedAppointment(userID: cacheUser.userID, on: req)
-		return try buildFezData(from: fez, with: nil, for: cacheUser, on: req)
+		return try buildFezData(from: fez, with: nil, for: cacheUser, on: req, formerMember: true)
 	}
 
 	// MARK: Posts
@@ -1215,7 +1218,8 @@ extension FezController {
 		guard initialUsers.count >= 1 else {
 			throw Abort(.badRequest, reason: "Cannot create \(data.fezType.lfgLabel) with 0 participants")
 		}
-		let fez = FriendlyFez(owner: creator.userID, fezType: data.fezType, title: data.title, info: data.info,
+		let visibility = try resolveVisibilityForCreate(fezType: data.fezType, requested: data.visibility)
+		let fez = FriendlyFez(owner: creator.userID, fezType: data.fezType, visibility: visibility, title: data.title, info: data.info,
 				location: data.location, startTime: data.startTime, endTime: data.endTime, minCapacity: data.minCapacity,
 				maxCapacity: data.maxCapacity)
 		fez.participantArray = initialUsers
@@ -1265,13 +1269,15 @@ extension FezController {
 		if fez.fezType.isSeamailType {
 			try guardEditSeamail(fez: fez, data: data)
 		}
-		
+		let visibility = try resolveVisibilityForUpdate(fez: fez, requested: data.visibility, cacheUser: cacheUser)
+
 		if data.title != fez.title || data.location != fez.location || data.info != fez.info {
 			let fezEdit = try FriendlyFezEdit(fez: fez, editorID: cacheUser.userID)
 			try await fez.logIfModeratorAction(.edit, moderatorID: cacheUser.userID, on: req)
 			try await fezEdit.save(on: req.db)
 		}
 		fez.fezType = data.fezType
+		fez.visibility = visibility
 		fez.title = data.title
 		fez.info = data.info
 		fez.startTime = Settings.shared.timeZoneChanges.serverTimeToPortTime(data.startTime)
@@ -1296,7 +1302,7 @@ extension FezController {
 	// To read the 'moderator' or 'twitarrteam' seamail, verify the requestor has access and call this fn with
 	// the effective user's account.
 	func buildFezData(from fez: FriendlyFez, with pivot: FezParticipant? = nil, posts: [FezPostData]? = nil,
-			for cacheUser: UserCacheData, on req: Request) throws -> FezData {
+			for cacheUser: UserCacheData, on req: Request, formerMember: Bool = false) throws -> FezData {
 		let userBlocks = cacheUser.getBlocks()
 		// init return struct
 		let ownerHeader = try req.userCache.getHeader(fez.$owner.id)
@@ -1333,13 +1339,18 @@ extension FezController {
 			fezData.members = FezData.MembersOnlyData(participants: participants, waitingList: waitingList, postCount: postCount,
 					readCount: pivot?.readCount ?? postCount, posts: posts, isMuted: pivot?.isMuted ?? false,
 					isFavorite: pivot?.isFavorite ?? false)
-		} else if fez.fezType.isPrivateEventType {
-			// We need to let non-members see private events they're not currently a member of (so they can report them), but
-			// they should only see a minimum amount of info on the event they're not in.
-			fezData.info = ""
-			fezData.startTime = nil
-			fezData.endTime = nil
-			fezData.location = nil
+		} else {
+			switch fez.visibility {
+			case .private:
+				// Former members retain the ability to see the (limited) data returned here, even though
+				// they're not currently members--e.g. `/fez/former`. Everyone else is denied outright.
+				guard formerMember else {
+					throw Abort(.forbidden, reason: "You do not have access to this \(fez.fezType.lfgLabel)")
+				}
+			case .public, .unlisted:
+				// fezData already has full title/info/location/times; .members stays nil.
+				break
+			}
 		}
 		return fezData
 	}
@@ -1510,6 +1521,46 @@ extension FezController {
 
 	func userCanViewMemberData(user: UserCacheData, fez: FriendlyFez) -> Bool {
 		return user.accessLevel.hasAccess(.moderator) || fez.participantArray.contains(user.userID)
+	}
+
+	/// Resolves and validates the `visibility` to use for a newly-created fez.
+	///
+	/// Every fez type other than `.privateEvent` has a fixed visibility (its `FezVisibility.defaultVisibility(for:)`);
+	/// requesting anything else for those types is a 400. `.privateEvent` may additionally be `.unlisted`, but never `.public`.
+	func resolveVisibilityForCreate(fezType: FezType, requested: FezVisibility?) throws -> FezVisibility {
+		let visibility = requested ?? FezVisibility.defaultVisibility(for: fezType)
+		guard fezType == .privateEvent else {
+			guard visibility == FezVisibility.defaultVisibility(for: fezType) else {
+				throw Abort(.badRequest, reason: "Cannot set visibility on a \(fezType.lfgLabel)")
+			}
+			return visibility
+		}
+		guard visibility != .public else {
+			throw Abort(.badRequest, reason: "Private Events cannot be set to public visibility")
+		}
+		return visibility
+	}
+
+	/// Resolves and validates the `visibility` to use when updating a fez.
+	///
+	/// Omitting `requested` leaves the fez's current visibility unchanged. Changing visibility is a 400 for
+	/// every fez type other than `.privateEvent` (it's fixed even for moderators), never allows `.public` on
+	/// a `.privateEvent`, and is otherwise owner-only.
+	func resolveVisibilityForUpdate(fez: FriendlyFez, requested: FezVisibility?, cacheUser: UserCacheData) throws -> FezVisibility {
+		let newVisibility = requested ?? fez.visibility
+		guard newVisibility != fez.visibility else {
+			return fez.visibility
+		}
+		guard fez.fezType == .privateEvent else {
+			throw Abort(.badRequest, reason: "Cannot change visibility of a \(fez.fezType.lfgLabel)")
+		}
+		guard newVisibility != .public else {
+			throw Abort(.badRequest, reason: "Private Events cannot be set to public visibility")
+		}
+		guard cacheUser.userID == fez.$owner.id else {
+			throw Abort(.forbidden, reason: "Only the owner can change this Private Event's visibility")
+		}
+		return newVisibility
 	}
 
 	/// Validates edits against a seamail.

--- a/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/ControllerStructs.swift
@@ -614,6 +614,11 @@ public struct EventFeedbackStats: Content, Sendable {
 public struct FezContentData: Content {
 	/// The `FezType` .label of the fez.
 	var fezType: FezType
+	/// Who besides the fez's members can view (and, for `.privateEvent`, join) the fez. Only settable for
+	/// `.privateEvent` fezzes (may be `.private` or `.unlisted`); every other fez type has a fixed visibility
+	/// and setting this to anything but that fixed value is a 400. Omit to leave visibility unchanged on update,
+	/// or to use the type's default on create.
+	var visibility: FezVisibility?
 	/// The title for the FriendlyFez.
 	var title: String
 	/// A description of the fez.
@@ -646,6 +651,7 @@ extension FezContentData {
 		self.startTime = privateEvent.startTime
 		self.endTime = privateEvent.endTime
 		self.fezType = .privateEvent
+		self.visibility = privateEvent.visibility
 		self.initialUsers = privateEvent.participants
 		self.minCapacity = 0
 		self.maxCapacity = 0
@@ -724,6 +730,9 @@ public struct FezData: Content, ResponseEncodable {
 	var owner: UserHeader
 	/// The `FezType` .label of the fez.
 	var fezType: FezType
+	/// Who besides the fez's members can view (and, for `.privateEvent`, join) the fez. Only meaningful for
+	/// `.privateEvent` fezzes; other fez types have a fixed value clients shouldn't surface in most UIs.
+	var visibility: FezVisibility
 	/// The title of the fez.
 	var title: String
 	/// A description of the fez.
@@ -781,6 +790,7 @@ extension FezData {
 		self.fezID = try fez.requireID()
 		self.owner = owner
 		self.fezType = fez.fezType
+		self.visibility = fez.visibility
 		let showContent = fez.moderationStatus.showsContent() || overrideQuarantine
 		let underReviewText = "\(fez.fezType.lfgLabel) is under moderator review"
 		self.title = showContent ? fez.title : underReviewText
@@ -3182,6 +3192,8 @@ extension ClientSettingsData {
 public struct PersonalEventData: Content {
 	/// The PersonalEvent's ID. This is the Swiftarr database record for this event.
 	var personalEventID: UUID
+	/// Who besides invited participants can view and join this event. See `PersonalEventContentData.visibility`.
+	var visibility: FezVisibility
 	/// The personal event's title.
 	var title: String
 	/// A description of the personal event.
@@ -3210,6 +3222,7 @@ extension PersonalEventData {
 	init(_ personalEvent: FriendlyFez, ownerHeader: UserHeader, participantHeaders: [UserHeader]) throws {
 		let timeZoneChanges = Settings.shared.timeZoneChanges
 		self.personalEventID = try personalEvent.requireID()
+		self.visibility = personalEvent.visibility
 		self.title = personalEvent.title
 		self.description = personalEvent.info
 		self.startTime = timeZoneChanges.portTimeToDisplayTime(personalEvent.startTime)
@@ -3228,6 +3241,7 @@ extension PersonalEventData {
 		}
 		let timeZoneChanges = Settings.shared.timeZoneChanges
 		self.personalEventID = lfg.fezID
+		self.visibility = lfg.visibility
 		self.title = lfg.title
 		self.description = lfg.info
 		self.startTime = startTime
@@ -3248,6 +3262,10 @@ extension PersonalEventData {
 public struct PersonalEventContentData: Content {
 	/// The title for the PersonalEvent.
 	var title: String
+	/// Who besides invited participants can view and join this event. May be `.private` (default; invite-only)
+	/// or `.unlisted` (viewable and self-joinable via direct link, but never listed/searchable). Omit to leave
+	/// unchanged on update, or to default to `.private` on create.
+	var visibility: FezVisibility?
 	/// A description of the PersonalEvent.
 	var description: String?
 	/// The starting time for the PersonalEvent.

--- a/Sources/swiftarr/Enumerations/FezVisibility.swift
+++ b/Sources/swiftarr/Enumerations/FezVisibility.swift
@@ -1,0 +1,18 @@
+import Vapor
+
+/// The visibility of a `FriendlyFez`, controlling whether non-members/non-moderators can view or join it.
+enum FezVisibility: String, CaseIterable, Codable {
+	/// The default for Seamails (`.open`/`.closed`) and `.personalEvent`. A non-member, non-moderator
+	/// GET on the fez 403s.
+	case `private`
+	/// The default for all LFG types. Non-members can view the fez (but not `.members`) and can search for it.
+	case `public`
+	/// Only valid on `.privateEvent`. Non-members can view the fez (but not `.members`) via a direct link,
+	/// and can self-join, but the event is never listed/searchable.
+	case unlisted
+
+	/// The visibility a fez of the given type gets unless explicitly overridden.
+	static func defaultVisibility(for fezType: FezType) -> FezVisibility {
+		fezType.isLFGType ? .public : .private
+	}
+}

--- a/Sources/swiftarr/Models/FriendlyFez.swift
+++ b/Sources/swiftarr/Models/FriendlyFez.swift
@@ -28,6 +28,9 @@ final class FriendlyFez: Model, Searchable, @unchecked Sendable {
 	/// The type of fez; what its purpose is..
 	@Field(key: "fezType") var fezType: FezType
 
+	/// Who besides the fez's members can view (and, for `.privateEvent`, join) the fez.
+	@Field(key: "visibility") var visibility: FezVisibility
+
 	/// The title of the fez.
 	@Field(key: "title") var title: String
 
@@ -107,6 +110,7 @@ final class FriendlyFez: Model, Searchable, @unchecked Sendable {
 	init(
 		owner: UUID,
 		fezType: FezType,
+		visibility: FezVisibility? = nil,
 		title: String = "",
 		info: String = "",
 		location: String?,
@@ -117,6 +121,7 @@ final class FriendlyFez: Model, Searchable, @unchecked Sendable {
 	) {
 		self.$owner.id = owner
 		self.fezType = fezType
+		self.visibility = visibility ?? FezVisibility.defaultVisibility(for: fezType)
 		self.title = title
 		self.info = info
 		self.location = location
@@ -133,6 +138,7 @@ final class FriendlyFez: Model, Searchable, @unchecked Sendable {
 	init(owner: UUID) {
 		self.$owner.id = owner
 		self.fezType = .closed
+		self.visibility = .private
 		self.title = ""
 		self.info = ""
 		self.location = nil
@@ -183,5 +189,26 @@ struct CreateFriendlyFezSchema: AsyncMigration {
 
 	func revert(on database: Database) async throws {
 		try await database.schema("friendlyfez").delete()
+	}
+}
+
+struct AddVisibilityFieldToFriendlyFezSchema: AsyncMigration {
+	func prepare(on database: Database) async throws {
+		try await database.schema("friendlyfez")
+			.field("visibility", .string, .required, .sql(.default("private")))
+			.update()
+		// Backfill: existing LFGs become .public (their correct default); everything else
+		// (seamail, personalEvent, privateEvent) is already correctly defaulted to .private.
+		let lfgFezzes = try await FriendlyFez.query(on: database)
+			.filter(\.$fezType ~~ FezType.lfgTypes)
+			.all()
+		for fez in lfgFezzes {
+			fez.visibility = .public
+			try await fez.save(on: database)
+		}
+	}
+
+	func revert(on database: Database) async throws {
+		try await database.schema("friendlyfez").deleteField("visibility").update()
 	}
 }

--- a/Sources/swiftarr/Resources/Views/PrivateEvent/privateEventCreate.html
+++ b/Sources/swiftarr/Resources/Views/PrivateEvent/privateEventCreate.html
@@ -122,9 +122,9 @@
 												<div class="row mb-3">
 													<div class="input-group">
 														<span class="input-group-text" id="basic-addon1">@</span>
-														<input type="text" class="form-control user-autocomplete" autofocus="true" 
-																placeholder="Search for users here" 
-																aria-label="participants" aria-describedby="basic-addon1" 
+														<input type="text" class="form-control user-autocomplete" autofocus="true"
+																placeholder="Search for users here"
+																aria-label="participants" aria-describedby="basic-addon1"
 																autocapitalize="off" autocomplete="off"
 																data-nameusage="seamail">
 													</div>
@@ -152,8 +152,25 @@
 														</li>
 													#endif
 												</ul>
+												<div class="row mt-2 ps-2">
+													<div class="col form-check">
+														<input type="hidden" name="showVisibilityOption" value="true">
+														<input type="checkbox" class="form-check-input" name="unlisted" id="unlistedCheckbox">
+														<label class="form-check-label" for="unlistedCheckbox">Allow anyone with a link to this event to view and join it</label>
+													</div>
+												</div>
 											</div>
 										</div>
+									#else:
+										#if(fezType == "privateEvent"):
+											<div class="row mb-2 ps-2">
+												<div class="col form-check">
+													<input type="hidden" name="showVisibilityOption" value="true">
+													<input type="checkbox" class="form-check-input" name="unlisted" id="unlistedCheckbox" #if(visibility == "unlisted"): checked#endif>
+													<label class="form-check-label" for="unlistedCheckbox">Allow anyone with a link to this event to view and join it</label>
+												</div>
+											</div>
+										#endif
 									#endif
 								#endif
 								<div class="alert alert-danger mt-3 d-none" role="alert">

--- a/Sources/swiftarr/Site/SiteChatController.swift
+++ b/Sources/swiftarr/Site/SiteChatController.swift
@@ -22,6 +22,7 @@ struct FezCreateUpdatePageContext: Encodable {
 	var fezTitle: String = ""
 	var fezLocation: String = ""
 	var fezType: String = ""
+	var visibility: String = ""
 	var groupLabel: String = ""		// Seamail, LFG, Private Event
 	var startTime: Date?
 	var minutes: Int = 0
@@ -53,6 +54,7 @@ struct FezCreateUpdatePageContext: Encodable {
 			fezTitle = fez.title
 			fezLocation = fez.location ?? ""
 			fezType = fez.fezType.rawValue
+			visibility = fez.visibility.rawValue
 			groupLabel = fez.fezType.lfgLabel
 			startTime = fez.startTime
 			if let start = fez.startTime, let end = fez.endTime {

--- a/Sources/swiftarr/Site/SitePrivateEventController.swift
+++ b/Sources/swiftarr/Site/SitePrivateEventController.swift
@@ -11,6 +11,11 @@ struct CreatePrivateEventPostFormContent: Codable {
 	var postText: String
 	var inviteOthers: String?
 	var participants: String  // Comma separated list of participant usernames
+	var unlisted: String?
+	// Hidden marker, present iff the visibility toggle was actually rendered on the page (only true for
+	// Private Events--not Personal Events--on both create and update). Distinguishes "toggle shown but left
+	// unchecked" (which must send .private) from "toggle not shown at all" (which must leave visibility untouched).
+	var showVisibilityOption: String?
 }
 
 struct PrivateEventListPageContext: Encodable {
@@ -429,6 +434,7 @@ struct SitePrivateEventController: SiteControllerUtils {
 		participants = Array(Set(participants))
 		var fezContentData = FezContentData(
 			fezType: fezType,
+			visibility: postStruct.showVisibilityOption != nil ? (postStruct.unlisted == "on" ? .unlisted : .private) : nil,
 			title: postStruct.subject,
 			info: postStruct.postText,
 			startTime: startTime,

--- a/Sources/swiftarr/configure.swift
+++ b/Sources/swiftarr/configure.swift
@@ -648,6 +648,7 @@ struct SwiftarrConfigurator {
 		app.migrations.add(UpdateUserDiscordHandleMigration(), to: .psql)
 		app.migrations.add(AddPerformerAlternativeNamesMigration(), to: .psql)
 		app.migrations.add(AddFavoriteFieldToFezParticipantSchema(), to: .psql)
+		app.migrations.add(AddVisibilityFieldToFriendlyFezSchema(), to: .psql)
 
 		// At this point the db *schema* should be set, and the rest of these migrations operate on the db's *data*.
 

--- a/Tests/AppTests/FezAndEventValidationTests.swift
+++ b/Tests/AppTests/FezAndEventValidationTests.swift
@@ -163,6 +163,45 @@ class FezAndEventValidationTests: XCTestCase {
 		XCTAssertThrowsError(try validationErrors(PersonalEventContentData.self, json))
 	}
 
+	// MARK: - FezController.resolveVisibilityForCreate (issue #470 "unlisted" Private Events)
+
+	func testResolveVisibilityForCreate_LFG_DefaultsToPublic() throws {
+		let visibility = try FezController().resolveVisibilityForCreate(fezType: .activity, requested: nil)
+		XCTAssertEqual(visibility, .public)
+	}
+
+	func testResolveVisibilityForCreate_Seamail_DefaultsToPrivate() throws {
+		let visibility = try FezController().resolveVisibilityForCreate(fezType: .closed, requested: nil)
+		XCTAssertEqual(visibility, .private)
+	}
+
+	func testResolveVisibilityForCreate_PersonalEvent_DefaultsToPrivate() throws {
+		let visibility = try FezController().resolveVisibilityForCreate(fezType: .personalEvent, requested: nil)
+		XCTAssertEqual(visibility, .private)
+	}
+
+	func testResolveVisibilityForCreate_PrivateEvent_DefaultsToPrivate() throws {
+		let visibility = try FezController().resolveVisibilityForCreate(fezType: .privateEvent, requested: nil)
+		XCTAssertEqual(visibility, .private)
+	}
+
+	func testResolveVisibilityForCreate_PrivateEvent_CanRequestUnlisted() throws {
+		let visibility = try FezController().resolveVisibilityForCreate(fezType: .privateEvent, requested: .unlisted)
+		XCTAssertEqual(visibility, .unlisted)
+	}
+
+	func testResolveVisibilityForCreate_PrivateEvent_RejectsPublic() {
+		XCTAssertThrowsError(try FezController().resolveVisibilityForCreate(fezType: .privateEvent, requested: .public))
+	}
+
+	func testResolveVisibilityForCreate_LFG_RejectsNonDefault() {
+		XCTAssertThrowsError(try FezController().resolveVisibilityForCreate(fezType: .activity, requested: .private))
+	}
+
+	func testResolveVisibilityForCreate_Seamail_RejectsNonDefault() {
+		XCTAssertThrowsError(try FezController().resolveVisibilityForCreate(fezType: .closed, requested: .unlisted))
+	}
+
 	// MARK: - UserRecoveryData
 
 	private func recoveryJSON(username: String = "skyler", recoveryKey: String = "abc123", newPassword: String = "newpass1") -> String {

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -305,3 +305,7 @@ additive; the existing count fields are unchanged and are now derived from these
   - `GET /api/v3/fez/joined` and `GET /api/v3/fez/owner` now support a `?favorite=true` filter.
 - `POST/DELETE /api/v3/fez/:fez_ID/mute` is no longer rejected for privileged mailboxes (`@moderator`/`@TwitarrTeam`).
 - `FezContentData` gains an optional `firstPost` (`PostContentData`), letting `POST /api/v3/fez/create` create the intial post in the same call.
+
+## Sep 10, 2026
+
+- `FezData`, `FezContentData`, `PersonalEventData`, and `PersonalEventContentData` gain a `visibility` field (`private`/`public`/`unlisted`). Seamails/LFGs/Personal Events have a fixed visibility that can't be changed; Private Events default to `private` but the owner may set `unlisted`, which lets non-members view (without `.members`) and self-join via `POST /api/v3/fez/:fez_ID/join` without needing an invite.


### PR DESCRIPTION
## Problem
If you want to share a Private-Event-like invite with a large relatively-private audience, the only options today are spammy bulk-inviting everyone or asking people to message you to be added. There was no way to just hand out a link and let people join themselves (issue #470).

## Solution
Adds a `visibility` field (`private`/`public`/`unlisted`) to fezzes. Seamails, LFGs, and Personal Events keep a fixed visibility they've always effectively had (`public` for LFGs, `private` for everything else). Private Events can now also be set to `unlisted` by their owner: non-members can view (without seeing `.members`) and self-join via a direct link, but the event is never listed or searchable.

Details:
- New `FezVisibility` enum with `defaultVisibility(for:)` per `FezType`.
- `FriendlyFez` gains a `visibility` field, backed by a new migration (`AddVisibilityFieldToFriendlyFezSchema`) that backfills existing LFGs to `.public` and defaults everything else to `.private`.
- `FezController.resolveVisibilityForCreate`/`resolveVisibilityForUpdate` validate and apply visibility on create/update, enforcing that only Private Events can deviate from their type's default, that Private Events can never be `.public`, and that only the owner can change it.
- `FezData`, `FezContentData`, `PersonalEventData`, and `PersonalEventContentData` all expose `visibility`.
- Joining a Private Event via `POST /api/v3/fez/:fez_ID/join` is now allowed when the event is `.unlisted`.
- Web UI: `privateEventCreate.html` gains an "Allow anyone with a link to view and join" checkbox for Private Events.
- Added unit tests for the visibility resolution logic and updated the API Changelist doc.

### Testing
- Added `FezAndEventValidationTests` cases covering default visibility per fez type and validation of disallowed visibility values.

Fixes #470