### PR TITLE
Site UI improvements for LFGs and Private Events

### DIFF
--- a/Sources/swiftarr/Controllers/FezController.swift
+++ b/Sources/swiftarr/Controllers/FezController.swift
@@ -311,6 +311,9 @@ struct FezController: APIRouteCollection {
 		guard !cacheUser.getBlocks().contains(fez.$owner.id) else {
 			throw Abort(.notFound, reason: "this \(fez.fezType.lfgLabel) is not available")
 		}
+		if fez.fezType.isPrivateEventType, !userCanViewMemberData(user: cacheUser, fez: fez) {
+			throw Abort(.notFound, reason: "this \(fez.fezType.lfgLabel) is not available")
+		}
 
 		// For privileged mailboxes, use the actual user's ID to query/ensure per-user FezParticipant
 		// This ensures each user has their own read tracking for privileged mailbox conversations
@@ -976,6 +979,9 @@ struct FezController: APIRouteCollection {
 		}
 		let fezParticipant = try await getOwnFezParticipant(fez: fez, cacheUser: cacheUser, req: req)
 
+		if fezParticipant.isFavorite {
+			throw Abort(.badRequest, reason: "Cannot mute a favorited \(fez.fezType.lfgLabel).")
+		}
 		if fezParticipant.isMuted == true {
 			return .ok
 		}
@@ -1031,6 +1037,9 @@ struct FezController: APIRouteCollection {
 		}
 		let fezParticipant = try await getOwnFezParticipant(fez: fez, cacheUser: cacheUser, req: req)
 
+		if fezParticipant.isMuted == true {
+			throw Abort(.badRequest, reason: "Cannot favorite a muted \(fez.fezType.lfgLabel).")
+		}
 		if fezParticipant.isFavorite {
 			return .ok
 		}

--- a/Sources/swiftarr/Resources/Assets/js/swiftarr.js
+++ b/Sources/swiftarr/Resources/Assets/js/swiftarr.js
@@ -17,6 +17,7 @@ for (let btn of document.querySelectorAll('[data-action]')) {
 		case "muteForum": // Different than mute[User] due to code in spinnerButtonAction.
 		case "pinForum":
 		case "muteSeamail":
+		case "muteFez":
 		case "unblock":
 		case "unfavorite":
 		case "unmute":

--- a/Sources/swiftarr/Resources/Assets/js/swiftarr.js
+++ b/Sources/swiftarr/Resources/Assets/js/swiftarr.js
@@ -617,6 +617,16 @@ async function submitAJAXForm(formElement, event) {
 				location.reload();
 				return;
 			}
+			if (successURL == "createdFez") {
+				let data = await response.json();
+				location.assign("/lfg/" + data.fezID);
+				return;
+			}
+			if (successURL == "createdPrivateEvent") {
+				let data = await response.json();
+				location.assign("/privateevent/" + data.fezID);
+				return;
+			}
 			if (successURL == "message") {
 				let data = await response.json();
 				let successAlert = formElement.querySelector('.alert-success');

--- a/Sources/swiftarr/Resources/Views/Fez/fezCreate.html
+++ b/Sources/swiftarr/Resources/Views/Fez/fezCreate.html
@@ -20,7 +20,8 @@
     			<div class="col">
 					<ul class="container-md mx-0 px-0 list-group">
 						<li class="list-group-item bg-transparent mb-3">				
-							<form class="ajax" action="#(formAction)" enctype="multipart/form-data" method="POST" data-successurl="/lfg">
+							<form class="ajax" action="#(formAction)" enctype="multipart/form-data" method="POST"
+									data-successurl="#if(fez):/lfg/#(fez.fezID)#else:createdFez#endif">
 								<div class="row mb-3">
 									<div class="input-group">
 										<input type="text" class="form-control" placeholder="Title" name="subject" aria-label="Title" value="#(fezTitle)">

--- a/Sources/swiftarr/Resources/Views/Fez/singleFez.html
+++ b/Sources/swiftarr/Resources/Views/Fez/singleFez.html
@@ -57,11 +57,8 @@
 			#endif
 			
 			#if(userIsMember):
-				<div class="row mt-1 justify-content-end row-cols-auto ">
-					<div class="col btn-group btn-group-sm" role="group" aria-label="member actions">
-						#if(trunk.userIsMod):
-							<a class="btn btn-outline-primary" href="/moderate/lfg/#(fez.fezID)">Mod</a>
-						#endif
+				<div class="row mt-1 justify-content-end row-cols-auto g-2">
+					<div class="col btn-group btn-group-sm" role="group" aria-label="favorite and mute actions">
 						<input type="checkbox" class="btn-check" autocomplete="off" data-action="favorite"
 									data-actionpath="/lfg/#(fez.fezID)/favorite"
 									data-istoggle="true"
@@ -73,7 +70,7 @@
 							<span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
 							<span class="visually-hidden">Loading...</span>
 						</label>
-						<input type="checkbox" class="btn-check" autocomplete="off" data-action="mute"
+						<input type="checkbox" class="btn-check" autocomplete="off" data-action="muteFez"
 									data-actionpath="/lfg/#(fez.fezID)/mute"
 									data-istoggle="true"
 									data-errordiv="mute_errorDisplay"
@@ -84,6 +81,11 @@
 							<span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
 							<span class="visually-hidden">Loading...</span>
 						</label>
+					</div>
+					<div class="col btn-group btn-group-sm" role="group" aria-label="member actions">
+						#if(trunk.userIsMod):
+							<a class="btn btn-outline-primary" href="/moderate/lfg/#(fez.fezID)">Mod</a>
+						#endif
 						#if(fez.owner.userID == trunk.userID):
 							#if(fez.fezType != "personalEvent"):
 								<a class="btn btn-outline-primary" href="/lfg/#(fez.fezID)/members">Manage Members</a>
@@ -94,7 +96,7 @@
 							<a class="btn btn-outline-primary px-3" href="/lfg/report/#(fez.fezID)">Report</a>
 							<button type="button" class="btn btn-outline-primary px-3" data-bs-toggle="modal" data-bs-target="\#leaveFezModal">Leave</button>
 						#endif
-					</div>								
+					</div>
 				</div>
 			#else:
 				<div class="row mt-1 justify-content-end row-cols-auto ">
@@ -269,11 +271,21 @@
 						<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
 					</div>
 					<div class="modal-body">
-						Are you sure you want to leave the #(typeName)? You'll be giving up your spot--LFGs with limited space are first-come, first-served.
+						#if(typeName == "Private Event"):
+							Are you sure you want to leave the #(typeName)?
+						#else:
+							Are you sure you want to leave the #(typeName)? You'll be giving up your spot--#(typeName)s with limited space are first-come, first-served.
+						#endif
 					</div>
 					<div class="modal-footer">
 						<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-						<input type="checkbox" class="btn-check" autocomplete="off" data-action="reload" 
+						<input type="checkbox" class="btn-check" autocomplete="off"
+								#if(typeName == "Private Event"):
+									data-action="redirect"
+									data-successpath="#(breadcrumbLink)"
+								#else:
+									data-action="reload"
+								#endif
 								data-actionpath="/lfg/#(fez.fezID)/leave"
 								data-errordiv="fezDialog_errorDisplay"
 								id="#(fez.fezID)_leave">

--- a/Sources/swiftarr/Resources/Views/Fez/singleFez.html
+++ b/Sources/swiftarr/Resources/Views/Fez/singleFez.html
@@ -73,6 +73,17 @@
 							<span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
 							<span class="visually-hidden">Loading...</span>
 						</label>
+						<input type="checkbox" class="btn-check" autocomplete="off" data-action="mute"
+									data-actionpath="/lfg/#(fez.fezID)/mute"
+									data-istoggle="true"
+									data-errordiv="mute_errorDisplay"
+									id="#(fez.fezID)_mute"
+								#if(fez.members.isMuted):checked#endif>
+						<label class="btn btn-outline-primary" for="#(fez.fezID)_mute">
+							Mute<span class="laughtext"></span>
+							<span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
+							<span class="visually-hidden">Loading...</span>
+						</label>
 						#if(fez.owner.userID == trunk.userID):
 							#if(fez.fezType != "personalEvent"):
 								<a class="btn btn-outline-primary" href="/lfg/#(fez.fezID)/members">Manage Members</a>
@@ -111,6 +122,9 @@
 				</div>
 				<div class="col text-end text-danger d-none" id="favorite_errorDisplay">
 					Could not add/remove favorite: <span class="errortext"></span>
+				</div>
+				<div class="col text-end text-danger d-none" id="mute_errorDisplay">
+					Could not add/remove mute: <span class="errortext"></span>
 				</div>
 			</div>
 			

--- a/Sources/swiftarr/Resources/Views/PrivateEvent/privateEventCreate.html
+++ b/Sources/swiftarr/Resources/Views/PrivateEvent/privateEventCreate.html
@@ -23,8 +23,8 @@
     			<div class="col">
 					<ul class="container-md mx-0 px-0 list-group">
 						<li class="list-group-item bg-transparent mb-3">				
-							<form class="ajax" action="#(formAction)" enctype="multipart/form-data" method="POST" 
-									data-successurl="#if(isPrivateEvent):/dayplanner#else:/lfg#endif">
+							<form class="ajax" action="#(formAction)" enctype="multipart/form-data" method="POST"
+									data-successurl="#if(fez):/privateevent/#(fez.fezID)#else:createdPrivateEvent#endif">
 								<input type="hidden" name="participants" id="participants_hidden" value="#(withUser.userID)">
 								<div class="row mb-3">
 									<div class="input-group">

--- a/Sources/swiftarr/Site/SiteChatController.swift
+++ b/Sources/swiftarr/Site/SiteChatController.swift
@@ -360,9 +360,14 @@ struct SiteFriendlyFezController: SiteControllerUtils {
 
 			init(_ req: Request, fez: FezData) throws {
 				let cacheUser = try req.auth.require(UserCacheData.self)
-				trunk = .init(req, title: "\(fez.title) | LFG", tab: .lfg)
-				self.fez = fez
 				self.typeName = fez.fezType.lfgLabel
+				if fez.fezType.isPrivateEventType {
+					trunk = .init(req, title: "\(fez.title) | \(self.typeName)", tab: .home)
+				}
+				else {
+					trunk = .init(req, title: "\(fez.title) | LFG", tab: .lfg)
+				}
+				self.fez = fez
 				self.breadcrumbLink = fez.fezType.isPrivateEventType ? "/dayplanner" : "/lfg"
 				self.userID = cacheUser.userID
 				userIsMember = false

--- a/Sources/swiftarr/Site/SiteChatController.swift
+++ b/Sources/swiftarr/Site/SiteChatController.swift
@@ -298,7 +298,10 @@ struct SiteFriendlyFezController: SiteControllerUtils {
 	// POST /lfg/create
 	// POST /lfg/ID/update
 	// Handles the POST from either the Create Or Update Fez page
-	func fezCreateOrUpdatePostHandler(_ req: Request) async throws -> HTTPStatus {
+	func fezCreateOrUpdatePostHandler(_ req: Request) async throws -> Response {
+		struct NewFezResponse: Content {
+			var fezID: UUID
+		}
 		let postStruct = try req.content.decode(CreateFezPostFormContent.self)
 		var fezType: FezType
 		switch postStruct.eventtype {
@@ -325,12 +328,18 @@ struct SiteFriendlyFezController: SiteControllerUtils {
 			maxCapacity: postStruct.maximum,
 			initialUsers: []
 		)
+		let isCreating = req.parameters.get(fezIDParam.paramString) == nil
 		var path = "/fez/create"
 		if let updatingFezID = req.parameters.get(fezIDParam.paramString)?.percentEncodeFilePathEntry() {
 			path = "/fez/\(updatingFezID)/update"
 		}
-		try await apiQuery(req, endpoint: path, method: .POST, encodeContent: fezContentData)
-		return .created
+		let apiResponse = try await apiQuery(req, endpoint: path, method: .POST, encodeContent: fezContentData)
+		let response = Response(status: .created)
+		if isCreating {
+			let newFez = try apiResponse.content.decode(FezData.self)
+			try response.content.encode(NewFezResponse(fezID: newFez.fezID))
+		}
+		return response
 	}
 
 	// GET /lfg/ID

--- a/Sources/swiftarr/Site/SiteChatController.swift
+++ b/Sources/swiftarr/Site/SiteChatController.swift
@@ -199,6 +199,8 @@ struct SiteFriendlyFezController: SiteControllerUtils {
 		privateRoutes.post(fezIDParam, "leave", use: fezLeavePostHandler)
 		privateRoutes.post(fezIDParam, "favorite", use: fezAddFavoritePostHandler)
 		privateRoutes.delete(fezIDParam, "favorite", use: fezRemoveFavoritePostHandler)
+		privateRoutes.post(fezIDParam, "mute", use: fezAddMutePostHandler)
+		privateRoutes.delete(fezIDParam, "mute", use: fezRemoveMutePostHandler)
 		privateRoutes.post(fezIDParam, "post", use: fezThreadPostHandler)
 		privateRoutes.post("post", postIDParam, "delete", use: fezPostDeleteHandler)
 		privateRoutes.delete("post", postIDParam, use: fezPostDeleteHandler)
@@ -508,6 +510,28 @@ struct SiteFriendlyFezController: SiteControllerUtils {
 			throw Abort(.badRequest, reason: "Missing fez_id")
 		}
 		try await apiQuery(req, endpoint: "/fez/\(fezID)/favorite/remove", method: .POST)
+		return .noContent
+	}
+
+	// POST /lfg/ID/mute
+	//
+	// Mutes a fez.
+	func fezAddMutePostHandler(_ req: Request) async throws -> HTTPStatus {
+		guard let fezID = req.parameters.get(fezIDParam.paramString)?.percentEncodeFilePathEntry() else {
+			throw Abort(.badRequest, reason: "Missing fez_id")
+		}
+		try await apiQuery(req, endpoint: "/fez/\(fezID)/mute", method: .POST)
+		return .created
+	}
+
+	// DELETE /lfg/ID/mute
+	//
+	// Unmutes a fez.
+	func fezRemoveMutePostHandler(_ req: Request) async throws -> HTTPStatus {
+		guard let fezID = req.parameters.get(fezIDParam.paramString)?.percentEncodeFilePathEntry() else {
+			throw Abort(.badRequest, reason: "Missing fez_id")
+		}
+		try await apiQuery(req, endpoint: "/fez/\(fezID)/mute/remove", method: .POST)
 		return .noContent
 	}
 

--- a/Sources/swiftarr/Site/SitePrivateEventController.swift
+++ b/Sources/swiftarr/Site/SitePrivateEventController.swift
@@ -411,7 +411,10 @@ struct SitePrivateEventController: SiteControllerUtils {
 	// POST /privateevent/create
 	// POST /privateevent/ID/update
 	// Handles the POST from either the Create Or Update Private Event page
-	func peCreateOrUpdatePostHandler(_ req: Request) async throws -> HTTPStatus {
+	func peCreateOrUpdatePostHandler(_ req: Request) async throws -> Response {
+		struct NewFezResponse: Content {
+			var fezID: UUID
+		}
 		let postStruct = try req.content.decode(CreatePrivateEventPostFormContent.self)
 		let fezType: FezType = postStruct.inviteOthers == "on" ? .privateEvent : .personalEvent
 		guard postStruct.subject.count > 0 else {
@@ -438,6 +441,7 @@ struct SitePrivateEventController: SiteControllerUtils {
 			maxCapacity: 0,
 			initialUsers: participants
 		)
+		let isCreating = req.parameters.get(fezIDParam.paramString) == nil
 		var path = "/fez/create"
 		if let updatingFezID = req.parameters.get(fezIDParam.paramString)?.percentEncodeFilePathEntry() {
 			path = "/fez/\(updatingFezID)/update"
@@ -445,8 +449,13 @@ struct SitePrivateEventController: SiteControllerUtils {
 			let fez = try response.content.decode(FezData.self)
 			fezContentData.fezType = fez.fezType
 		}
-		try await apiQuery(req, endpoint: path, method: .POST, encodeContent: fezContentData)
-		return .created
+		let apiResponse = try await apiQuery(req, endpoint: path, method: .POST, encodeContent: fezContentData)
+		let response = Response(status: .created)
+		if isCreating {
+			let newFez = try apiResponse.content.decode(FezData.self)
+			try response.content.encode(NewFezResponse(fezID: newFez.fezID))
+		}
+		return response
 	}
 
 	// GET /privateevent/ID


### PR DESCRIPTION
## Problem
The API lets you mute or unmute any Fez type (Seamail, LFG, Private Events), but the Site UI only exposed this for chats — there was no way to mute a noisy LFG or Private Event from the web interface.

## Solution
Adds a Mute button next to Favorite on the fez detail page, wired up to new site routes and API guards.

- Added `POST /lfg/ID/mute` and `DELETE /lfg/ID/mute` site routes in `SiteChatController.swift` that call the existing `/fez/ID/mute` and `/fez/ID/mute/remove` API endpoints.
- Added a Mute toggle button to `singleFez.html`, alongside the existing Favorite button, with its own error display.
- Registered `muteFez` as a recognized toggle action in `swiftarr.js`.
- In `FezController.swift`, prevented a fez from being simultaneously muted and favorited (each action now rejects if the other state is already set), and fixed a visibility check on private event fetches to properly restrict access via `userCanViewMemberData`.
- Adjusted the Leave modal copy and redirect behavior for Private Events vs. other fez types, and fixed the trunk title/tab for Private Event pages.

Hey I'm a human and wrote this part: Also fixes some less ideal behavior with editing/creating Fezzes and getting redirected to lists or other places that make no sense.

Fixes #486