### PR TITLE
Implement performer search

### DIFF
--- a/Sources/swiftarr/Controllers/PerformerController.swift
+++ b/Sources/swiftarr/Controllers/PerformerController.swift
@@ -53,11 +53,13 @@ struct PerformerController: APIRouteCollection {
 	///  before the schedule.
 	///
 	/// **URL Query Parameters:**
+	/// * `?search=STRING` - Full-text search across name, organization, title, and bio.
 	///	* `?start=INT` - Offset from start of results set
 	/// * `?limit=INT` - the maximum number of games to retrieve: 1-200, default is 50.
 	func getOfficialPerformers(_ req: Request) async throws -> PerformerResponseData {
 		let pagination = Pagination(on: req, maxPageSize: Settings.shared.maximumTwarrts)
 		let query = Performer.query(on: req.db).filter(\.$officialPerformer == true).sort(\.$sortOrder)
+		try applyPerformerSearchFilter(from: req, to: query)
 		let performerCount = try await query.count()
 		let performers = try await query.copy().range(pagination.range).all()
 		let performerDataArray = try performers.map { try PerformerHeaderData($0) }
@@ -76,6 +78,7 @@ struct PerformerController: APIRouteCollection {
 	/// The form doesn't include years attended or social media links; those fields will be empty.
 	///
 	/// **URL Query Parameters:**
+	/// * `?search=STRING` - Full-text search across name, organization, title, and bio.
 	///	* `?start=INT` - Offset from start of results set
 	/// * `?limit=INT` - the maximum number of games to retrieve: 1-200, default is 50.
 	func getShadowPerformers(_ req: Request) async throws -> PerformerResponseData {
@@ -87,6 +90,7 @@ struct PerformerController: APIRouteCollection {
 		let query = Performer.query(on: req.db).filter(\.$officialPerformer == false).sort(\.$sortOrder)
 				.join(User.self, on: \Performer.$user.$id == \User.$id)
 				.filter(User.self, \.$accessLevel != .banned)
+		try applyPerformerSearchFilter(from: req, to: query)
 		let performerCount = try await query.count()
 		let performers = try await query.copy().range(pagination.range).with(\.$events).all()
 		let performerDataArray = try performers.map { try PerformerHeaderData($0) }
@@ -612,7 +616,25 @@ struct PerformerController: APIRouteCollection {
 	}
 	
 	// MARK: Utilities
-	
+
+	// Applies the `?search=` query param (if present and non-empty after sanitization) to a Performer query,
+	// matching against name, organization, title, and bio via full-text search.
+	func applyPerformerSearchFilter(from req: Request, to query: QueryBuilder<Performer>) throws {
+		guard var search = req.query[String.self, at: "search"] else {
+			return
+		}
+		search = search.escapedForSQLWildcards()
+		guard !search.isEmpty else {
+			return
+		}
+		query.group(.or) { or in
+			or.fullTextFilter(\.$name, search)
+			or.fullTextFilter(\.$organization, search)
+			or.fullTextFilter(\.$title, search)
+			or.fullTextFilter(\.$bio, search)
+		}
+	}
+
 	// Gets the path where the uploaded performer links file is kept. Only one file can be in the hopper at a time.
 	func uploadedPerformerLinksPath() throws -> URL {
 		let filePath = Settings.shared.adminDirectoryPath.appendingPathComponent("uploadperformerlinks.ics")

--- a/Sources/swiftarr/Migrations/Schema Creation/PerformerSearchIndexCreation.swift
+++ b/Sources/swiftarr/Migrations/Schema Creation/PerformerSearchIndexCreation.swift
@@ -1,0 +1,37 @@
+import FluentSQL
+
+struct CreatePerformerSearchIndexes: AsyncMigration {
+	func prepare(on database: Database) async throws {
+		let sqlDatabase = (database as! SQLDatabase)
+		// Postgres's generic array I/O routines (used by both `array_to_string` and a plain `::text` cast)
+		// are marked STABLE rather than IMMUTABLE, because they dispatch through the array element type's
+		// output function, which isn't provably immutable for every possible element type -- even though
+		// it genuinely is for `text`. A thin SQL wrapper declared IMMUTABLE here sidesteps that, which is
+		// safe since `text[]` output never varies by locale or session state.
+		try await sqlDatabase.raw(
+			"""
+			CREATE OR REPLACE FUNCTION performer_alt_names_to_text(text[]) RETURNS text AS
+			$$ SELECT array_to_string($1, ' ') $$ LANGUAGE sql IMMUTABLE
+			"""
+		)
+		.run()
+
+		try await sqlDatabase.addFullTextSearchColumn(
+			tableName: "performer",
+			tsvectorExpression: """
+				to_tsvector('english',
+				  coalesce(name, '') || ' ' ||
+				  coalesce(organization, '') || ' ' ||
+				  coalesce(title, '') || ' ' ||
+				  coalesce(bio, '') || ' ' ||
+				  coalesce(performer_alt_names_to_text(alternative_names), ''))
+				"""
+		)
+	}
+
+	func revert(on database: Database) async throws {
+		let sqlDatabase = (database as! SQLDatabase)
+		try await sqlDatabase.dropSearchIndexAndColumn(tableName: "performer")
+		try await sqlDatabase.raw("DROP FUNCTION IF EXISTS performer_alt_names_to_text(text[])").run()
+	}
+}

--- a/Sources/swiftarr/Models/Performer.swift
+++ b/Sources/swiftarr/Models/Performer.swift
@@ -12,7 +12,7 @@ import Vapor
 /// Because it's often the case that there's at least one late change to the official lineup, these models can be soft-deleted by admin, which
 /// should be easier to manage than delete-on-update logic.This also gives the *technical* ability to list performers who weren't able to make it aboard. 
 /// I haven't checked whether this is information we can actually provide--there may be contractual issues or something.
-final class Performer: Model, @unchecked Sendable {
+final class Performer: Model, Searchable, @unchecked Sendable {
 	static let schema = "performer"
 	
 	@ID(key: .id) var id: UUID?

--- a/Sources/swiftarr/Resources/Views/Performers/list.html
+++ b/Sources/swiftarr/Resources/Views/Performers/list.html
@@ -30,4 +30,13 @@
 			</div>
 		</div>
     #endexport
+    #export("hassearch", true)
+    #export("searchform"):
+		<div class="container-fluid collapse swiftarr-searchbar" id="searchBar">
+			<form class="d-flex">
+				<input class="form-control" type="search" name="search" value="#(searchText)" placeholder="Search Performers" aria-label="Search" autocapitalize="off" required>
+				<button class="btn btn-success ms-2" type="submit">Search</button>
+			</form>
+		</div>
+    #endexport
 #endextend

--- a/Sources/swiftarr/configure.swift
+++ b/Sources/swiftarr/configure.swift
@@ -684,6 +684,7 @@ struct SwiftarrConfigurator {
 		app.migrations.add(CreateMicroKaraokeUser(), to: .psql)
 		app.migrations.add(RemoveCovidCategory(), to: .psql)
 		app.migrations.add(CreateQuartermasterSearchIndexes(), to: .psql)
+		app.migrations.add(CreatePerformerSearchIndexes(), to: .psql)
 
 		// DON'T add schema-modification migrations down here. Appending migrations that modify a table's schema at the end will
 		// break migrations that use Fluent to populate that table with data, as Fluent only models the current db schema.

--- a/Tests/AppTests/PerformerSearchTests.swift
+++ b/Tests/AppTests/PerformerSearchTests.swift
@@ -1,0 +1,122 @@
+import Fluent
+import XCTVapor
+@testable import swiftarr
+
+// Tests for Performer search (issue #507): full-text search across name, organization, title, and bio,
+// scoped to either /performer/official or /performer/shadow.
+//
+// Uses SwiftarrBaseTest and a live Postgres instance (port 5433) plus Redis (port 6380), same as
+// QuartermasterControllerTests.
+final class PerformerSearchTests: XCTestCase, SwiftarrBaseTest {
+
+	// MARK: - Helpers
+
+	private func makeUser(_ app: Application, username: String, accessLevel: UserAccessLevel) async throws -> User {
+		let user = User(
+			username: username,
+			password: try Bcrypt.hash("password1"),
+			recoveryKey: try Bcrypt.hash("recovery key"),
+			accessLevel: accessLevel
+		)
+		try await user.save(on: app.db)
+		return user
+	}
+
+	private func makeToken(_ app: Application, for user: User) async throws -> String {
+		let token = try Token.generate(for: user)
+		try await token.save(on: app.db)
+		return token.token
+	}
+
+	private func bearer(_ token: String) -> HTTPHeaders {
+		var headers = HTTPHeaders()
+		headers.bearerAuthorization = BearerAuthorization(token: token)
+		return headers
+	}
+
+	@discardableResult
+	private func makeOfficialPerformer(
+		_ app: Application,
+		name: String,
+		organization: String? = nil,
+		title: String? = nil,
+		bio: String? = nil
+	) async throws -> Performer {
+		let performer = Performer()
+		performer.name = name
+		performer.sortOrder = (name.split(separator: " ").last?.string ?? name).uppercased()
+		performer.organization = organization
+		performer.title = title
+		performer.bio = bio
+		performer.yearsAttended = [2026]
+		performer.officialPerformer = true
+		try await performer.save(on: app.db)
+		return performer
+	}
+
+	// MARK: - Tests
+
+	func testOfficialSearch_MatchesOrganization() async throws {
+		try await withApp { app in
+			let user = try await makeUser(app, username: "perf-search-org-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let token = try await makeToken(app, for: user)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			try await makeOfficialPerformer(app, name: "Sam Reich", organization: "Dropout")
+			try await makeOfficialPerformer(app, name: "Someone Else", organization: "Other Company")
+
+			try await app.test(.GET, "/api/v3/performer/official?search=dropout", headers: bearer(token)) { res async throws in
+				XCTAssertEqual(res.status, .ok, "body=\(String(buffer: res.body))")
+				let list = try res.content.decode(PerformerResponseData.self)
+				XCTAssertTrue(list.performers.contains { $0.name == "Sam Reich" },
+					"search=dropout should match performers via organization")
+				XCTAssertFalse(list.performers.contains { $0.name == "Someone Else" },
+					"search=dropout should not match unrelated performers")
+			}
+		}
+	}
+
+	func testOfficialSearch_MatchesTitleAndBio() async throws {
+		try await withApp { app in
+			let user = try await makeUser(app, username: "perf-search-bio-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let token = try await makeToken(app, for: user)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			try await makeOfficialPerformer(app, name: "Jonathan Coulton", title: "Musician")
+			try await makeOfficialPerformer(app, name: "Bio Person", bio: "Known for narwhal-related folk songs.")
+
+			try await app.test(.GET, "/api/v3/performer/official?search=musician", headers: bearer(token)) { res async throws in
+				XCTAssertEqual(res.status, .ok, "body=\(String(buffer: res.body))")
+				let list = try res.content.decode(PerformerResponseData.self)
+				XCTAssertTrue(list.performers.contains { $0.name == "Jonathan Coulton" },
+					"search=musician should match performers via title")
+			}
+
+			try await app.test(.GET, "/api/v3/performer/official?search=narwhal", headers: bearer(token)) { res async throws in
+				XCTAssertEqual(res.status, .ok, "body=\(String(buffer: res.body))")
+				let list = try res.content.decode(PerformerResponseData.self)
+				XCTAssertTrue(list.performers.contains { $0.name == "Bio Person" },
+					"search=narwhal should match performers via bio")
+			}
+		}
+	}
+
+	func testOfficialSearch_NoMatch_ExcludesPerformer() async throws {
+		try await withApp { app in
+			let user = try await makeUser(app, username: "perf-search-none-\(UUID().uuidString.prefix(6))", accessLevel: .verified)
+			let token = try await makeToken(app, for: user)
+			try await app.asyncBoot()
+			try await app.initializeUserCache(app)
+
+			try await makeOfficialPerformer(app, name: "Zzyzx Performer")
+
+			try await app.test(.GET, "/api/v3/performer/official?search=nonexistentsearchterm", headers: bearer(token)) { res async throws in
+				XCTAssertEqual(res.status, .ok, "body=\(String(buffer: res.body))")
+				let list = try res.content.decode(PerformerResponseData.self)
+				XCTAssertFalse(list.performers.contains { $0.name == "Zzyzx Performer" })
+			}
+		}
+	}
+}

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -305,3 +305,7 @@ additive; the existing count fields are unchanged and are now derived from these
   - `GET /api/v3/fez/joined` and `GET /api/v3/fez/owner` now support a `?favorite=true` filter.
 - `POST/DELETE /api/v3/fez/:fez_ID/mute` is no longer rejected for privileged mailboxes (`@moderator`/`@TwitarrTeam`).
 - `FezContentData` gains an optional `firstPost` (`PostContentData`), letting `POST /api/v3/fez/create` create the intial post in the same call.
+
+## Sep 10, 2026
+
+- `GET /api/v3/performer/official` and `GET /api/v3/performer/shadow` now support a `?search=STRING` parameter, full-text searching across each performer's name, organization, title, and bio.


### PR DESCRIPTION
## Problem
There was no way to search for performers by name, organization, job title, or bio. Users needed to be able to, for example, "find all the dropout people" and scope results to either official or shadow performers.

## Solution
Adds a `?search=STRING` query parameter to the official and shadow performer list endpoints, backed by a Postgres full-text search index (tsvector) covering name, organization, title, bio, and alternative names. The performer list web view now includes a search bar to use this feature.

### Details
- `Performer` now conforms to `Searchable`, and a new migration (`CreatePerformerSearchIndexes`) adds a generated tsvector search column plus a helper SQL function to fold `alternative_names` into the indexed text.
- `PerformerController.applyPerformerSearchFilter` sanitizes the `search` query param and applies an OR'd full-text filter across name, organization, title, and bio to both `getOfficialPerformers` and `getShadowPerformers`.
- Added `PerformerSearchTests` covering matches via organization, title, bio, and the no-match case.

Fixes #507