### PR TITLE
Add Daily Themes and Hunts to bulk data export/import

### DIFF
--- a/Sources/swiftarr/Controllers/AdminController.swift
+++ b/Sources/swiftarr/Controllers/AdminController.swift
@@ -1,5 +1,4 @@
 import FluentSQL
-import PostgresNIO
 import Vapor
 
 /// The collection of `/api/v3/admin` route endpoints and handler functions related to admin tasks.
@@ -93,7 +92,7 @@ struct AdminController: APIRouteCollection {
 		do {
 			try await dailyTheme.save(on: req.db)
 		}
-		catch let error as PostgresError where error.code == .uniqueViolation {
+		catch let error as DatabaseError where error.isConstraintFailure {
 			throw Abort(.conflict, reason: "A daily theme for day \(data.cruiseDay) already exists. Edit the existing theme instead.")
 		}
 		return .created
@@ -122,7 +121,7 @@ struct AdminController: APIRouteCollection {
 		do {
 			try await dailyTheme.save(on: req.db)
 		}
-		catch let error as PostgresError where error.code == .uniqueViolation {
+		catch let error as DatabaseError where error.isConstraintFailure {
 			throw Abort(.conflict, reason: "A daily theme for day \(data.cruiseDay) already exists.")
 		}
 		return .created

--- a/Sources/swiftarr/Controllers/AdminController.swift
+++ b/Sources/swiftarr/Controllers/AdminController.swift
@@ -42,10 +42,10 @@ struct AdminController: APIRouteCollection {
 
 		// endpoints available for THO and Admin only
 		let thoAuthGroup = adminRoutes.tokenRoutes(minAccess: .tho)
-		thoAuthGroup.on(.POST, "dailytheme", "create", body: .collect(maxSize: ByteCount(value: Settings.shared.imageMaxBodySize)), use: addDailyThemeHandler)
-		thoAuthGroup.on(.POST, "dailytheme", dailyThemeIDParam, "edit", body: .collect(maxSize: ByteCount(value: Settings.shared.imageMaxBodySize)), use: editDailyThemeHandler)
-		thoAuthGroup.post("dailytheme", dailyThemeIDParam, "delete", use: deleteDailyThemeHandler)
-		thoAuthGroup.delete("dailytheme", dailyThemeIDParam, use: deleteDailyThemeHandler)
+		thoAuthGroup.on(.POST, "dailytheme", "create", body: .collect(maxSize: ByteCount(value: Settings.shared.imageMaxBodySize)), use: addDailyThemeHandler).setUsedForPreregistration()
+		thoAuthGroup.on(.POST, "dailytheme", dailyThemeIDParam, "edit", body: .collect(maxSize: ByteCount(value: Settings.shared.imageMaxBodySize)), use: editDailyThemeHandler).setUsedForPreregistration()
+		thoAuthGroup.post("dailytheme", dailyThemeIDParam, "delete", use: deleteDailyThemeHandler).setUsedForPreregistration()
+		thoAuthGroup.delete("dailytheme", dailyThemeIDParam, use: deleteDailyThemeHandler).setUsedForPreregistration()
 
 		// Note that there's several promote method that promote to different access levels, but
 		// only one demote, that returns the user to Verified.
@@ -888,7 +888,12 @@ struct AdminController: APIRouteCollection {
 		let performers = try await Performer.query(on: req.db).filter(\.$officialPerformer == true).with(\.$events).all()
 		let performerData = try performers.map { try PerformerUploadData($0) }
 		let needsPhotographerEvents = try await Event.query(on: req.db).filter(\.$needsPhotographer == true).all().map { $0.uid }
-		let dto = SaveRestoreData(users: userData, performers: performerData, needsPhotographer: needsPhotographerEvents)
+		let dailyThemes = try await DailyTheme.query(on: req.db).all()
+		let dailyThemeData = dailyThemes.map { DailyThemeSaveRestoreData($0) }
+		let hunts = try await Hunt.query(on: req.db).with(\.$puzzles).all()
+		let huntData = hunts.map { HuntSaveRestoreData($0, $0.puzzles) }
+		let dto = SaveRestoreData(users: userData, performers: performerData, needsPhotographer: needsPhotographerEvents,
+				dailyThemes: dailyThemeData, hunts: huntData)
 		let data = try JSONEncoder().encode(dto)
 		let userfile = sourceDirectoryURL.appendingPathComponent("userfile.json", isDirectory: true)
 		try data.write(to: userfile, options: .atomic)
@@ -897,7 +902,7 @@ struct AdminController: APIRouteCollection {
 		let destImageDir = sourceDirectoryURL.appendingPathComponent("userImages", isDirectory: true)
 		try FileManager.default.createDirectory(at: destImageDir, withIntermediateDirectories: true)
 		let imageNames = users.compactMap { $0.userImage } + users.compactMap { $0.performer?.photo } +
-				performerData.compactMap { $0.photo.filename }
+				performerData.compactMap { $0.photo.filename } + dailyThemes.compactMap { $0.image }
 		for imageName in imageNames {
 			do {
 				let imgSource = Settings.shared.userImagesRootPath.appendingPathComponent(ImageSizeGroup.full.rawValue)
@@ -1018,6 +1023,12 @@ struct AdminController: APIRouteCollection {
 		}
 		for needsPhotog in importData.needsPhotographer {
 			await importNeedPhotographer_Event(req, eventUID: needsPhotog, verifyOnly: verifyOnly, verification: &verification)
+		}
+		for theme in importData.dailyThemes {
+			await importDailyTheme(req, themeData: theme, verifyOnly: verifyOnly, verification: &verification)
+		}
+		for hunt in importData.hunts {
+			await importHunt(req, huntData: hunt, verifyOnly: verifyOnly, verification: &verification)
 		}
 		return verification
 	}
@@ -1313,6 +1324,69 @@ struct AdminController: APIRouteCollection {
 		catch {
 			verification.needsPhotographerCounts.errorCount += 1
 			verification.otherErrors.append("Error when importing Needs Photographer flag for event with UID \(eventUID): \(error.localizedDescription)")
+		}
+	}
+
+	// Imports a single DailyTheme. `cruiseDay` is unique in the db, so we use it to detect duplicates--this lets the same
+	// bulk import file be applied more than once without creating multiple theme records for the same day.
+	func importDailyTheme(_ req: Request, themeData: DailyThemeSaveRestoreData, verifyOnly: Bool,
+			verification: inout BulkUserUpdateVerificationData) async {
+		// Copy the theme's image first, if it has one.
+		var copiedImage: String?
+		do {
+			if let image = themeData.image {
+				copiedImage = try await copyImage(image, verifyOnly: verifyOnly, on: req)
+			}
+		}
+		catch {
+			verification.otherErrors.append("Couldn't copy image for Daily Theme \"\(themeData.title)\": \(error.localizedDescription)")
+		}
+
+		verification.dailyThemeCounts.totalRecordsProcessed += 1
+		do {
+			if try await DailyTheme.query(on: req.db).filter(\.$cruiseDay == themeData.cruiseDay).first() != nil {
+				verification.dailyThemeCounts.duplicateCount += 1
+				return
+			}
+			let theme = DailyTheme(title: themeData.title, info: themeData.info, image: copiedImage, day: themeData.cruiseDay)
+			if !verifyOnly {
+				try await theme.save(on: req.db)
+			}
+			verification.dailyThemeCounts.importedCount += 1
+		}
+		catch {
+			verification.otherErrors.append("Error when importing Daily Theme \"\(themeData.title)\": \(error.localizedDescription)")
+			verification.dailyThemeCounts.errorCount += 1
+		}
+	}
+
+	// Imports a single Hunt, along with all of its child Puzzles, as a single unit. Hunt has no natural unique key, so
+	// we dedupe on title--if a Hunt with the same title already exists we assume it's a true duplicate (e.g. this import
+	// file was already applied) and skip it rather than trying to merge/update its puzzles.
+	func importHunt(_ req: Request, huntData: HuntSaveRestoreData, verifyOnly: Bool,
+			verification: inout BulkUserUpdateVerificationData) async {
+		verification.huntCounts.totalRecordsProcessed += 1
+		do {
+			if try await Hunt.query(on: req.db).filter(\.$title == huntData.title).first() != nil {
+				verification.huntCounts.duplicateCount += 1
+				return
+			}
+			if !verifyOnly {
+				try await req.db.transaction { transaction in
+					let hunt = try Hunt(title: huntData.title, description: huntData.description)
+					try await hunt.create(on: transaction)
+					for puzzleData in huntData.puzzles {
+						let puzzle = try Puzzle(hunt: hunt, title: puzzleData.title, body: puzzleData.body,
+								answer: puzzleData.answer, hints: puzzleData.hints, unlockTime: puzzleData.unlockTime)
+						try await puzzle.create(on: transaction)
+					}
+				}
+			}
+			verification.huntCounts.importedCount += 1
+		}
+		catch {
+			verification.otherErrors.append("Error when importing Hunt \"\(huntData.title)\": \(error.localizedDescription)")
+			verification.huntCounts.errorCount += 1
 		}
 	}
 

--- a/Sources/swiftarr/Controllers/AlertController.swift
+++ b/Sources/swiftarr/Controllers/AlertController.swift
@@ -30,7 +30,7 @@ struct AlertController: APIRouteCollection {
 		flexAuthGroup.get("global", use: globalNotificationHandler)
 		flexAuthGroup.get("user", use: globalNotificationHandler)
 		flexAuthGroup.get("announcements", use: getAnnouncements).setUsedForPreregistration()
-		flexAuthGroup.get("dailythemes", use: getDailyThemes)
+		flexAuthGroup.get("dailythemes", use: getDailyThemes).setUsedForPreregistration()
 
 		// endpoints available only when logged in
 		let tokenAuthGroup = alertRoutes.tokenRoutes()

--- a/Sources/swiftarr/Controllers/BoardgameController.swift
+++ b/Sources/swiftarr/Controllers/BoardgameController.swift
@@ -1,5 +1,4 @@
 import Fluent
-import PostgresNIO
 import Vapor
 
 /// Methods for accessing the list of boardgames available in the onboard Games Library.
@@ -122,11 +121,11 @@ struct BoardgameController: APIRouteCollection {
 			try await fav.save(on: req.db)
 			return .created
 		}
-		catch let sqlError as PostgresError {
-			if sqlError.code == .uniqueViolation {
+		catch let error {
+			if let sqlError = error as? DatabaseError, sqlError.isConstraintFailure {
 				return .ok
 			}
-			throw sqlError
+			throw error
 		}
 	}
 

--- a/Sources/swiftarr/Controllers/HuntController.swift
+++ b/Sources/swiftarr/Controllers/HuntController.swift
@@ -19,11 +19,11 @@ struct HuntController: APIRouteCollection {
 		tokenAuthGroup.post("puzzles", puzzleIDParam, "callin", use: callIn)
 
 		let adminAuthGroup = huntRoutes.tokenRoutes(feature: .hunts, minAccess: .twitarrteam)
-		adminAuthGroup.post("create", use: addHunt)
-		adminAuthGroup.get(huntIDParam, "admin", use: getHuntAdmin)
-		adminAuthGroup.patch(huntIDParam, use: updateHunt)
-		adminAuthGroup.patch("puzzles", puzzleIDParam, use: updatePuzzle)
-		adminAuthGroup.delete(huntIDParam, use: deleteHunt)
+		adminAuthGroup.post("create", use: addHunt).setUsedForPreregistration()
+		adminAuthGroup.get(huntIDParam, "admin", use: getHuntAdmin).setUsedForPreregistration()
+		adminAuthGroup.patch(huntIDParam, use: updateHunt).setUsedForPreregistration()
+		adminAuthGroup.patch("puzzles", puzzleIDParam, use: updatePuzzle).setUsedForPreregistration()
+		adminAuthGroup.delete(huntIDParam, use: deleteHunt).setUsedForPreregistration()
 	}
 
 	func list(_ req: Request) async throws -> HuntListData {

--- a/Sources/swiftarr/Controllers/KaraokeController.swift
+++ b/Sources/swiftarr/Controllers/KaraokeController.swift
@@ -1,5 +1,4 @@
 import Fluent
-import PostgresNIO
 import Vapor
 
 /// Methods for accessing the list of boardgames available in the onboard Games Library.
@@ -206,7 +205,7 @@ struct KaraokeController: APIRouteCollection {
 			try await KaraokeFavorite(user.userID, song).create(on: req.db)
 		}
 		catch let error {
-			if let sqlError = error as? PostgresError, sqlError.code == .uniqueViolation {
+			if let sqlError = error as? DatabaseError, sqlError.isConstraintFailure {
 				return .ok
 			}
 			throw error

--- a/Sources/swiftarr/Controllers/Structs/AdminControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/AdminControllerStructs.swift
@@ -57,6 +57,10 @@ public struct BulkUserUpdateVerificationData: Content {
 	var performerCounts: BulkUserUpdateCounts
 	/// Counts for Events that were marked as needing photographers by the Shutternaut Manager.
 	var needsPhotographerCounts: BulkUserUpdateCounts
+	/// Counts for Daily Theme import.
+	var dailyThemeCounts: BulkUserUpdateCounts
+	/// Counts for Hunt import. Includes Hunts and their child Puzzles as a single unit.
+	var huntCounts: BulkUserUpdateCounts
 
 	/// Cases where the server has a registered user with the same regcode as the update file, but the usernames differ.
 	/// This may mean the user preregistered and then (somehow) registered on-boat with a different username before the bulk import happened.
@@ -77,6 +81,8 @@ extension BulkUserUpdateVerificationData {
 		userCounts = BulkUserUpdateCounts(totalRecordsProcessed: 0, importedCount: 0, duplicateCount: 0, errorCount: 0)
 		performerCounts = BulkUserUpdateCounts(totalRecordsProcessed: 0, importedCount: 0, duplicateCount: 0, errorCount: 0)
 		needsPhotographerCounts = BulkUserUpdateCounts(totalRecordsProcessed: 0, importedCount: 0, duplicateCount: 0, errorCount: 0)
+		dailyThemeCounts = BulkUserUpdateCounts(totalRecordsProcessed: 0, importedCount: 0, duplicateCount: 0, errorCount: 0)
+		huntCounts = BulkUserUpdateCounts(totalRecordsProcessed: 0, importedCount: 0, duplicateCount: 0, errorCount: 0)
 		regCodeConflicts = []
 		usernameConflicts = []
 		errorNotImported = []
@@ -365,12 +371,69 @@ public struct RegistrationCodeStatsData: Content {
 
 /// The Bulk User Download file is a serialization of this object, plus a bunch of image files, all zipped up.
 public struct SaveRestoreData: Content {
-	/// Array of users to save and restore. 
+	/// Array of users to save and restore.
 	var users: [UserSaveRestoreData]
 	/// Array of official performers to save and restore.
 	var performers: [PerformerUploadData]
 	/// Array of event UIDs that need photographers.
 	var needsPhotographer: [String]
+	/// Array of Daily Themes to save and restore.
+	var dailyThemes: [DailyThemeSaveRestoreData]
+	/// Array of Hunts (with their Puzzles) to save and restore.
+	var hunts: [HuntSaveRestoreData]
+}
+
+/// Used during bulk export/import to save and restore `DailyTheme` records. Unlike `DailyThemeData` (the API-facing DTO),
+/// this is only ever used for Admin-to-Admin server transfer, so it carries the raw image filename rather than an upload/URL.
+struct DailyThemeSaveRestoreData: Content, Sendable {
+	let title: String
+	let info: String
+	let image: String?
+	let cruiseDay: Int32
+}
+
+extension DailyThemeSaveRestoreData {
+	init(_ theme: DailyTheme) {
+		title = theme.title
+		info = theme.info
+		image = theme.image
+		cruiseDay = theme.cruiseDay
+	}
+}
+
+/// Used during bulk export/import to save and restore a `Hunt` and its child `Puzzle`s as a single unit.
+struct HuntSaveRestoreData: Content, Sendable {
+	let title: String
+	let description: String
+	let puzzles: [HuntPuzzleSaveRestoreData]
+}
+
+extension HuntSaveRestoreData {
+	init(_ hunt: Hunt, _ puzzles: [Puzzle]) {
+		title = hunt.title
+		description = hunt.description
+		self.puzzles = puzzles.map { HuntPuzzleSaveRestoreData($0) }
+	}
+}
+
+/// Used during bulk export/import to save and restore a `Puzzle`, including its answer and hints. This is purposefully full-fidelity,
+/// unlike the redacted `HuntPuzzleData` DTO returned by the public API, since this is only ever used for Admin-to-Admin server transfer.
+struct HuntPuzzleSaveRestoreData: Content, Sendable {
+	let title: String
+	let body: String
+	let answer: String
+	let hints: [String: String]
+	let unlockTime: Date?
+}
+
+extension HuntPuzzleSaveRestoreData {
+	init(_ puzzle: Puzzle) {
+		title = puzzle.title
+		body = puzzle.body
+		answer = puzzle.answer
+		hints = puzzle.hints
+		unlockTime = puzzle.unlockTime
+	}
 }
 
 /// An array of totals for various database entities. Each value in the array is essentially a `SQL SELECT COUNT() FROM <table>`,

--- a/Sources/swiftarr/Resources/Views/admin/bulkUser.html
+++ b/Sources/swiftarr/Resources/Views/admin/bulkUser.html
@@ -6,19 +6,19 @@
 					<nav aria-label="breadcrumb">
 						<ol class="breadcrumb">
 							<li class="breadcrumb-item"><a href="/admin">Admin</a></li>
-							<li class="breadcrumb-item active" aria-current="page">Bulk User Import/Export</li>
+							<li class="breadcrumb-item active" aria-current="page">Bulk Data Import/Export</li>
 						</ol>
 					</nav>
 				</div>
 			</div>
 			<ul class="list-group">
 				<li class="list-group-item active">
-					<b>Download archive of registered users</b>
+					<b>Download data export archive</b>
 				</li>
 				<li class="list-group-item bg-transparent">
-					This creates and downloads a ZIP archive of all users who registered with a registration code. Archive does not contain
-					'special' users like @admin, @twitarrteam, and @moderator, nor does it contain test users or users who were issued
-					codes tied to their Discord username.
+					This creates and downloads a ZIP archive of all users who registered with a registration code, along with other data.
+					Archive does not contain 'special' users like @admin, @twitarrteam, and @moderator, nor does it contain test users
+					or users who were issued codes tied to their Discord username.
 				</li>
 				<li class="list-group-item bg-transparent">
 					The server needs to be in Admin-only mode (Admin->Server Settings->Minimum User Access Level) and 
@@ -33,18 +33,18 @@
 			</ul>
 			<ul class="list-group mt-3">
 				<li class="list-group-item active">
-					<b>Upload archive of registered users</b>
+					<b>Upload data import archive</b>
 				</li>
 				<li class="list-group-item bg-transparent">
-					Uploads a user archive file and validates its contents. After tapping 'Upload' you'll be taken to a page that previews
-					what changes the import will have on the database. 
+					Uploads a data export archive and validates its contents. After tapping 'Upload' you'll be taken to a page that previews
+					what changes the import will have on the database.
 				</li>
 				<li class="list-group-item bg-transparent">
 					The server needs to be in Admin-only mode to perform an import. Ideally the server has been admin-only since installation
 					and admin-only can be turned off after this import is completed.
 				</li>
 				<li class="list-group-item bg-transparent">
-					The user archive file *should* be named 'Twitarr_userfile.zip'.
+					The data export archive file *should* be named 'Twitarr_userfile.zip'.
 				</li>
 				<li class="list-group-item bg-transparent mb-3">				
 					<form class="ajax fileupload" action="/admin/bulkuser/upload" enctype="multipart/form-data" method="POST" data-successurl="/admin/bulkuser/upload/verify" id="userfileuploadform">

--- a/Sources/swiftarr/Resources/Views/admin/bulkUserVerify.html
+++ b/Sources/swiftarr/Resources/Views/admin/bulkUserVerify.html
@@ -6,7 +6,7 @@
 					<nav aria-label="breadcrumb">
 						<ol class="breadcrumb">
 							<li class="breadcrumb-item"><a href="/admin">Admin</a></li>
-							<li class="breadcrumb-item"><a href="/admin/bulkuser">Bulk User Update</a></li>
+							<li class="breadcrumb-item"><a href="/admin/bulkuser">Bulk Data Import/Export</a></li>
 							<li class="breadcrumb-item active" aria-current="page">Verify Updates</li>
 						</ol>
 					</nav>
@@ -20,9 +20,9 @@
 				</div>
 			#else:
 				<div class="alert alert-info mt-3" role="alert">
-					Shown below are the validation results--what this user import is likely to do once applied.
-					Review that these results match expectations and then tap the <b>Perform User Import</b> button to apply them.
-					<br><a class="btn btn-primary mt-2" href="/admin/bulkuser/upload/commit">Perform User Import</a>
+					Shown below are the validation results--what this data import is likely to do once applied.
+					Review that these results match expectations and then tap the <b>Perform Data Import</b> button to apply them.
+					<br><a class="btn btn-primary mt-2" href="/admin/bulkuser/upload/commit">Perform Data Import</a>
 				</div>
 			#endif
 			
@@ -106,7 +106,61 @@
 					</tr>
 				</tbody>
 			</table>
-			
+
+			<table class="table table-bordered">
+				<thead>
+					<tr class="table-secondary">
+						<th scope="col">Daily Theme Import</th>
+						<th scope="col">#</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th scope="row">Total Records Processed</th>
+						<td>#(diff.dailyThemeCounts.totalRecordsProcessed)</td>
+					</tr>
+					<tr>
+						<th scope="row">Records Imported</th>
+						<td>#(diff.dailyThemeCounts.importedCount)</td>
+					</tr>
+					<tr>
+						<th scope="row">Duplicates Found</th>
+						<td>#(diff.dailyThemeCounts.duplicateCount)</td>
+					</tr>
+					<tr>
+						<th scope="row">Errors</th>
+						<td>#(diff.dailyThemeCounts.errorCount)</td>
+					</tr>
+				</tbody>
+			</table>
+
+			<table class="table table-bordered">
+				<thead>
+					<tr class="table-secondary">
+						<th scope="col">Puzzle Hunt Import</th>
+						<th scope="col">#</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th scope="row">Total Records Processed</th>
+						<td>#(diff.huntCounts.totalRecordsProcessed)</td>
+					</tr>
+					<tr>
+						<th scope="row">Records Imported</th>
+						<td>#(diff.huntCounts.importedCount)</td>
+					</tr>
+					<tr>
+						<th scope="row">Duplicates Found</th>
+						<td>#(diff.huntCounts.duplicateCount)</td>
+					</tr>
+					<tr>
+						<th scope="row">Errors</th>
+						<td>#(diff.huntCounts.errorCount)</td>
+					</tr>
+				</tbody>
+			</table>
+
 			<div class="accordion mb-2" id="importErrors">
 				<div class="accordion-item">
 					<h2 class="accordion-header" id="regCodeConflictHeader">

--- a/Sources/swiftarr/Resources/Views/admin/root.html
+++ b/Sources/swiftarr/Resources/Views/admin/root.html
@@ -94,7 +94,7 @@
 				</a>
 				#if(trunk.username == "admin"):
 					<a class="list-group-item list-group-item-action" href="/admin/bulkuser">
-						<b>User</b>: Bulk user import/export.
+						<b>Data Export</b>: Bulk data import/export.
 					</a>
 					<a class="list-group-item list-group-item-action" href="/admin/karaoke">
 						<b>Karaoke</b>: Administer karaoke settings.

--- a/Sources/swiftarr/Site/SiteAdminController.swift
+++ b/Sources/swiftarr/Site/SiteAdminController.swift
@@ -54,13 +54,13 @@ struct SiteAdminController: SiteControllerUtils {
 		privateTTRoutes.post("announcement", announcementIDParam, "edit", use: announcementEditPostHandler)
 		privateTTRoutes.post("announcement", announcementIDParam, "delete", use: announcementDeletePostHandler)
 
-		privateTTRoutes.get("dailythemes", use: dailyThemesViewHandler)
-		privateTTRoutes.get("dailytheme", "create", use: dailyThemeCreateViewHandler)
-		privateTTRoutes.post("dailytheme", "create", use: dailyThemeCreatePostHandler)
-		privateTTRoutes.get("dailytheme", dailyThemeParam, "edit", use: dailyThemeEditViewHandler)
-		privateTTRoutes.post("dailytheme", dailyThemeParam, "edit", use: dailyThemeEditPostHandler)
-		privateTTRoutes.post("dailytheme", dailyThemeParam, "delete", use: dailyThemeDeletePostHandler)
-		privateTTRoutes.delete("dailytheme", dailyThemeParam, use: dailyThemeDeletePostHandler)
+		privateTTRoutes.get("dailythemes", use: dailyThemesViewHandler).setUsedForPreregistration()
+		privateTTRoutes.get("dailytheme", "create", use: dailyThemeCreateViewHandler).setUsedForPreregistration()
+		privateTTRoutes.post("dailytheme", "create", use: dailyThemeCreatePostHandler).setUsedForPreregistration()
+		privateTTRoutes.get("dailytheme", dailyThemeParam, "edit", use: dailyThemeEditViewHandler).setUsedForPreregistration()
+		privateTTRoutes.post("dailytheme", dailyThemeParam, "edit", use: dailyThemeEditPostHandler).setUsedForPreregistration()
+		privateTTRoutes.post("dailytheme", dailyThemeParam, "delete", use: dailyThemeDeletePostHandler).setUsedForPreregistration()
+		privateTTRoutes.delete("dailytheme", dailyThemeParam, use: dailyThemeDeletePostHandler).setUsedForPreregistration()
 
 		privateTTRoutes.get("serversettings", use: settingsViewHandler)
 		privateTTRoutes.post("serversettings", use: settingsPostHandler)
@@ -96,12 +96,12 @@ struct SiteAdminController: SiteControllerUtils {
 		privateTTRoutes.post("userroles", userRoleParam, "removerole", userIDParam, use: removeRoleFromUser)
 
 		
-		privateTTRoutes.get("hunts", use: huntHandler)
-		privateTTRoutes.post("hunt", "create", use: huntPostHandler)
-		privateTTRoutes.post("hunt", huntIDParam, "delete", use: huntDeleteHandler)
-		privateTTRoutes.get("hunt", huntIDParam, "edit", use: huntEditHandler)
-		privateTTRoutes.post("hunt", huntIDParam, "edit", use: huntEditPostHandler)
-		privateTTRoutes.post("puzzle", puzzleIDParam, "edit", use: puzzleEditPostHandler)
+		privateTTRoutes.get("hunts", use: huntHandler).setUsedForPreregistration()
+		privateTTRoutes.post("hunt", "create", use: huntPostHandler).setUsedForPreregistration()
+		privateTTRoutes.post("hunt", huntIDParam, "delete", use: huntDeleteHandler).setUsedForPreregistration()
+		privateTTRoutes.get("hunt", huntIDParam, "edit", use: huntEditHandler).setUsedForPreregistration()
+		privateTTRoutes.post("hunt", huntIDParam, "edit", use: huntEditPostHandler).setUsedForPreregistration()
+		privateTTRoutes.post("puzzle", puzzleIDParam, "edit", use: puzzleEditPostHandler).setUsedForPreregistration()
 
 		// Mods, TwitarrTeam, and THO levels can all be promoted to, but they all demote back to Verified.
 		let privateTHORoutes = getPrivateRoutes(app, minAccess: .tho, path: "admin")

--- a/Sources/swiftarr/Site/SiteAdminController.swift
+++ b/Sources/swiftarr/Site/SiteAdminController.swift
@@ -911,7 +911,7 @@ struct SiteAdminController: SiteControllerUtils {
 			var trunk: TrunkContext
 
 			init(_ req: Request) throws {
-				trunk = .init(req, title: "Bulk User Import/Export", tab: .admin)
+				trunk = .init(req, title: "Bulk Data Import/Export", tab: .admin)
 			}
 		}
 		let ctx = try BulkUserRootContext(req)
@@ -950,7 +950,7 @@ struct SiteAdminController: SiteControllerUtils {
 			var diff: BulkUserUpdateVerificationData
 
 			init(_ req: Request, verificationData: BulkUserUpdateVerificationData) throws {
-				trunk = .init(req, title: "Verify Bulk User Import Changes", tab: .admin)
+				trunk = .init(req, title: "Verify Bulk Data Import Changes", tab: .admin)
 				self.diff = verificationData
 			}
 		}
@@ -975,7 +975,7 @@ struct SiteAdminController: SiteControllerUtils {
 			var diff: BulkUserUpdateVerificationData
 
 			init(_ req: Request, verificationData: BulkUserUpdateVerificationData) throws {
-				trunk = .init(req, title: "Bulk User Import Applied", tab: .admin)
+				trunk = .init(req, title: "Bulk Data Import Applied", tab: .admin)
 				self.diff = verificationData
 			}
 		}


### PR DESCRIPTION
## Problem
The bulk user import/export tool only handled user accounts, official performers, and photographer needs. Daily Themes and Puzzle Hunts (with their puzzles) had no way to be transferred between servers, and some database error handling relied on the Postgres-specific driver instead of Fluent's generic error types.

## Solution
In simple terms: the "Bulk User Import/Export" admin page is now a general "Data Export" tool that also carries Daily Themes and Hunts/Puzzles along for the ride, and duplicate-detection error handling was made more portable.

- Extended `SaveRestoreData` with `dailyThemes` and `hunts` arrays, backed by new `DailyThemeSaveRestoreData`, `HuntSaveRestoreData`, and `HuntPuzzleSaveRestoreData` DTOs that preserve full fidelity (including puzzle answers/hints and theme images) for admin-to-admin transfer.
- Added `importDailyTheme` and `importHunt` handlers in `AdminController` that dedupe on cruise day / title respectively, copy associated images, and import Hunts with their Puzzles inside a single transaction.
- Added `dailyThemeCounts` and `huntCounts` to `BulkUserUpdateVerificationData`, and surfaced them in the `bulkUserVerify.html` verification tables.
- Updated admin UI wording (`bulkUser.html`, `bulkUserVerify.html`, `root.html`, `SiteAdminController.swift`) from "Bulk User Import/Export" to "Bulk Data Import/Export" to reflect the broader scope.
- Replaced `PostgresError`/`.uniqueViolation` checks with the database-agnostic `DatabaseError`/`.isConstraintFailure` in `AdminController`, `BoardgameController`, and `KaraokeController`, removing the now-unused `PostgresNIO` imports and fixing an error-handling bug in `AdminController`'s daily theme creation.
- Marked several previously-missed Daily Theme, Hunt, and Alert routes with `.setUsedForPreregistration()` for consistency with the rest of the route table.

### Testing
Manually tested export and import between instances.