### PR TITLE
Expose table counts as Prometheus metrics

### DIFF
--- a/Sources/swiftarr/Controllers/AdminController.swift
+++ b/Sources/swiftarr/Controllers/AdminController.swift
@@ -280,68 +280,7 @@ struct AdminController: APIRouteCollection {
 	///  More sophisticated servers run an operation like this on a cronjob and analyze the results each time to check that recent db activity matches expectations.
 	///  Mostly this is just a quick way for us to check usage.
 	func serverRollupCounts(_ req: Request) async throws -> ServerRollupData {
-		let counts = try await withThrowingTaskGroup(of: (countType: ServerRollupData.CountType, value: Int32).self) { group in
-			let tasks: [ServerRollupData.CountType : EventLoopFuture<Int>] = [
-					// User
-					.user :  User.query(on: req.db).count(),
-					.profileEdit: ProfileEdit.query(on: req.db).count(),
-					.userNote: UserNote.query(on: req.db).count(),
-					.alertword: AlertWord.query(on: req.db).count(),
-					.muteword: MuteWord.query(on: req.db).count(),
-					.photoStream: StreamPhoto.query(on: req.db).count(),
-
-					// LFGs and Seamails
-					.lfg: FriendlyFez.query(on: req.db).filter(\.$fezType ~~ FezType.lfgTypes).count(),
-					.lfgParticipant: FezParticipant.query(on: req.db)
-							.join(FriendlyFez.self, on: \FezParticipant.$fez.$id == \FriendlyFez.$id)
-							.filter(FriendlyFez.self, \.$fezType  ~~ FezType.lfgTypes).count(),
-					.lfgPost: FezPost.query(on: req.db).join(FriendlyFez.self, on: \FezPost.$fez.$id == \FriendlyFez.$id)
-							.filter(FriendlyFez.self, \.$fezType ~~ FezType.lfgTypes).count(),
-					.seamail: FriendlyFez.query(on: req.db).filter(\.$fezType ~~ FezType.seamailTypes).count(),
-					.seamailPost: FezPost.query(on: req.db).join(FriendlyFez.self, on: \FezPost.$fez.$id == \FriendlyFez.$id)
-							.filter(FriendlyFez.self, \.$fezType ~~ FezType.seamailTypes).count(),
-					.privateEvent: FriendlyFez.query(on: req.db).filter(\.$fezType == FezType.privateEvent).count(),
-					.personalEvent: FriendlyFez.query(on: req.db).filter(\.$fezType == FezType.personalEvent).count(),
-
-					// Forums
-					.forum: Forum.query(on: req.db).count(),
-					.forumPost: ForumPost.query(on: req.db).count(),
-					.forumPostEdit: ForumPostEdit.query(on: req.db).count(),
-					.forumPostLike: PostLikes.query(on: req.db).filter(\.$likeType != nil).count(),
-					
-					// Games and Karaoke
-					.karaokePlayedSong: KaraokePlayedSong.query(on: req.db).count(),
-					.microKaraokeSnippet: MKSnippet.query(on: req.db).count(),
-					
-					// Favorites
-					.userFavorite: UserFavorite.query(on: req.db).count(),
-					.eventFavorite: EventFavorite.query(on: req.db).count(),
-					.forumFavorite: ForumReaders.query(on: req.db).filter(\.$isFavorite == true).count(),
-					.forumPostFavorite: PostLikes.query(on: req.db).filter(\.$isFavorite == true).count(),
-					.boardgameFavorite: BoardgameFavorite.query(on: req.db).count(),
-					.karaokeFavorite: KaraokeFavorite.query(on: req.db).count(),
-
-					// Moderation
-					.report: Report.query(on: req.db).count(),
-					.moderationAction: ModeratorAction.query(on: req.db).count(),
-
-					// Quartermaster
-					.quartermasterItem: QuartermasterItem.query(on: req.db).count(),
-					.quartermasterItemEdit: QuartermasterItemEdit.query(on: req.db).count(),
-			]
-			
-			for (key, task) in tasks {
-				group.addTask {
-					return try await (key, Int32(task.get()))
-				}
-			}
-			var result = [Int32](repeating: 0, count: tasks.count)
-			for try await (key, value) in group {
-				result[key.rawValue] = Int32(value)
-			}
-			return result
-		}
-		return ServerRollupData(counts: counts)
+		return try await ServerRollupData.computeRollupCounts(on: req.db)
 	}
 	
 	

--- a/Sources/swiftarr/Controllers/Structs/AdminControllerStructs.swift
+++ b/Sources/swiftarr/Controllers/Structs/AdminControllerStructs.swift
@@ -1,3 +1,4 @@
+import Fluent
 import Vapor
 
 /// structs in this file should only be used by Admin APIs, that is: API calls that require administrator access.
@@ -491,6 +492,109 @@ struct ServerRollupData: Content {
 		// Quartermaster
 		case quartermasterItem
 		case quartermasterItemEdit
+
+		/// A short, stable, snake_case name for this count type, suitable for use as a Prometheus label value.
+		var metricName: String {
+			switch self {
+			case .user: return "user"
+			case .profileEdit: return "profile_edit"
+			case .userNote: return "user_note"
+			case .alertword: return "alert_word"
+			case .muteword: return "mute_word"
+			case .photoStream: return "photo_stream"
+			case .lfg: return "lfg"
+			case .lfgParticipant: return "lfg_participant"
+			case .lfgPost: return "lfg_post"
+			case .seamail: return "seamail"
+			case .seamailPost: return "seamail_post"
+			case .privateEvent: return "private_event"
+			case .personalEvent: return "personal_event"
+			case .forum: return "forum"
+			case .forumPost: return "forum_post"
+			case .forumPostEdit: return "forum_post_edit"
+			case .forumPostLike: return "forum_post_like"
+			case .karaokePlayedSong: return "karaoke_played_song"
+			case .microKaraokeSnippet: return "micro_karaoke_snippet"
+			case .userFavorite: return "user_favorite"
+			case .eventFavorite: return "event_favorite"
+			case .forumFavorite: return "forum_favorite"
+			case .forumPostFavorite: return "forum_post_favorite"
+			case .boardgameFavorite: return "boardgame_favorite"
+			case .karaokeFavorite: return "karaoke_favorite"
+			case .report: return "report"
+			case .moderationAction: return "moderation_action"
+			case .quartermasterItem: return "quartermaster_item"
+			case .quartermasterItemEdit: return "quartermaster_item_edit"
+			}
+		}
+	}
+
+	/// Runs the full set of table-count queries and returns a `ServerRollupData`. Shared by the
+	/// on-demand `GET /api/v3/admin/rollup` endpoint and `TableCountsJob`, which caches the results
+	/// as Prometheus gauges on a timer so the counts don't need to be recomputed on every metrics scrape.
+	static func computeRollupCounts(on db: Database) async throws -> ServerRollupData {
+		let counts = try await withThrowingTaskGroup(of: (countType: CountType, value: Int32).self) { group in
+			let tasks: [CountType: EventLoopFuture<Int>] = [
+				// User
+				.user: User.query(on: db).count(),
+				.profileEdit: ProfileEdit.query(on: db).count(),
+				.userNote: UserNote.query(on: db).count(),
+				.alertword: AlertWord.query(on: db).count(),
+				.muteword: MuteWord.query(on: db).count(),
+				.photoStream: StreamPhoto.query(on: db).count(),
+
+				// LFGs and Seamails
+				.lfg: FriendlyFez.query(on: db).filter(\.$fezType ~~ FezType.lfgTypes).count(),
+				.lfgParticipant: FezParticipant.query(on: db)
+					.join(FriendlyFez.self, on: \FezParticipant.$fez.$id == \FriendlyFez.$id)
+					.filter(FriendlyFez.self, \.$fezType ~~ FezType.lfgTypes).count(),
+				.lfgPost: FezPost.query(on: db).join(FriendlyFez.self, on: \FezPost.$fez.$id == \FriendlyFez.$id)
+					.filter(FriendlyFez.self, \.$fezType ~~ FezType.lfgTypes).count(),
+				.seamail: FriendlyFez.query(on: db).filter(\.$fezType ~~ FezType.seamailTypes).count(),
+				.seamailPost: FezPost.query(on: db).join(FriendlyFez.self, on: \FezPost.$fez.$id == \FriendlyFez.$id)
+					.filter(FriendlyFez.self, \.$fezType ~~ FezType.seamailTypes).count(),
+				.privateEvent: FriendlyFez.query(on: db).filter(\.$fezType == FezType.privateEvent).count(),
+				.personalEvent: FriendlyFez.query(on: db).filter(\.$fezType == FezType.personalEvent).count(),
+
+				// Forums
+				.forum: Forum.query(on: db).count(),
+				.forumPost: ForumPost.query(on: db).count(),
+				.forumPostEdit: ForumPostEdit.query(on: db).count(),
+				.forumPostLike: PostLikes.query(on: db).filter(\.$likeType != nil).count(),
+
+				// Games and Karaoke
+				.karaokePlayedSong: KaraokePlayedSong.query(on: db).count(),
+				.microKaraokeSnippet: MKSnippet.query(on: db).count(),
+
+				// Favorites
+				.userFavorite: UserFavorite.query(on: db).count(),
+				.eventFavorite: EventFavorite.query(on: db).count(),
+				.forumFavorite: ForumReaders.query(on: db).filter(\.$isFavorite == true).count(),
+				.forumPostFavorite: PostLikes.query(on: db).filter(\.$isFavorite == true).count(),
+				.boardgameFavorite: BoardgameFavorite.query(on: db).count(),
+				.karaokeFavorite: KaraokeFavorite.query(on: db).count(),
+
+				// Moderation
+				.report: Report.query(on: db).count(),
+				.moderationAction: ModeratorAction.query(on: db).count(),
+
+				// Quartermaster
+				.quartermasterItem: QuartermasterItem.query(on: db).count(),
+				.quartermasterItemEdit: QuartermasterItemEdit.query(on: db).count(),
+			]
+
+			for (key, task) in tasks {
+				group.addTask {
+					return try await (key, Int32(task.get()))
+				}
+			}
+			var result = [Int32](repeating: 0, count: tasks.count)
+			for try await (key, value) in group {
+				result[key.rawValue] = value
+			}
+			return result
+		}
+		return ServerRollupData(counts: counts)
 	}
 }
 

--- a/Sources/swiftarr/Jobs/TableCountsJob.swift
+++ b/Sources/swiftarr/Jobs/TableCountsJob.swift
@@ -1,0 +1,26 @@
+import Fluent
+import Metrics
+import Queues
+import Vapor
+
+/// Job that periodically recomputes the table-count rollup (same data as `GET /api/v3/admin/rollup`)
+/// and stores it as Prometheus gauges. Runs on its own timer, independent of how often Prometheus
+/// scrapes `/api/v3/client/metrics`, so a scrape never triggers a fresh round of COUNT queries.
+///
+/// Also invoked once at startup (see `postBootConfigure`) so the gauges aren't simply absent from
+/// `/api/v3/client/metrics` for up to a full schedule interval after every restart.
+struct TableCountsJob: AsyncScheduledJob {
+	func run(context: QueueContext) async throws {
+		try await Self.recordTableCounts(on: context.application.db, logger: context.logger)
+	}
+
+	static func recordTableCounts(on db: Database, logger: Logger) async throws {
+		logger.debug("Starting TableCountsJob")
+		let rollup = try await ServerRollupData.computeRollupCounts(on: db)
+		for countType in ServerRollupData.CountType.allCases {
+			let gauge = Gauge(label: "swiftarr_table_row_count", dimensions: [("table", countType.metricName)])
+			gauge.record(Int64(rollup.counts[countType.rawValue]))
+		}
+		logger.debug("Finished TableCountsJob")
+	}
+}

--- a/Sources/swiftarr/configure.swift
+++ b/Sources/swiftarr/configure.swift
@@ -91,6 +91,16 @@ struct SwiftarrConfigurator {
 		// As a lifecycle handler, our 'didBoot' callback got put in a list with Redis's, and we had to hope Vapor called them first.
 		try await app.initializeUserCache(app)
 
+		// Populate the table-count gauges immediately so they aren't simply missing from
+		// /api/v3/client/metrics for up to a full schedule interval after every restart.
+		// A failure here shouldn't block startup; the scheduled job will retry on its own cadence.
+		do {
+			try await TableCountsJob.recordTableCounts(on: app.db, logger: app.logger)
+		}
+		catch {
+			app.logger.notice("Initial TableCountsJob run failed: \(String(reflecting: error))")
+		}
+
 		// Add custom commands
 		configureCommands(app)
 	}
@@ -552,6 +562,12 @@ struct SwiftarrConfigurator {
 		}
 		app.queues.schedule(UserEventNotificationJob()).minutely().at(0)
 		app.queues.schedule(UpdateRedisJob()).daily().at(.init(integerLiteral: Settings.shared.nightlyJobHour), 0)
+		// Queues has no native "every N minutes" builder, so register the same job on 6 fixed
+		// minute-of-hour offsets to approximate a 10-minute cadence.
+		// A scrape before this has run for the first time is typically treated as "no data".
+		for minute in stride(from: 0, to: 60, by: 10) {
+			app.queues.schedule(TableCountsJob()).hourly().at(.init(integerLiteral: minute))
+		}
 		app.queues.add(OnDemandScheduleUpdateJob())
 		app.queues.add(OnDemandUpdateRedisJob())
 		try app.queues.startInProcessJobs(on: .default)


### PR DESCRIPTION
## Problem
We track counts of key database tables (users, LFGs, forums, favorites, etc.) via the admin rollup endpoint, but that data is only available on-demand and isn't exposed to our metrics/monitoring stack, so we can't graph or alert on it in Prometheus.

## Solution
We extracted the existing rollup-count logic from `AdminController` into a shared `ServerRollupData.computeRollupCounts(on:)` function, then added a new `TableCountsJob` that runs on a ~10-minute schedule, recomputes the counts, and records each one as a `swiftarr_table_row_count` Prometheus gauge (labeled by table). The job also runs once at startup so the gauges aren't missing from `/api/v3/client/metrics` for a full interval after every restart. The admin `GET /api/v3/admin/rollup` endpoint behavior is unchanged, just now backed by the shared function.

Fixes #505