### PR TITLE
Mark chats read for live-rendered websocket messages

### DIFF
--- a/Sources/swiftarr/Controllers/FezController.swift
+++ b/Sources/swiftarr/Controllers/FezController.swift
@@ -66,6 +66,7 @@ struct FezController: APIRouteCollection {
 		tokenAuthGroup.on(.POST, "create", body: .collect(maxSize: ByteCount(value: Settings.shared.imageMaxBodySize)), use: createHandler)
 		tokenAuthGroup.on(.POST, fezIDParam, "post", body: .collect(maxSize: ByteCount(value: Settings.shared.imageMaxBodySize)), use: postAddHandler)
 		tokenAuthGroup.webSocket(fezIDParam, "socket", onUpgrade: createFezSocket)
+		tokenAuthGroup.post(fezIDParam, "markRead", use: fezMarkReadHandler)
 		tokenAuthGroup.post(fezIDParam, "cancel", use: cancelHandler)
 		tokenAuthGroup.post(fezIDParam, "join", use: joinHandler)
 		tokenAuthGroup.post(fezIDParam, "unjoin", use: unjoinHandler)
@@ -338,7 +339,33 @@ struct FezController: APIRouteCollection {
 		}
 		return fezData
 	}
-	
+
+	/// `POST /api/v3/fez/ID/markRead`
+	///
+	/// Mark the specified `FriendlyFez` (Seamail, LFG, or Private Event chat) as read for the current user.
+	/// This sets the user's read count to the fez's current post count, effectively marking all posts as
+	/// read without requiring the user to re-fetch them. Intended for chats whose latest post(s) were
+	/// already rendered live via websocket, so the caller doesn't have to re-request the thread just to
+	/// clear its unread state.
+	///
+	/// - Parameter fezID: in URL path
+	/// - Throws: 404 error if the fez is not available, or if the user is not a member.
+	/// - Returns: 201 Created if the read count advanced; 200 OK if already marked as read.
+	func fezMarkReadHandler(_ req: Request) async throws -> HTTPStatus {
+		let cacheUser = try req.auth.require(UserCacheData.self)
+		let fez = try await FriendlyFez.findFromParameter(fezIDParam, on: req)
+		guard let pivot = try await getUserPivot(lfg: fez, userID: cacheUser.userID, on: req.db) else {
+			throw Abort(.notFound, reason: "user is not member of \(fez.fezType.lfgLabel)")
+		}
+		if pivot.readCount + pivot.hiddenCount >= fez.postCount {
+			return .ok
+		}
+		pivot.readCount = fez.postCount - pivot.hiddenCount
+		try await pivot.save(on: req.db)
+		try await markNotificationViewed(user: cacheUser, type: .chatUnreadMsg(fez.requireID(), fez.fezType), on: req)
+		return .created
+	}
+
 	/// `GET /api/v3/fez/former`
 	/// 
 	/// **Query Parameters:**

--- a/Sources/swiftarr/Resources/Assets/js/swiftarrMessages.js
+++ b/Sources/swiftarr/Resources/Assets/js/swiftarrMessages.js
@@ -23,6 +23,10 @@ function startLiveMessageStream() {
 				postCountSpan.innerText = String(postCount + 1);
 			}
 		}
+		// The post was just rendered live into the page, so tell the server we've read it too.
+		// This keeps the "new"/unread badges from lighting up for content the user already saw.
+		let markReadURL = socketURL.replace(/\/socket$/, '/markRead');
+		fetch(markReadURL, { method: 'POST' });
 	};
 
 	ws.onclose = () => {

--- a/Sources/swiftarr/Site/SiteChatController.swift
+++ b/Sources/swiftarr/Site/SiteChatController.swift
@@ -200,6 +200,7 @@ struct SiteFriendlyFezController: SiteControllerUtils {
 		privateRoutes.post(fezIDParam, "favorite", use: fezAddFavoritePostHandler)
 		privateRoutes.delete(fezIDParam, "favorite", use: fezRemoveFavoritePostHandler)
 		privateRoutes.post(fezIDParam, "post", use: fezThreadPostHandler)
+		privateRoutes.post(fezIDParam, "markRead", use: fezMarkReadPostHandler)
 		privateRoutes.post("post", postIDParam, "delete", use: fezPostDeleteHandler)
 		privateRoutes.delete("post", postIDParam, use: fezPostDeleteHandler)
 		privateRoutes.post(fezIDParam, "cancel", use: fezCancelPostHandler)
@@ -453,6 +454,18 @@ struct SiteFriendlyFezController: SiteControllerUtils {
 		let postContent = postStruct.buildPostContentData()
 		try await apiQuery(req, endpoint: "/fez/\(fezID)/post", method: .POST, encodeContent: postContent)
 		return .created
+	}
+
+	// POST /lfg/:fez_ID/markRead
+	//
+	// Marks an LFG/Private Event chat as read for the current user. Used by the live-message websocket JS
+	// to clear unread state for posts that were already rendered into the page live.
+	func fezMarkReadPostHandler(_ req: Request) async throws -> HTTPStatus {
+		guard let fezID = req.parameters.get(fezIDParam.paramString)?.percentEncodeFilePathEntry() else {
+			throw Abort(.badRequest, reason: "Missing fez_id")
+		}
+		let response = try await apiQuery(req, endpoint: "/fez/\(fezID)/markRead", method: .POST)
+		return response.status
 	}
 
 	// POST /lfg/post/:fezPost_ID/delete

--- a/Sources/swiftarr/Site/SiteSeamailController.swift
+++ b/Sources/swiftarr/Site/SiteSeamailController.swift
@@ -111,6 +111,7 @@ struct SiteSeamailController: SiteControllerUtils {
 		privateRoutes.post("seamail", "create", use: seamailCreatePostHandler)
 		privateRoutes.post("seamail", fezIDParam, use: seamailViewPageHandler)
 		privateRoutes.post("seamail", fezIDParam, "post", use: seamailThreadPostHandler)
+		privateRoutes.post("seamail", fezIDParam, "markRead", use: seamailMarkReadPostHandler)
 		privateRoutes.post("seamail", fezIDParam, "mute", use: seamailAddMutePostHandler)
 		privateRoutes.delete("seamail", fezIDParam, "mute", use: seamailRemoveMutePostHandler)
 		privateRoutes.post("seamail", fezIDParam, "favorite", use: seamailAddFavoritePostHandler)
@@ -419,6 +420,18 @@ struct SiteSeamailController: SiteControllerUtils {
 		let postContent = postStruct.buildPostContentData()
 		try await apiQuery(req, endpoint: "/fez/\(fezID)/post", method: .POST, encodeContent: postContent)
 		return .created
+	}
+
+	// POST /seamail/:seamail_ID/markRead
+	//
+	// Marks a seamail as read for the current user. Used by the live-message websocket JS to clear
+	// unread state for posts that were already rendered into the page live.
+	func seamailMarkReadPostHandler(_ req: Request) async throws -> HTTPStatus {
+		guard let fezID = req.parameters.get(fezIDParam.paramString)?.percentEncodeFilePathEntry() else {
+			throw Abort(.badRequest, reason: "Missing fez_id parameter.")
+		}
+		let response = try await apiQuery(req, endpoint: "/fez/\(fezID)/markRead", method: .POST)
+		return response.status
 	}
 
 	// POST /seamail/mute/:seamail_ID

--- a/docs/Swiftarr/API Changelist.md
+++ b/docs/Swiftarr/API Changelist.md
@@ -305,3 +305,7 @@ additive; the existing count fields are unchanged and are now derived from these
   - `GET /api/v3/fez/joined` and `GET /api/v3/fez/owner` now support a `?favorite=true` filter.
 - `POST/DELETE /api/v3/fez/:fez_ID/mute` is no longer rejected for privileged mailboxes (`@moderator`/`@TwitarrTeam`).
 - `FezContentData` gains an optional `firstPost` (`PostContentData`), letting `POST /api/v3/fez/create` create the intial post in the same call.
+
+## Sep 12, 2026
+
+- Added `POST /api/v3/fez/:fez_ID/markRead`, mirroring the existing forum `markRead` endpoint.


### PR DESCRIPTION
## Problem
When a chat is open and a new message arrives over the websocket, it gets rendered live into the page so the user sees it immediately. But the server didn't know the user had "read" it, so navigating away (e.g. to `/seamail`) still showed a "new" badge and the red notification bar on Chat, forcing the user to reopen a conversation they'd already seen.

## Solution
Add a `markRead` endpoint that advances a user's read count for a fez (Seamail/LFG/Private Event) to the current post count, and call it automatically from the client whenever the live-message websocket renders a new post.

- `POST /api/v3/fez/:fezID/markRead` (`FezController`) sets the pivot's `readCount` and clears the related unread notification.
- Site-level wrappers `POST /seamail/:id/markRead` and `POST /lfg/:id/markRead` proxy to the API endpoint.
- `swiftarrMessages.js` fires a `fetch` to `markRead` right after live-rendering a websocket message, so the badge never appears for content the user already saw live.

Fixes #129